### PR TITLE
Add check command to the CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1386,6 +1386,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "glob"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
+
+[[package]]
 name = "glow"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2420,6 +2426,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "unescaper",
+ "wild",
  "winnow",
 ]
 
@@ -3738,6 +3745,15 @@ dependencies = [
  "log",
  "thiserror 2.0.12",
  "web-sys",
+]
+
+[[package]]
+name = "wild"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3131afc8c575281e1e80f36ed6a092aa502c08b18ed7524e86fbbb12bb410e1"
+dependencies = [
+ "glob",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ byteview = "0.7.0"
 num-bigint = "0.4.6"
 unescaper = "0.1.6"
 tokio-util = "0.7.15"
+wild = "2.2.1"
 
 [package.metadata.spellcheck]
 config = ".config/spellcheck.toml"


### PR DESCRIPTION
Usage: `par-lang check FILES`

Supports wildcards even in windows, so you can do: `par-lang check ./examples/*.par`