### PR TITLE
[LSP] Get go-to-definition working for globals

### DIFF
--- a/src/par/program.rs
+++ b/src/par/program.rs
@@ -12,7 +12,7 @@ use crate::{
 use super::{
     language::{CompileError, GlobalName, LocalName},
     parse::SyntaxError,
-    process,
+    process::{self, NameWithType},
     types::{Context, Type, TypeDefs, TypeError},
 };
 
@@ -284,83 +284,100 @@ impl<Expr> Default for Module<Expr> {
     }
 }
 
-#[derive(Clone, Debug)]
-pub struct NameWithType(pub Option<String>, pub Type);
-
 pub struct TypeOnHover {
-    map_of_sorted_pairs: hashbrown::HashMap<FileName, Vec<((Point, Point), NameWithType)>>,
+    files: hashbrown::HashMap<FileName, FileHovers>,
+}
+
+#[derive(Default)]
+struct FileHovers {
+    pairs: Vec<((Point, Point), NameWithType)>,
 }
 
 impl TypeOnHover {
     pub fn new(program: &CheckedModule) -> Self {
-        let mut map_of_pairs = hashbrown::HashMap::<_, Vec<((Point, Point), _)>>::new();
+        let mut files = hashbrown::HashMap::<_, FileHovers>::new();
 
         for (name, (_, file, _, typ)) in program.type_defs.globals.iter() {
-            let pairs = map_of_pairs.entry_ref(file).or_default();
-            if let Some((start, end)) = name.span.points() {
-                pairs.push((
-                    (start, end),
-                    NameWithType(Some(format!("{}", name)), typ.clone()),
-                ));
-            }
-            typ.types_at_spans(&program.type_defs, &mut |span, name, typ| {
-                if let Some((start, end)) = span.points() {
-                    pairs.push(((start, end), NameWithType(name, typ)))
-                }
+            let file_hovers = files.entry_ref(file).or_default();
+            file_hovers.push(
+                name.span,
+                NameWithType::named(name.to_string(), typ.clone()),
+            );
+            typ.types_at_spans(&program.type_defs, &mut |span, name_info| {
+                file_hovers.push(span, name_info)
             });
         }
 
         for (name, declaration) in &program.declarations {
-            let pairs = map_of_pairs.entry_ref(&declaration.file).or_default();
-            if let Some((start, end)) = name.span.points() {
-                pairs.push((
-                    (start, end),
-                    NameWithType(Some(format!("{}", name)), declaration.typ.clone()),
-                ));
-            }
+            let file_hovers = files.entry_ref(&declaration.file).or_default();
+            let (def_span, def_file) = match program.definitions.get(name) {
+                Some(def) => (def.name.span, def.file.clone()),
+                None => (Span::None, FileName::Builtin),
+            };
+            file_hovers.push(
+                name.span,
+                NameWithType {
+                    name: Some(name.to_string()),
+                    typ: declaration.typ.clone(),
+                    def_span,
+                    decl_span: Span::None,
+                    def_file,
+                },
+            );
             declaration
                 .typ
-                .types_at_spans(&program.type_defs, &mut |span, name, typ| {
-                    if let Some((start, end)) = span.points() {
-                        pairs.push(((start, end), NameWithType(name, typ)))
-                    }
+                .types_at_spans(&program.type_defs, &mut |span, name_info| {
+                    file_hovers.push(span, name_info)
                 });
         }
 
         for (name, definition) in &program.definitions {
-            let pairs = map_of_pairs.entry_ref(&definition.file).or_default();
-            if name.primary == "TraverseDir" {
-                dbg!(&name);
-            }
-            if let Some((start, end)) = name.span.points() {
-                pairs.push((
-                    (start, end),
-                    NameWithType(Some(format!("{}", name)), definition.expression.get_type()),
-                ));
-            }
+            let file_hovers = files.entry_ref(&definition.file).or_default();
+            let (decl_span, decl_file) = match program.declarations.get(name) {
+                Some(decl) => (decl.name.span, decl.file.clone()),
+                None => (Span::None, FileName::Builtin),
+            };
+            file_hovers.push(
+                name.span,
+                NameWithType {
+                    name: Some(name.to_string()),
+                    typ: definition.expression.get_type(),
+                    def_span: Span::None,
+                    decl_span,
+                    def_file: decl_file,
+                },
+            );
             definition
                 .expression
-                .types_at_spans(&program.type_defs, &mut |span, name, typ| {
-                    if let Some((start, end)) = span.points() {
-                        pairs.push(((start, end), NameWithType(name, typ)))
-                    }
+                .types_at_spans(program, &mut |span, name_info| {
+                    file_hovers.push(span, name_info)
                 });
         }
 
-        for (_, pairs) in &mut map_of_pairs {
-            pairs.sort_by_key(|((start, _), _)| start.offset);
-            pairs.dedup_by_key(|((start, _), _)| start.offset);
+        for file_hovers in files.values_mut() {
+            file_hovers.sort_and_dedup();
         }
 
-        Self {
-            map_of_sorted_pairs: map_of_pairs,
-        }
+        Self { files }
+    }
+
+    pub fn query(&self, file: &FileName, row: usize, column: usize) -> Option<NameWithType> {
+        self.files.get(file)?.query(row, column)
     }
 }
 
-impl TypeOnHover {
-    pub fn query(&self, file: &FileName, row: usize, column: usize) -> Option<NameWithType> {
-        let sorted_pairs = self.map_of_sorted_pairs.get(file)?;
+impl FileHovers {
+    fn push(&mut self, span: Span, name_info: NameWithType) {
+        if let Some(points) = span.points() {
+            self.pairs.push((points, name_info))
+        }
+    }
+    fn sort_and_dedup(&mut self) {
+        self.pairs.sort_by_key(|((start, _), _)| start.offset);
+        self.pairs.dedup_by_key(|((start, _), _)| start.offset);
+    }
+    fn query(&self, row: usize, column: usize) -> Option<NameWithType> {
+        let sorted_pairs = &self.pairs;
         if sorted_pairs.is_empty() {
             return None;
         }

--- a/src/par/types/definitions.rs
+++ b/src/par/types/definitions.rs
@@ -77,8 +77,17 @@ impl TypeDefs {
     }
 
     pub fn get(&self, span: &Span, name: &GlobalName, args: &[Type]) -> Result<Type, TypeError> {
+        self.get_with_span(span, name, args).map(|(_, _, typ)| typ)
+    }
+
+    pub fn get_with_span(
+        &self,
+        span: &Span,
+        name: &GlobalName,
+        args: &[Type],
+    ) -> Result<(Span, &FileName, Type), TypeError> {
         match self.globals.get(name) {
-            Some((_, _, params, typ)) => {
+            Some((span, file, params, typ)) => {
                 if params.len() != args.len() {
                     return Err(TypeError::WrongNumberOfTypeArgs(
                         span.clone(),
@@ -87,7 +96,8 @@ impl TypeDefs {
                         args.len(),
                     ));
                 }
-                Ok(typ.clone().substitute(params.iter().zip(args).collect())?)
+                let typ = typ.clone().substitute(params.iter().zip(args).collect())?;
+                Ok((*span, file, typ))
             }
             None => Err(TypeError::TypeNameNotDefined(span.clone(), name.clone())),
         }
@@ -99,8 +109,18 @@ impl TypeDefs {
         name: &GlobalName,
         args: &[Type],
     ) -> Result<Type, TypeError> {
+        self.get_dual_with_span(span, name, args)
+            .map(|(_, _, typ)| typ)
+    }
+
+    pub fn get_dual_with_span(
+        &self,
+        span: &Span,
+        name: &GlobalName,
+        args: &[Type],
+    ) -> Result<(Span, &FileName, Type), TypeError> {
         match self.globals.get(name) {
-            Some((_, _, params, typ)) => {
+            Some((span, file, params, typ)) => {
                 if params.len() != args.len() {
                     return Err(TypeError::WrongNumberOfTypeArgs(
                         span.clone(),
@@ -109,10 +129,11 @@ impl TypeDefs {
                         args.len(),
                     ));
                 }
-                Ok(typ
+                let typ = typ
                     .clone()
                     .dual(Span::None)
-                    .substitute(params.iter().zip(args).collect())?)
+                    .substitute(params.iter().zip(args).collect())?;
+                Ok((*span, file, typ))
             }
             None => Err(TypeError::TypeNameNotDefined(span.clone(), name.clone())),
         }

--- a/src/playground.rs
+++ b/src/playground.rs
@@ -15,9 +15,7 @@ use crate::{
     location::{FileName, Span},
     par::{
         builtin::import_builtins,
-        program::{
-            CheckedModule, Definition, Module, NameWithType, ParseAndCompileError, TypeOnHover,
-        },
+        program::{CheckedModule, Definition, Module, ParseAndCompileError, TypeOnHover},
     },
     readback::Element,
     spawn::TokioSpawn,
@@ -512,14 +510,14 @@ impl Playground {
                     })) = &mut self.compiled
                     {
                         if let Ok(checked) = checked {
-                            if let Some(NameWithType(_, typ)) = checked.type_on_hover.query(
+                            if let Some(name_info) = checked.type_on_hover.query(
                                 &Self::FILE_NAME,
                                 self.cursor_pos.0,
                                 self.cursor_pos.1,
                             ) {
                                 ui.horizontal(|ui| {
                                     let mut buf = String::new();
-                                    typ.pretty(&mut buf, 0).unwrap();
+                                    name_info.typ.pretty(&mut buf, 0).unwrap();
                                     ui.label(RichText::new(buf).code().color(green()));
                                 });
                             }


### PR DESCRIPTION
Getting it working for local variables is more complicated, but thanks to the nature of the relatively flat global namespace and the way local and global variables are syntactically distinct, go-to-def was fairly easy for globals.