### PR TITLE
feat: Backup playground contents and print to stderr on panic.

### DIFF
--- a/src/playground.rs
+++ b/src/playground.rs
@@ -212,6 +212,11 @@ impl Playground {
 
 impl eframe::App for Playground {
     fn update(&mut self, ctx: &egui::Context, _frame: &mut eframe::Frame) {
+        // Try to backup current playground code contents in case of panic.
+        if let Ok(e) = &mut crate::CRASH_STR.try_lock() {
+            **e = Some(self.code.clone());
+        }
+
         // Set overall UI style based on theme mode
         let system_dark = ctx
             .input(|ri| ri.raw.system_theme.map(|t| t == egui::Theme::Dark))


### PR DESCRIPTION
The recent demo motivated me to finally fix the worry about losing everything when you forget to save and playground crashes.

Now crash will print code to stderr before exit.

Clones the string for the entire playground file every render, but testing indicated it wasn't too slow at 50,000 lines.