### PR TITLE
fix: playground crash when compiles programs with only type definitions

### DIFF
--- a/src/par/program.rs
+++ b/src/par/program.rs
@@ -162,9 +162,9 @@ impl<Name: Clone + Spanning> TypeOnHover<Name> {
 
 impl<Name: Clone> TypeOnHover<Name> {
     pub fn query(&self, row: usize, column: usize) -> Option<NameWithType<Name>> {
-        // if self.sorted_pairs.is_empty() {
-        //     return None;
-        // }
+        if self.sorted_pairs.is_empty() {
+            return None;
+        }
         // find index with the greatest start that is <= than (row, column)
         let (mut lo, mut hi) = (0, self.sorted_pairs.len());
         while lo + 1 < hi {

--- a/src/par/program.rs
+++ b/src/par/program.rs
@@ -162,6 +162,9 @@ impl<Name: Clone + Spanning> TypeOnHover<Name> {
 
 impl<Name: Clone> TypeOnHover<Name> {
     pub fn query(&self, row: usize, column: usize) -> Option<NameWithType<Name>> {
+        // if self.sorted_pairs.is_empty() {
+        //     return None;
+        // }
         // find index with the greatest start that is <= than (row, column)
         let (mut lo, mut hi) = (0, self.sorted_pairs.len());
         while lo + 1 < hi {


### PR DESCRIPTION
# Description

The playground was crashing when trying to compile a programs containing only type definitions (like `type Either = either {.a ! .b !}`).

This was happening because the `TypeOnHover::query` method was attempting to access an empty `sorted_pairs` vector.

The fix adds a check for empty `sorted_pairs` at the beginning of the query method, returning `None` immediately if there are no type definitions to query. This ensures the playground handles these cases without crashing.

closes #43