### PR TITLE
fix typo in exists.md

### DIFF
--- a/docs/src/types/exists.md
+++ b/docs/src/types/exists.md
@@ -62,7 +62,7 @@ dropping a value of that type.
 Here’s how we can construct a value of `DropMe`:
 
 ```par
-def Drop42: DropMe = (type Int) (42) choice {
+def Drop42: DropMe = (type Int) (42) case {
   .drop(n) => !,  // `n`, being an `Int`, is dropped by being unused
 }
 ```


### PR DESCRIPTION
Fixes typo pointed out by `「CRY」` on discord.