### PR TITLE
fix(playground): Handle unimplemented type cases gracefully instead of panicking

### DIFF
--- a/src/readback.rs
+++ b/src/readback.rs
@@ -593,7 +593,7 @@ impl ReadbackImplLevel {
                 res
             }
             Type::Self_(_, _) => Ok,
-            _ => unreachable!("Type not implemented: {typ:?}"),
+            _ => ReadbackImplLevel::Incomplete,
         }
     }
 


### PR DESCRIPTION
# Description

The program was crashing when encountering unimplemented type cases. This was happening because the code was using `unreachable!()` in the `ReadbackImplLevel::from_type` function when it encountered types that weren't implemented yet.

## Changes
- Modified `ReadbackImplLevel::from_type` to return `ReadbackImplLevel::Incomplete` instead of panicking