### PR TITLE
fix: Confusing error message for pattern matching without type annotation

### DIFF
--- a/src/par/language.rs
+++ b/src/par/language.rs
@@ -84,6 +84,7 @@ impl LocalName {
         }
     }
 
+    /// Check if this is an internal pattern matching variable.
     pub fn is_match(&self) -> bool {
         self.string.starts_with("#match")
     }

--- a/src/par/language.rs
+++ b/src/par/language.rs
@@ -83,6 +83,10 @@ impl LocalName {
             string: literal!("#invalid"),
         }
     }
+
+    pub fn is_match(&self) -> bool {
+        self.string.starts_with("#match")
+    }
 }
 
 #[derive(Clone, Debug)]

--- a/src/par/types.rs
+++ b/src/par/types.rs
@@ -3246,7 +3246,8 @@ impl TypeError {
             Self::ParameterTypeMustBeKnown(span, param) => {
                 let labels = labels_from_span(code, span);
 
-                // check if this is an internal pattern matching variable
+                // filter out internal pattern matching variables
+                // issue #44: https://github.com/faiface/par-lang/issues/44
                 if param.is_match() {
                     miette::miette!(
                         labels = labels,

--- a/src/par/types.rs
+++ b/src/par/types.rs
@@ -3245,11 +3245,21 @@ impl TypeError {
             }
             Self::ParameterTypeMustBeKnown(span, param) => {
                 let labels = labels_from_span(code, span);
-                miette::miette!(
-                    labels = labels,
-                    "Type of parameter `{}` must be known.",
-                    param,
-                )
+
+                // check if this is an internal pattern matching variable
+                if param.string.starts_with("#match") {
+                    miette::miette!(
+                        labels = labels,
+                        help = "Consider adding a type annotation to the pattern, e.g., [(x : Type)y]",
+                        "Type annotation required for pattern matching"
+                    )
+                } else {
+                    miette::miette!(
+                        labels = labels,
+                        "Type of parameter `{}` must be known.",
+                        param,
+                    )
+                }
             }
             Self::CannotAssignFromTo(span, from_type, to_type) => {
                 let labels = labels_from_span(code, span);

--- a/src/par/types.rs
+++ b/src/par/types.rs
@@ -3247,7 +3247,7 @@ impl TypeError {
                 let labels = labels_from_span(code, span);
 
                 // check if this is an internal pattern matching variable
-                if param.string.starts_with("#match") {
+                if param.is_match() {
                     miette::miette!(
                         labels = labels,
                         help = "Consider adding a type annotation to the pattern, e.g., [(x : Type)y]",

--- a/src/playground.rs
+++ b/src/playground.rs
@@ -668,15 +668,36 @@ def Pair = [type _] [(x)y] (x) y
 
         match result {
             Ok(Ok(_)) => {
-                // unexpected
-                println!("compiled successfully");
+                panic!("Expected compilation to fail, but it succeeded");
             }
             Ok(Err(err)) => {
-                // ideal
-                println!("{:?}", err);
+                // Check that we get the expected error type
+                match err {
+                    Error::Type(type_err) => {
+                        let error_msg = format!("{:?}", type_err.to_report(Arc::from(code)));
+
+                        assert!(
+                            error_msg.contains("Type annotation required for pattern matching")
+                                || error_msg.contains("pattern matching"),
+                            "Error message should mention pattern matching, got: {}",
+                            error_msg
+                        );
+
+                        assert!(
+                            error_msg.contains("Consider adding a type annotation"),
+                            "Error should contain help text about adding type annotations"
+                        );
+
+                        assert!(
+                            !error_msg.contains("Type of parameter `#match0`"),
+                            "Error should not expose internal variable names like #match0"
+                        );
+                    }
+                    _ => panic!("Expected TypeError, got {:?}", err),
+                }
             }
             Err(_) => {
-                println!("compiler panicked");
+                panic!("Compiler panicked unexpectedly");
             }
         }
     }

--- a/src/playground.rs
+++ b/src/playground.rs
@@ -651,3 +651,33 @@ fn green() -> egui::Color32 {
 fn blue() -> egui::Color32 {
     egui::Color32::from_hex("#118ab2").unwrap()
 }
+
+#[cfg(test)]
+mod playground_test {
+    use super::*;
+
+    #[test]
+    fn test_issue_44() {
+        let code = r#"
+def Pair = [type _] [(x)y] (x) y
+"#;
+
+        let result = std::panic::catch_unwind(|| {
+            stacker::grow(32 * 1024 * 1024, || Compiled::from_string(code))
+        });
+
+        match result {
+            Ok(Ok(_)) => {
+                // unexpected
+                println!("compiled successfully");
+            }
+            Ok(Err(err)) => {
+                // ideal
+                println!("{:?}", err);
+            }
+            Err(_) => {
+                println!("compiler panicked");
+            }
+        }
+    }
+}


### PR DESCRIPTION
# Description

Closes #44 

During pattern compilation, the compiler transforms complex patterns into simpler forms using synthetic variable names (`#match0`, `#match1`, etc.). When type inference fails for these patterns, the error message references these internal names instead of providing context about the original pattern.

## Changes

The fix detects when an error involves an internal pattern matching variable (those starting with `#match`) and provides a more user-friendly error message.

<img width="1112" height="840" alt="Screenshot 2025-07-13 at 4 08 23 PM" src="https://github.com/user-attachments/assets/071c2627-7752-4652-b0d9-6405add8b0ea" />
