### PR TITLE
Complete&sound fixpoint subtyping

### DIFF
--- a/examples/Queue.par
+++ b/examples/Queue.par
@@ -1,4 +1,4 @@
-def PlayWithQueue = Queue.Empty(type String)
+def PlayWithQueue:Queue<String> = Queue.Empty(type String)
 
 type Queue<a> =
   iterative/push recursive/pop
@@ -24,16 +24,19 @@ def Queue.Empty = [type a] do {
   .pop => front.begin/pop.case {
     .end! => back.build.begin/pop.case {
       .end! => .end!,
-      .item(value) front => .item(value) case {
-        .push => {do {
-          let back = List.Builder(type a)
-        } in loop/push}.push,
+      .item(value) front => 
+		.item(value) case {
+      .push(value) => do {
+        let back = List.Builder(type a) 
+        back.add(value)
+      } in loop/push,
         .pop => front.loop/pop,
       }
     }
-
     .item(value) front => .item(value) case {
-      .push => {loop/push}.push,
+      .push(value) => do {
+        back.add(value)
+      } in loop/push,
       .pop => front.loop/pop,
     }
   }

--- a/src/icombs/compiler.rs
+++ b/src/icombs/compiler.rs
@@ -503,9 +503,9 @@ impl Compiler {
                 Type::expand_recursive(&asc, &label, &body, &self.type_defs).unwrap(),
             ),
             Type::Iterative {
-                asc, label, body, ..
+                 asc, label, body,..
             } => self.normalize_type(
-                Type::expand_iterative(&asc, &label, &body, &self.type_defs).unwrap(),
+                Type::expand_iterative(&Span::None, &asc, &label, &body, &self.type_defs).unwrap(),
             ),
             ty => ty,
         }

--- a/src/icombs/readback.rs
+++ b/src/icombs/readback.rs
@@ -755,11 +755,11 @@ pub fn expand_type(typ: Type, type_defs: &TypeDefs) -> Type {
                 body,
             } => Type::expand_recursive(&asc, &label, &body, &type_defs).unwrap(),
             Type::Iterative {
-                span: _,
+                span: span,
                 asc,
                 label,
                 body,
-            } => Type::expand_iterative(&asc, &label, &body, &type_defs).unwrap(),
+            } => Type::expand_iterative(&Span::None, &asc, &label, &body, &type_defs).unwrap(),
             typ => break typ,
         };
     }

--- a/src/par/types.rs
+++ b/src/par/types.rs
@@ -1,17 +1,18 @@
-use arcstr::ArcStr;
-use indexmap::{IndexMap, IndexSet};
-use std::{
-    collections::{BTreeMap, HashSet},
-    fmt::{self, Write},
-    sync::{Arc, RwLock},
-};
-
 use super::{
     language::{GlobalName, LocalName},
     process::{Captures, Command, Expression, Process},
 };
 use crate::location::{Span, Spanning};
+use arcstr::ArcStr;
+use indexmap::{IndexMap, IndexSet};
 use miette::LabeledSpan;
+use std::collections::HashMap;
+use std::rc::Rc;
+use std::{
+    collections::{BTreeMap, HashSet},
+    fmt::{self, Write},
+    sync::{Arc, RwLock},
+};
 
 #[derive(Clone, Debug)]
 pub enum TypeError {
@@ -473,6 +474,32 @@ impl Spanning for Type {
     }
 }
 
+#[derive(Debug)]
+enum FixPointType {
+    Recursive,
+    Iterative,
+}
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq)]
+enum Path {
+    Empty,
+    Node(usize, Rc<Path>),
+    NamedNode(LocalName, Rc<Path>),
+}
+
+impl Path {
+    fn add(&self, index: usize) -> Self {
+        Path::Node(index, Rc::new(self.clone()))
+    }
+
+    fn add_name(&self, name: LocalName) -> Self {
+        Path::NamedNode(name, Rc::new(self.clone()))
+    }
+}
+
+#[derive(Clone, Debug)]
+struct LabelsMap(HashMap<Option<LocalName>, Rc<(Path, Type, FixPointType, LabelsMap)>>);
+
 impl Type {
     pub fn substitute(self, map: BTreeMap<&LocalName, &Type>) -> Result<Self, TypeError> {
         Ok(match self {
@@ -647,7 +674,7 @@ impl Type {
         u: &Type,
         type_defs: &TypeDefs,
     ) -> Result<(), TypeError> {
-        if !self.is_assignable_to(u, type_defs, &HashSet::new())? {
+        if !self.is_assignable_to(u, type_defs)? {
             return Err(TypeError::CannotAssignFromTo(
                 span.clone(),
                 self.clone(),
@@ -657,13 +684,136 @@ impl Type {
         Ok(())
     }
 
-    fn is_assignable_to(
+    fn is_assignable_to(&self, other: &Self, type_defs: &TypeDefs) -> Result<bool, TypeError> {
+        self.is_assignable_to_internal(
+            other,
+            type_defs,
+            Path::Empty,
+            Path::Empty,
+            &mut Default::default(),
+            LabelsMap(HashMap::new()),
+            LabelsMap(HashMap::new()),
+            HashSet::new(),
+        )
+    }
+
+    /**
+     This function checks if `self` <: `other`.
+
+      This algorithm is a generalization of the algorithm presented in `Subtyping recursive types (1993)`,
+      to support both least and greatest fixpoint types.
+
+      We believe it to be both complete and sound
+      with respect to their definition as an infinite union/intersection respectively.
+    */
+    fn is_assignable_to_internal(
         &self,
         other: &Self,
         type_defs: &TypeDefs,
-        ind: &HashSet<(Option<LocalName>, Option<LocalName>)>,
+        self_path: Path,
+        other_path: Path,
+        visited: &mut HashSet<(Path, Path)>,
+        mut self_labels: LabelsMap,
+        mut other_labels: LabelsMap,
+        mut cyclic_points: HashSet<(Path, Path)>,
     ) -> Result<bool, TypeError> {
         Ok(match (self, other) {
+            (Self::Self_(_, label1), Self::Self_(_, label2)) => {
+                let (self_path, self_type, self_fixpoint_type, self_labels) = self_labels
+                    .0
+                    .get(label1)
+                    .expect("Self label not found")
+                    .as_ref();
+                let (other_path, other_type, other_fixpoint_type, other_labels) = other_labels
+                    .0
+                    .get(label2)
+                    .expect("Other label not found")
+                    .as_ref();
+
+                if visited.contains(&(self_path.clone(), other_path.clone())) {
+                    if let (FixPointType::Recursive, _) | (_, FixPointType::Iterative) =
+                        (self_fixpoint_type, other_fixpoint_type)
+                    {
+                        return Ok(true);
+                    } else {
+                        if cyclic_points.contains(&(self_path.clone(), other_path.clone())) {
+                            return Ok(false);
+                        } else {
+                            cyclic_points.insert((self_path.clone(), other_path.clone()));
+                        }
+                    }
+                }
+                self_type.is_assignable_to_internal(
+                    &other_type,
+                    type_defs,
+                    self_path.clone(),
+                    other_path.clone(),
+                    visited,
+                    self_labels.clone(),
+                    other_labels.clone(),
+                    cyclic_points,
+                )?
+            }
+
+            (Self::Self_(_, label1), t2) => {
+                let (self_path, self_type, self_fixpoint_type, self_labels) = self_labels
+                    .0
+                    .get(label1)
+                    .expect("Self label not found")
+                    .as_ref();
+
+                if visited.contains(&(self_path.clone(), other_path.clone())) {
+                    if let FixPointType::Recursive = self_fixpoint_type {
+                        return Ok(true);
+                    } else {
+                        if cyclic_points.contains(&(self_path.clone(), other_path.clone())) {
+                            return Ok(false);
+                        } else {
+                            cyclic_points.insert((self_path.clone(), other_path.clone()));
+                        }
+                    }
+                }
+                self_type.is_assignable_to_internal(
+                    t2,
+                    type_defs,
+                    self_path.clone(),
+                    other_path.clone(),
+                    visited,
+                    self_labels.clone(),
+                    other_labels.clone(),
+                    cyclic_points,
+                )?
+            }
+
+            (t1, Self::Self_(_, label2)) => {
+                let (other_path, other_type, other_fixpoint_type, other_labels) = other_labels
+                    .0
+                    .get(label2)
+                    .expect("Other label not found")
+                    .as_ref();
+
+                if visited.contains(&(self_path.clone(), other_path.clone())) {
+                    if let FixPointType::Iterative = other_fixpoint_type {
+                        return Ok(true);
+                    } else {
+                        if cyclic_points.contains(&(self_path.clone(), other_path.clone())) {
+                            return Ok(false);
+                        } else {
+                            cyclic_points.insert((self_path.clone(), other_path.clone()));
+                        }
+                    }
+                }
+                t1.is_assignable_to_internal(
+                    &other_type,
+                    type_defs,
+                    self_path.clone(),
+                    other_path.clone(),
+                    visited,
+                    self_labels.clone(),
+                    other_labels.clone(),
+                    cyclic_points,
+                )?
+            }
             (Self::Primitive(_, PrimitiveType::Nat), Self::Primitive(_, PrimitiveType::Int)) => {
                 true
             }
@@ -683,47 +833,180 @@ impl Type {
 
             (Self::Var(_, name1), Self::Var(_, name2)) => name1 == name2,
             (Self::DualVar(_, name1), Self::DualVar(_, name2)) => name1 == name2,
-            (Self::Name(span, name, args), t2) => type_defs
-                .get(span, name, args)?
-                .is_assignable_to(t2, type_defs, ind)?,
-            (t1, Self::Name(span, name, args)) => {
-                t1.is_assignable_to(&type_defs.get(span, name, args)?, type_defs, ind)?
+            (Self::Name(span, name, args), t2) => {
+                type_defs.get(span, name, args)?.is_assignable_to_internal(
+                    t2,
+                    type_defs,
+                    self_path,
+                    other_path,
+                    visited,
+                    self_labels,
+                    other_labels,
+                    cyclic_points,
+                )?
             }
+            (t1, Self::Name(span, name, args)) => t1.is_assignable_to_internal(
+                &type_defs.get(span, name, args)?,
+                type_defs,
+                self_path,
+                other_path,
+                visited,
+                self_labels,
+                other_labels,
+                cyclic_points,
+            )?,
             (Self::DualName(span, name, args), t2) => type_defs
                 .get_dual(span, name, args)?
-                .is_assignable_to(t2, type_defs, ind)?,
-            (t1, Self::DualName(span, name, args)) => {
-                t1.is_assignable_to(&type_defs.get_dual(span, name, args)?, type_defs, ind)?
-            }
+                .is_assignable_to_internal(
+                    t2,
+                    type_defs,
+                    self_path,
+                    other_path,
+                    visited,
+                    self_labels,
+                    other_labels,
+                    cyclic_points,
+                )?,
+            (t1, Self::DualName(span, name, args)) => t1.is_assignable_to_internal(
+                &type_defs.get_dual(span, name, args)?,
+                type_defs,
+                self_path,
+                other_path,
+                visited,
+                self_labels,
+                other_labels,
+                cyclic_points,
+            )?,
 
-            (t1, Self::Box(_, t2)) if t1.is_positive(type_defs)? => {
-                t1.is_assignable_to(t2, type_defs, ind)?
+            (t1, Self::Box(_, t2)) if t1.is_positive(type_defs)? => t1.is_assignable_to_internal(
+                t2,
+                type_defs,
+                self_path,
+                other_path.add(0),
+                visited,
+                self_labels,
+                other_labels,
+                cyclic_points,
+            )?,
+            (Self::DualBox(_, t1), t2) if t1.is_positive(type_defs)? => {
+                t1.clone().dual(Span::None).is_assignable_to_internal(
+                    t2,
+                    type_defs,
+                    self_path.add(0),
+                    other_path,
+                    visited,
+                    self_labels,
+                    other_labels,
+                    cyclic_points,
+                )?
             }
-            (Self::DualBox(_, t1), t2) if t1.is_positive(type_defs)? => t1
-                .clone()
-                .dual(Span::None)
-                .is_assignable_to(t2, type_defs, ind)?,
-            (Self::Box(_, t1), Self::Box(_, t2)) => t1.is_assignable_to(t2, type_defs, ind)?,
-            (Self::Box(_, t1), t2) => t1.is_assignable_to(t2, type_defs, ind)?,
+            (Self::Box(_, t1), Self::Box(_, t2)) => t1.is_assignable_to_internal(
+                t2,
+                type_defs,
+                self_path.add(0),
+                other_path.add(0),
+                visited,
+                self_labels,
+                other_labels,
+                cyclic_points,
+            )?,
+            (Self::Box(_, t1), t2) => t1.is_assignable_to_internal(
+                t2,
+                type_defs,
+                self_path.add(0),
+                other_path.add(0),
+                visited,
+                self_labels,
+                other_labels,
+                cyclic_points,
+            )?,
             (Self::DualBox(_, t1), Self::DualBox(_, t2)) => {
-                t2.is_assignable_to(t1, type_defs, ind)?
+                let t1 = t1.clone().dual(Span::None);
+                let t2 = t2.clone().dual(Span::None);
+                t1.is_assignable_to_internal(
+                    &t2,
+                    type_defs,
+                    self_path.add(0),
+                    other_path.add(0),
+                    visited,
+                    self_labels,
+                    other_labels,
+                    cyclic_points,
+                )?
             }
-            (t1, Self::DualBox(_, t2)) => t2.is_assignable_to(t1, type_defs, ind)?,
+            (t1, Self::DualBox(_, t2)) => {
+                let t2 = t2.clone().dual(Span::None);
+                t1.is_assignable_to_internal(
+                    &t2,
+                    type_defs,
+                    self_path,
+                    other_path.add(0),
+                    visited,
+                    self_labels,
+                    other_labels,
+                    cyclic_points,
+                )?
+            }
 
             (Self::Pair(_, t1, u1), Self::Pair(_, t2, u2)) => {
-                t1.is_assignable_to(t2, type_defs, ind)?
-                    && u1.is_assignable_to(u2, type_defs, ind)?
+                t1.is_assignable_to_internal(
+                    t2,
+                    type_defs,
+                    self_path.add(0),
+                    other_path.add(0),
+                    visited,
+                    self_labels.clone(),
+                    other_labels.clone(),
+                    cyclic_points.clone(),
+                )? && u1.is_assignable_to_internal(
+                    u2,
+                    type_defs,
+                    self_path.add(1),
+                    other_path.add(1),
+                    visited,
+                    self_labels,
+                    other_labels,
+                    cyclic_points,
+                )?
             }
             (Self::Function(_, t1, u1), Self::Function(_, t2, u2)) => {
-                t2.is_assignable_to(t1, type_defs, ind)?
-                    && u1.is_assignable_to(u2, type_defs, ind)?
+                let t1 = t1.clone().dual(Span::None);
+                let t2 = t2.clone().dual(Span::None);
+                t1.is_assignable_to_internal(
+                    &t2,
+                    type_defs,
+                    self_path.add(0),
+                    other_path.add(0),
+                    visited,
+                    self_labels.clone(),
+                    other_labels.clone(),
+                    cyclic_points.clone(),
+                )? && u1.is_assignable_to_internal(
+                    u2,
+                    type_defs,
+                    self_path.add(1),
+                    other_path.add(1),
+                    visited,
+                    self_labels,
+                    other_labels,
+                    cyclic_points,
+                )?
             }
             (Self::Either(_, branches1), Self::Either(_, branches2)) => {
-                for (branch, t1) in branches1 {
+                for ((branch, t1)) in branches1 {
                     let Some(t2) = branches2.get(branch) else {
                         return Ok(false);
                     };
-                    if !t1.is_assignable_to(t2, type_defs, ind)? {
+                    if !t1.is_assignable_to_internal(
+                        t2,
+                        type_defs,
+                        self_path.add_name(branch.clone()),
+                        other_path.add_name(branch.clone()),
+                        visited,
+                        self_labels.clone(),
+                        other_labels.clone(),
+                        cyclic_points.clone(),
+                    )? {
                         return Ok(false);
                     }
                 }
@@ -734,7 +1017,16 @@ impl Type {
                     let Some(t1) = branches1.get(branch) else {
                         return Ok(false);
                     };
-                    if !t1.is_assignable_to(t2, type_defs, ind)? {
+                    if !t1.is_assignable_to_internal(
+                        t2,
+                        type_defs,
+                        self_path.add_name(branch.clone()),
+                        other_path.add_name(branch.clone()),
+                        visited,
+                        self_labels.clone(),
+                        other_labels.clone(),
+                        cyclic_points.clone(),
+                    )? {
                         return Ok(false);
                     }
                 }
@@ -742,72 +1034,128 @@ impl Type {
             }
             (Self::Break(_), Self::Break(_)) => true,
             (Self::Continue(_), Self::Continue(_)) => true,
-
             (
-                Self::Recursive {
-                    asc: asc1,
-                    label: label1,
-                    body: body1,
-                    ..
-                },
-                Self::Recursive {
+                typ,
+                t2 @ Self::Recursive {
                     asc: asc2,
-                    label: label2,
-                    body: body2,
+                    label,
+                    body,
                     ..
                 },
             ) => {
-                if !asc2.iter().all(|label| asc1.contains(label)) {
-                    return Ok(false);
+                if !asc2.is_empty() {
+                    if let Self::Recursive { asc: asc1, .. } = typ {
+                        if !asc2.is_subset(asc1) {
+                            return Ok(false);
+                        }
+                    } else {
+                        return Ok(false);
+                    }
                 }
-                let mut ind = ind.clone();
-                ind.insert((label1.clone(), label2.clone()));
-                body1.is_assignable_to(body2, type_defs, &ind)?
+                visited.insert((self_path.clone(), other_path.clone()));
+                other_labels.0.insert(
+                    label.clone(),
+                    Rc::new((
+                        other_path.clone(),
+                        t2.clone(),
+                        FixPointType::Recursive,
+                        other_labels.clone(),
+                    )),
+                );
+                typ.is_assignable_to_internal(
+                    body,
+                    type_defs,
+                    self_path,
+                    other_path.add(0),
+                    visited,
+                    self_labels,
+                    other_labels,
+                    cyclic_points,
+                )?
             }
-            (
-                typ,
-                Self::Recursive {
-                    asc, label, body, ..
-                },
-            ) => typ.is_assignable_to(
-                &Self::expand_recursive(asc, label, body, type_defs)?,
-                type_defs,
-                ind,
-            )?,
-            (
-                Self::Iterative {
-                    asc: asc1,
-                    label: label1,
-                    body: body1,
-                    ..
-                },
-                Self::Iterative {
-                    asc: asc2,
-                    label: label2,
-                    body: body2,
-                    ..
-                },
-            ) => {
-                if !asc1.iter().all(|label| asc2.contains(label)) {
-                    return Ok(false);
-                }
-                let mut ind = ind.clone();
-                ind.insert((label1.clone(), label2.clone()));
-                body1.is_assignable_to(body2, type_defs, &ind)?
-            }
-            (
-                Self::Iterative {
-                    asc, label, body, ..
-                },
-                typ,
-            ) => Self::expand_iterative(asc, label, body, type_defs)?
-                .is_assignable_to(typ, type_defs, ind)?,
 
-            (Self::Self_(_, label1), Self::Self_(_, label2)) => {
-                ind.contains(&(label1.clone(), label2.clone()))
+            (t1 @ Self::Recursive { label, body, .. }, typ) => {
+                visited.insert((self_path.clone(), other_path.clone()));
+                self_labels.0.insert(
+                    label.clone(),
+                    Rc::new((
+                        self_path.clone(),
+                        t1.clone(),
+                        FixPointType::Recursive,
+                        self_labels.clone(),
+                    )),
+                );
+                body.is_assignable_to_internal(
+                    typ,
+                    type_defs,
+                    self_path.add(0),
+                    other_path,
+                    visited,
+                    self_labels,
+                    other_labels,
+                    cyclic_points,
+                )?
             }
-            (Self::DualSelf(_, label1), Self::DualSelf(_, label2)) => {
-                ind.contains(&(label2.clone(), label1.clone()))
+            (
+                t1 @ Self::Iterative {
+                    asc: asc1,
+                    label,
+                    body,
+                    ..
+                },
+                typ,
+            ) => {
+                if !asc1.is_empty() {
+                    if let Self::Iterative { asc: asc2, .. } = typ {
+                        if !asc1.is_subset(asc2) {
+                            return Ok(false);
+                        }
+                    } else {
+                        return Ok(false);
+                    }
+                }
+                visited.insert((self_path.clone(), other_path.clone()));
+                self_labels.0.insert(
+                    label.clone(),
+                    Rc::new((
+                        self_path.clone(),
+                        t1.clone(),
+                        FixPointType::Iterative,
+                        self_labels.clone(),
+                    )),
+                );
+                body.is_assignable_to_internal(
+                    typ,
+                    type_defs,
+                    self_path.add(0),
+                    other_path,
+                    visited,
+                    self_labels,
+                    other_labels,
+                    cyclic_points,
+                )?
+            }
+            (typ, t2 @ Self::Iterative { label, body, .. }) => {
+                visited.insert((self_path.clone(), other_path.clone()));
+                other_labels.0.insert(
+                    label.clone(),
+                    Rc::new((
+                        other_path.clone(),
+                        t2.clone(),
+                        FixPointType::Iterative,
+                        other_labels.clone(),
+                    )),
+                );
+                typ.is_assignable_to_internal(
+                    body,
+                    type_defs,
+                    self_path,
+                    other_path.add(0),
+                    visited,
+                    self_labels,
+                    other_labels,
+                    cyclic_points,
+                )?
             }
 
             (Self::Exists(loc, name1, body1), Self::Exists(_, name2, body2))
@@ -818,7 +1166,16 @@ impl Type {
                 )]))?;
                 let mut type_defs = type_defs.clone();
                 type_defs.vars.insert(name1.clone());
-                body1.is_assignable_to(&body2, &type_defs, ind)?
+                body1.is_assignable_to_internal(
+                    &body2,
+                    &type_defs,
+                    self_path.add(0),
+                    other_path.add(0),
+                    visited,
+                    self_labels,
+                    other_labels,
+                    cyclic_points,
+                )?
             }
 
             _ => false,
@@ -1974,14 +2331,10 @@ impl Context {
 
                     match (inferred_type, inferred_in_branch) {
                         (None, Some(t2)) => inferred_type = Some(t2),
-                        (Some(t1), Some(t2))
-                            if t2.is_assignable_to(&t1, &self.type_defs, &HashSet::new())? =>
-                        {
+                        (Some(t1), Some(t2)) if t2.is_assignable_to(&t1, &self.type_defs)? => {
                             inferred_type = Some(t2)
                         }
-                        (Some(t1), Some(t2))
-                            if !t1.is_assignable_to(&t2, &self.type_defs, &HashSet::new())? =>
-                        {
+                        (Some(t1), Some(t2)) if !t1.is_assignable_to(&t2, &self.type_defs)? => {
                             return Err(TypeError::TypesCannotBeUnified(t1, t2))
                         }
                         (t1, _) => inferred_type = t1,
@@ -2134,11 +2487,7 @@ impl Context {
                             var.clone(),
                         ));
                     };
-                    if !current_type.is_assignable_to(
-                        type_at_begin,
-                        &self.type_defs,
-                        &HashSet::new(),
-                    )? {
+                    if !current_type.is_assignable_to(type_at_begin, &self.type_defs)? {
                         return Err(TypeError::LoopVariableChangedType(
                             span.clone(),
                             var.clone(),
@@ -2395,11 +2744,7 @@ impl Context {
                             var.clone(),
                         ));
                     };
-                    if !current_type.is_assignable_to(
-                        type_at_begin,
-                        &self.type_defs,
-                        &HashSet::new(),
-                    )? {
+                    if !current_type.is_assignable_to(type_at_begin, &self.type_defs)? {
                         return Err(TypeError::LoopVariableChangedType(
                             span.clone(),
                             var.clone(),


### PR DESCRIPTION
Additionally I disabled expansion of iteratives with an asc label, as this breaks totality.
We can reenable this once we implement appropriate checks.

fixes #75 