### PR TITLE
Optimize initial net with safe-rules.

### DIFF
--- a/src/icombs/compiler.rs
+++ b/src/icombs/compiler.rs
@@ -341,6 +341,24 @@ impl Compiler {
                 (tree, tree1)
             })
             .collect();
+        self.net.redexes = core::mem::take(&mut self.net.redexes)
+            .into_iter()
+            .map(|(tree, tree1)| {
+                let tree = self
+                    .non_principal_interactions(TypedTree {
+                        tree: tree,
+                        ty: Type::Break(Default::default()),
+                    })
+                    .tree;
+                let tree1 = self
+                    .non_principal_interactions(TypedTree {
+                        tree: tree1,
+                        ty: Type::Break(Default::default()),
+                    })
+                    .tree;
+                (tree, tree1)
+            })
+            .collect();
         self.net.ports.push_back(tree.tree);
 
         self.net.packages = Arc::new(self.id_to_package.clone().into_iter().enumerate().collect());

--- a/src/icombs/net.rs
+++ b/src/icombs/net.rs
@@ -268,6 +268,7 @@ impl Net {
         }
     }
 
+    /// Where vars occur in the given tree which already have been linked from the other side, finish linking them.
     pub fn substitute_tree(&mut self, tree: &mut Tree) {
         match tree {
             Tree::Con(a, b) | Tree::Dup(a, b) => {
@@ -495,14 +496,7 @@ impl Net {
 
     fn assert_tree_valid(&self, tree: &Tree) -> Vec<usize> {
         match tree {
-            Tree::Con(a, b) => {
-                let mut a = self.assert_tree_valid(a.as_ref());
-                let mut b = self.assert_tree_valid(b.as_ref());
-                a.append(&mut b);
-                a
-            }
-            Tree::Dup(a, b) => {
-                // do the same thing as Con
+            Tree::Con(a, b) | Tree::Dup(a, b) => {
                 let mut a = self.assert_tree_valid(a.as_ref());
                 let mut b = self.assert_tree_valid(b.as_ref());
                 a.append(&mut b);


### PR DESCRIPTION
Perform various non-principal-port interactions which simplify the initial net.

Not done because this still doesn't handle optimizing `!` or `?` and seems to be missing some instances of dup(eras,) that should be optimized away such as in the `fibonacci.par` example.

I don't have more time to work on this, so I'm leaving progress so far in this pr.