### PR TITLE
docs: Update documentation to reflect new language features

### DIFF
--- a/docs/src/SUMMARY.md
+++ b/docs/src/SUMMARY.md
@@ -5,7 +5,7 @@
 - [Getting Started](./getting_started.md)
 - [Basic Program Structure](./basic_program_structure.md)
   - [Definitions & Declarations](./structure/definitions_and_declarations.md)
-  - [Strings & Numbers](./structure/strings_and_numbers.md)
+  - [Primitive Types](./structure/primitive_types.md)
   - [The `let` Expression](./structure/let_expressions.md)
 - [The Big Table](./big_table.md)
 - [Built-In Definitions](./builtin.md)

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -5,6 +5,7 @@ Let's install the **Par** programming language. Currently, we have:
   an _automatic UI._
 - A _`run`_ command to run definitions with the [unit](./types/unit.md) type straight from
   the console.
+- A _`check`_ command to check Par programs for validity without actually running them.
 
 At the moment, there are no pre-built binaries, or releases, so we'll have to build it from
 souce.

--- a/docs/src/process_syntax.md
+++ b/docs/src/process_syntax.md
@@ -34,7 +34,7 @@ language consists of:
   what to send, what to receive.
 
 From among these, we have already encountered one in Par: _channels_. That's because aside from
-[primitives](./structure/strings_and_numbers.md), **all values in Par are channels.** Yes,
+[primitives](./structure/primitive_types.md), **all values in Par are channels.** Yes,
 [functions](./types/function.md), [pairs](./types/pair.md), [choices](./types/choice.md), all of them. It will become much
 clearer as we understand this process syntax.
 

--- a/docs/src/structure/definitions_and_declarations.md
+++ b/docs/src/structure/definitions_and_declarations.md
@@ -52,7 +52,7 @@ followed by an upper-case name, an `=` sign, and an expression computing the val
 def MyNumber = 7
 ```
 
-In this case, Par is able to infer the type of `MyNumber` as [`Nat`](./strings_and_numbers.md#nat)
+In this case, Par is able to infer the type of `MyNumber` as [`Nat`](./primitive_types.md#nat)
 (a natural number), so no type annotation is needed. Often, a type annotation is needed, or wanted.
 In those cases, we can add it using a colon after the name:
 
@@ -101,7 +101,7 @@ Par has a [structural](TODO) type system. While many languages offer multiple fo
 > With [recursive](../types/recursive.md) and [iterative](../types/iterative.md) types being anonymous,
 > Par has no issue treating types as their shapes, instead of their names. In fact, type definitions are
 > completely redundant in Par. Every usage of a global type (with the exception of the
-> [primitives](./strings_and_numbers.md)) can be replaced by its definition, until no definitions are
+> [primitives](./primitive_types.md)) can be replaced by its definition, until no definitions are
 > used.
 >
 > _Actually, all definitions are redundant in Par. However, programming without them would be quite tedious._

--- a/docs/src/structure/primitive_types.md
+++ b/docs/src/structure/primitive_types.md
@@ -1,13 +1,15 @@
-# Strings & Numbers
+# Primitive Types
 
 Before taking a stroll in the diverse garden of Par's types, let's stop by the most basic ones:
 the _primitives._
 
-At the moment, Par has four primitive types:
+At the moment, Par has six primitive types:
 - **`Int`** — Integers, positive and negative whole numbers, arbitrary size.
 - **`Nat`** — Natural numbers, starting from zero, arbitrary size. They are a subtype of `Int`.
 - **`String`** — UTF-8 encoded sequence of Unicode characters.
-- **`Char`** — Singular Unicode characters.
+- **`Char`** — Singular Unicode character.
+- **`Byte`** — Singular data unit that consists of eight bits. They are a subtype of `Bytes`.
+- **`Bytes`** — Sequence of bytes.
 
 > There's a **significant distinction** between _primitives_ and all other types in Par.
 >
@@ -28,6 +30,9 @@ Primitives are manipulated using magical built-in functions.
    ```
 2. Press **Compile,** and **Run.** Scroll the list that pops up.
    ![List of built-in functions](../images/strings_and_numbers_1.png)
+
+Alternatively, the [Built-In Definitions](../builtin.md) chapter contains all built-in definitions
+available in the language.
 
 **To figure out the type of a built-in function:**
 
@@ -182,7 +187,45 @@ copy-paste this one, if you ever need it:
 ```par
 dec Chars : [String] List<Char>
 def Chars = [s] String.Reader(s).begin.char.case {
-  .end! => .end!,
+  .end r => let ! = Result.Always(type !)(r) in .end!,
   .char(c) rest => .item(c) rest.loop,
+}
+```
+
+## `Byte`
+
+A byte consists of eight bits, whose numerical value can range from 0 and 255, inclusive. `Byte`
+literals are written in decimal, enclosed in double angle brackets:
+
+```par
+def Byte1 = <<65>>   // inferred as `Byte`
+def Byte2 = <<321>>  // out-of-bounds values are automatically wrapped
+```
+
+Since `Byte` is a subtype of `Bytes`, every variable of type `Byte` can be used as a `Bytes`, too.
+
+Just like `Char`s, there's a built-in function to check if a `Byte` falls into a user-defined range:
+
+```par
+def IsMsbSet = Byte.Is(<<192>>, .range(<<128>>, <<255>>)!)  // .true!
+```
+
+## `Bytes`
+
+`Bytes` are sequences of one or more bytes. Their literals are similar to those of `Byte`s, except
+that multiple decimal values are allowed, and are delimited by spaces:
+
+```par
+def Bytes1 = <<65 91>>  // inferred as `Bytes`
+def Bytes2 = <<>>       // Error! Empty `Bytes` are not supported
+```
+
+A `Bytes` can also be broken down to a list of `Byte`s:
+
+```par
+dec Bytes : [Bytes] List<Byte>
+def Bytes = [bs] Bytes.Reader(bs).begin.byte.case {
+	.end r => let ! = Result.Always(type !)(r) in .end!,
+	.byte(b) rest => .item(b) rest.loop,
 }
 ```

--- a/docs/src/types/box.md
+++ b/docs/src/types/box.md
@@ -16,7 +16,7 @@ Even without box types, some types in Par are already non-linear. These are the 
 - [Either](./either.md)
 - [Pair](./pair.md)
 - [Recursive](./recursive.md)
-- All the [primitives](../structure/strings_and_numbers.md): `Int`, `Nat`, `String`, `Char`.
+- All the [primitives](../structure/primitive_types.md): `Int`, `Nat`, `String`, `Char`.
 
 Any combination of these is always non-linear — they can be copied and discarded freely.
 

--- a/docs/src/types/iterative.md
+++ b/docs/src/types/iterative.md
@@ -77,7 +77,7 @@ Just like [recursive types](./recursive.md), iterative types can be equated with
 
 > Just like [`recursive`](./recursive.md) types, `iterative` types have an important restriction:
 > **every `self` reference for an `iterative` must be guarded by a `choice`.** The `choice` doesn't
-> have to be right next to the `iterative`, but it *has* to be somewhere in between `iterative` and
+> have to be right next to the `iterative`, but it *has* to be somewhere in-between `iterative` and
 > `self`:
 >
 > ```par

--- a/docs/src/types/iterative.md
+++ b/docs/src/types/iterative.md
@@ -77,7 +77,7 @@ Just like [recursive types](./recursive.md), iterative types can be equated with
 
 > Just like [`recursive`](./recursive.md) types, `iterative` types have an important restriction:
 > **every `self` reference for an `iterative` must be guarded by a `choice`.** The `choice` doesn't
-> have to be right next to the `iterative`, but it *has* to be somewhere between `iterative` and
+> have to be right next to the `iterative`, but it *has* to be somewhere in between `iterative` and
 > `self`:
 >
 > ```par

--- a/docs/src/types/iterative.md
+++ b/docs/src/types/iterative.md
@@ -75,6 +75,20 @@ Just like [recursive types](./recursive.md), iterative types can be equated with
    ```
 4. And so on...
 
+> Just like [`recursive`](./recursive.md) types, `iterative` types have an important restriction:
+> **every `self` reference for an `iterative` must be guarded by a `choice`.** The `choice` doesn't
+> have to be right next to the `iterative`, but it *has* to be somewhere between `iterative` and
+> `self`:
+>
+> ```par
+> type ValidSequence<a> = iterative (a) choice {
+>   .close => !,
+>   .next => self,  // Okay. This `self` is guarded by a `choice`.
+> }
+> 
+> type InvalidSequence<a> = iterative (a) self  // Error! Unguarded `self` reference
+> ```
+
 So, if both [recursive](./recursive.md) and iterative types can be equated with their expansions,
 **what's the difference?** The difference lies in their construction and destruction:
 - **Recursive types** are **constructed step by step** and **destructed by loops**.

--- a/docs/src/types/recursive.md
+++ b/docs/src/types/recursive.md
@@ -136,6 +136,22 @@ The recursive type can be thought of as being equivalent to its _expansion_. Tha
 > This one starts with a [choice](./choice.md), which enables polling the elements on demand, or
 > cancelling the rest of the stream. However, being recursive, a `FiniteStream<a>` is guaranteed
 > to reach the `.end!` eventually, if not cancelled.
+>
+> There is nonetheless still an important restriction: **every `self` reference for a `recursive`
+> must be guarded by an `either`.** The `either` doesn't have to be right next to the `recursive`,
+> but it *has* to be somewhere between `recursive` and `self`:
+>
+> ```par
+> type ValidList<a> = recursive (a) either {
+>   .end!,
+>   .item self,  // Okay. This `self` is guarded by an `either`.
+> }
+> 
+> type InvalidList<a> = recursive (a) self  // Error! Unguarded `self` reference
+> ```
+> 
+> [Iterative](./iterative.md) types have a similar restriction: **their `self` reference must be
+> guarded by a [`choice`](./choice.md).**
 
 The key features of _recursive types_ are that **their values are finite,** and that
 **we can perform recursion on them.**

--- a/docs/src/types/recursive.md
+++ b/docs/src/types/recursive.md
@@ -139,7 +139,7 @@ The recursive type can be thought of as being equivalent to its _expansion_. Tha
 >
 > There is nonetheless an important restriction: in order for `self` references to remain useful,
 > **every `self` reference for a `recursive` must be guarded by an `either`.** The `either` doesn't
-> have to be right next to the `recursive`, but it *has* to be somewhere in between `recursive` and
+> have to be right next to the `recursive`, but it *has* to be somewhere in-between `recursive` and
 > `self`:
 >
 > ```par

--- a/docs/src/types/recursive.md
+++ b/docs/src/types/recursive.md
@@ -137,9 +137,10 @@ The recursive type can be thought of as being equivalent to its _expansion_. Tha
 > cancelling the rest of the stream. However, being recursive, a `FiniteStream<a>` is guaranteed
 > to reach the `.end!` eventually, if not cancelled.
 >
-> There is nonetheless still an important restriction: **every `self` reference for a `recursive`
-> must be guarded by an `either`.** The `either` doesn't have to be right next to the `recursive`,
-> but it *has* to be somewhere between `recursive` and `self`:
+> There is nonetheless an important restriction: in order for `self` references to remain useful,
+> **every `self` reference for a `recursive` must be guarded by an `either`.** The `either` doesn't
+> have to be right next to the `recursive`, but it *has* to be somewhere in between `recursive` and
+> `self`:
 >
 > ```par
 > type ValidList<a> = recursive (a) either {

--- a/docs/src/types_and_expressions.md
+++ b/docs/src/types_and_expressions.md
@@ -75,7 +75,7 @@ Let’s look at what falls into each category.
 
 These are:
 
-- All [**primitives**](./structure/strings_and_numbers.md): `Int`, `Nat`, `String`, `Char`
+- All [**primitives**](./structure/primitive_types.md): `Int`, `Nat`, `String`, `Char`
 - [**Unit**](./types/unit.md)
 - [**Either**](./types/either.md)
 - [**Pair**](./types/pair.md)


### PR DESCRIPTION
This PR updates a number of outdated documentation chapters to better reflect new language features introduced to Par.

## Summary of Changes

* Getting Started
  * Add `check` command
* Strings & Numbers
  * **Breaking change:** change chapter name to "Primitive Types". Existing links from outside will break.
  * Add link to Built-In Definitions chapter
  * Add `Byte` and `Bytes` types
  * Fix `Chars` function to handle the new `.end` payload
* Recursive / Iterative
  * Add descriptions about "guarded `self`" restriction

## Other Concerns

* Does the playground still display types for definitions? The Strings & Numbers chapter mentions that moving the cursor to definitions will show their types, but I've never seen this feature actually working.