### PR TITLE
Tidy up span storage a bit

### DIFF
--- a/src/language_server/feedback.rs
+++ b/src/language_server/feedback.rs
@@ -135,7 +135,7 @@ fn span_to_lsp_range(span: &Span) -> lsp::Range {
                 character: 0,
             },
         },
-        Span::At { start, end } => lsp::Range {
+        Span::At { start, end, .. } => lsp::Range {
             start: lsp::Position {
                 line: start.row as u32,
                 character: start.column as u32,

--- a/src/location.rs
+++ b/src/location.rs
@@ -1,4 +1,5 @@
 use arcstr::ArcStr;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Hash)]
 pub struct Point {
@@ -10,10 +11,14 @@ pub struct Point {
     pub column: u32,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub enum Span {
     None,
-    At { start: Point, end: Point },
+    At {
+        start: Point,
+        end: Point,
+        file: FileName,
+    },
 }
 
 impl Default for Span {
@@ -30,14 +35,21 @@ impl Span {
     pub fn len(&self) -> u32 {
         match self {
             Self::None => 0,
-            Self::At { start, end } => end.offset - start.offset,
+            Self::At { start, end, .. } => end.offset - start.offset,
         }
     }
 
     pub fn points(&self) -> Option<(Point, Point)> {
         match self {
             Self::None => None,
-            Self::At { start, end } => Some((*start, *end)),
+            Self::At { start, end, .. } => Some((*start, *end)),
+        }
+    }
+
+    pub fn file(&self) -> Option<FileName> {
+        match self {
+            Self::None => None,
+            Self::At { file, .. } => Some(file.clone()),
         }
     }
 
@@ -50,133 +62,104 @@ impl Span {
     }
 
     pub fn only_start(&self) -> Self {
-        match self {
+        match self.clone() {
             Self::None => Self::None,
-            Self::At { start, .. } => Self::At {
-                start: *start,
-                end: *start,
+            Self::At { start, file, .. } => Self::At {
+                start,
+                end: start,
+                file,
             },
         }
     }
 
     pub fn only_end(&self) -> Self {
-        match self {
+        match self.clone() {
             Self::None => Self::None,
-            Self::At { end, .. } => Self::At {
-                start: *end,
-                end: *end,
+            Self::At { end, file, .. } => Self::At {
+                start: end,
+                end,
+                file,
             },
         }
     }
 
     pub fn join(&self, other: Self) -> Self {
-        match (self, other) {
-            (Self::None, span) | (&span, Self::None) => span,
+        match (self.clone(), other) {
+            (Self::None, span) | (span, Self::None) => span,
             (
-                &Self::At {
+                Self::At {
                     start: start1,
                     end: end1,
+                    file: file1,
                 },
                 Self::At {
                     start: start2,
                     end: end2,
+                    file: file2,
                 },
-            ) => Self::At {
-                start: if start1.offset < start2.offset {
-                    start1
-                } else {
-                    start2
-                },
-                end: if end1.offset > end2.offset {
-                    end1
-                } else {
-                    end2
-                },
-            },
+            ) => {
+                assert_eq!(file1, file2, "can't join spans from different files");
+                Self::At {
+                    start: if start1.offset < start2.offset {
+                        start1
+                    } else {
+                        start2
+                    },
+                    end: if end1.offset > end2.offset {
+                        end1
+                    } else {
+                        end2
+                    },
+                    file: file1,
+                }
+            }
         }
-    }
-
-    pub fn with_file(self, file: FileName) -> FileSpan {
-        FileSpan::new(self, file)
     }
 }
 
 impl Point {
-    pub fn point_span(&self) -> Span {
+    pub fn point_span(&self, file: FileName) -> Span {
         Span::At {
             start: *self,
             end: *self,
+            file,
         }
     }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
-pub enum FileName {
-    Builtin,
-    Path(ArcStr),
+pub struct FileName(pub ArcStr);
+
+impl FileName {
+    pub const BUILTIN: Self = FileName(arcstr::literal!("par:Builtin"));
 }
 
 impl From<&str> for FileName {
     fn from(path: &str) -> Self {
-        FileName::Path(path.into())
+        FileName(path.into())
     }
 }
 
 impl From<String> for FileName {
     fn from(path: String) -> Self {
-        FileName::Path(path.into())
+        FileName(path.into())
+    }
+}
+
+impl From<&Path> for FileName {
+    fn from(path: &Path) -> Self {
+        (&*path.to_string_lossy()).into()
+    }
+}
+
+impl From<PathBuf> for FileName {
+    fn from(path: PathBuf) -> Self {
+        path.as_path().into()
     }
 }
 
 impl From<&FileName> for FileName {
     fn from(file: &FileName) -> Self {
         file.clone()
-    }
-}
-
-#[derive(Debug, Clone, Default)]
-pub struct FileSpan {
-    inner: Option<((Point, Point), FileName)>,
-}
-
-impl FileSpan {
-    pub const NONE: Self = Self { inner: None };
-
-    pub fn new(span: Span, file: FileName) -> Self {
-        match span {
-            Span::None => Self { inner: None },
-            Span::At { start, end } => Self {
-                inner: Some(((start, end), file)),
-            },
-        }
-    }
-
-    pub fn span(&self) -> Span {
-        match self.inner {
-            Some(((start, end), _)) => Span::At { start, end },
-            None => Span::None,
-        }
-    }
-
-    pub fn file(&self) -> Option<&FileName> {
-        self.inner.as_ref().map(|(_, file)| file)
-    }
-
-    pub fn file_path(&self) -> Option<&ArcStr> {
-        match &self.inner {
-            Some((_, FileName::Path(path))) => Some(path),
-            _ => None,
-        }
-    }
-
-    pub fn with_span(&self, span: Span) -> Self {
-        match &self.inner {
-            Some((_, file)) => FileSpan::new(span, file.clone()),
-            None => FileSpan::NONE,
-        }
-    }
-
-    pub fn points(&self) -> Option<(Point, Point)> {
-        self.inner.as_ref().map(|&(points, _)| points)
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -140,7 +140,7 @@ fn run_definition(file: PathBuf, definition: String) {
         };
 
         let compiled = match stacker::grow(32 * 1024 * 1024, || {
-            Compiled::from_string(&code, file.display().to_string().into())
+            Compiled::from_string(&code, file.into())
         }) {
             Ok(compiled) => compiled,
             Err(err) => {
@@ -223,7 +223,7 @@ fn check(file: PathBuf) {
     };
 
     match stacker::grow(32 * 1024 * 1024, || {
-        Compiled::from_string(&code, file.display().to_string().into())
+        Compiled::from_string(&code, file.into())
     }) {
         Ok(_compiled) => (),
         Err(err) => {

--- a/src/par/builtin.rs
+++ b/src/par/builtin.rs
@@ -21,7 +21,7 @@ use super::{process, program::Module};
 pub fn import_builtins(module: &mut Module<Arc<process::Expression<()>>>) {
     module.import(
         None,
-        Module::parse_and_compile(include_str!("./builtin/Builtin.par"), FileName::Builtin)
+        Module::parse_and_compile(include_str!("./builtin/Builtin.par"), FileName::BUILTIN)
             .unwrap(),
     );
 

--- a/src/par/builtin/test.rs
+++ b/src/par/builtin/test.rs
@@ -2,7 +2,7 @@ use std::sync::{mpsc, Arc};
 
 use crate::{
     icombs::readback::Handle,
-    location::FileSpan,
+    location::Span,
     par::{
         language::GlobalName,
         process,
@@ -15,7 +15,7 @@ use crate::{
 pub fn external_module() -> Module<Arc<process::Expression<()>>> {
     Module {
         type_defs: vec![TypeDef {
-            span: FileSpan::NONE,
+            span: Span::None,
             name: GlobalName::external(Some("Test"), "Test"),
             params: vec![],
             typ: Type::iterative_box_choice(

--- a/src/par/language.rs
+++ b/src/par/language.rs
@@ -483,18 +483,17 @@ impl Expression {
             )),
 
             Self::List(span, items) => {
-                let span = *span;
                 let mut process = Arc::new(process::Process::Do {
-                    span,
+                    span: span.clone(),
                     name: LocalName::result(),
                     typ: (),
                     command: process::Command::Signal(
                         LocalName {
-                            span,
+                            span: span.clone(),
                             string: literal!("end"),
                         },
                         Arc::new(process::Process::Do {
-                            span,
+                            span: span.clone(),
                             name: LocalName::result(),
                             typ: (),
                             command: process::Command::Break,
@@ -504,12 +503,12 @@ impl Expression {
                 for item in items.iter().rev() {
                     let span = item.span();
                     process = Arc::new(process::Process::Do {
-                        span,
+                        span: span.clone(),
                         name: LocalName::result(),
                         typ: (),
                         command: process::Command::Signal(
                             LocalName {
-                                span,
+                                span: span.clone(),
                                 string: literal!("item"),
                             },
                             Arc::new(process::Process::Do {
@@ -522,7 +521,7 @@ impl Expression {
                     });
                 }
                 Arc::new(process::Expression::Fork {
-                    span,
+                    span: span.clone(),
                     captures: Captures::new(),
                     chan_name: LocalName::result(),
                     chan_annotation: None,
@@ -547,7 +546,7 @@ impl Expression {
             Self::Box(span, expression) => {
                 let expression = expression.compile()?;
                 Arc::new(process::Expression::Box(
-                    *span,
+                    span.clone(),
                     Captures::new(),
                     expression,
                     (),
@@ -960,7 +959,7 @@ impl Spanning for Apply {
             | Self::Begin { span, .. }
             | Self::Loop(span, _)
             | Self::SendType(span, _, _)
-            | Self::Noop(span) => *span,
+            | Self::Noop(span) => span.clone(),
         }
     }
 }
@@ -1044,13 +1043,13 @@ impl Process {
             } => pattern.compile_let(span, value.compile()?, then.compile(pass)?),
 
             Self::GlobalCommand(global_name, command) => {
-                let span = global_name.span;
+                let span = global_name.span.clone();
                 let local_name = LocalName {
-                    span,
+                    span: span.clone(),
                     string: arcstr::format!("{}", global_name),
                 };
                 Arc::new(process::Process::Let {
-                    span,
+                    span: span.clone(),
                     name: local_name.clone(),
                     annotation: None,
                     typ: (),
@@ -1068,7 +1067,7 @@ impl Process {
 
             Self::Noop(span) => match pass {
                 Some(process) => process,
-                None => Err(CompileError::MustEndProcess(*span))?,
+                None => Err(CompileError::MustEndProcess(span.clone()))?,
             },
         })
     }
@@ -1080,7 +1079,7 @@ impl Spanning for Process {
             Self::Let { span, .. } | Self::Telltypes(span, _) => span.clone(),
             Self::GlobalCommand(_, command) => command.span(),
             Self::Command(_, command) => command.span(),
-            Self::Noop(span) => *span,
+            Self::Noop(span) => span.clone(),
         }
     }
 }

--- a/src/par/parse.rs
+++ b/src/par/parse.rs
@@ -136,7 +136,7 @@ fn lowercase_identifier(input: &mut Input) -> Result<(Span, String)> {
         .context(StrContext::Expected(StrContextValue::Description(
             "lower-case alphabetic",
         )))
-        .map(|token: &[Token]| (token[0].span, token[0].raw.to_owned()))
+        .map(|token: &[Token]| (token[0].span(), token[0].raw.to_owned()))
         .parse_next(input)
 }
 
@@ -145,7 +145,7 @@ fn uppercase_identifier(input: &mut Input) -> Result<(Span, String)> {
         .context(StrContext::Expected(StrContextValue::Description(
             "upper-case alphabetic",
         )))
-        .map(|token: &[Token]| (token[0].span, token[0].raw.to_owned()))
+        .map(|token: &[Token]| (token[0].span(), token[0].raw.to_owned()))
         .parse_next(input)
 }
 
@@ -192,18 +192,7 @@ impl ProgramParseError {
     }
 }
 
-fn with_file<'a, I, O, E, F>(mut f: F, file: &'a FileName) -> impl Parser<I, O, E> + 'a
-where
-    I: Stream,
-    F: FnMut(&mut I, &FileName) -> std::result::Result<O, E> + 'a,
-{
-    move |i: &mut I| f(i, file)
-}
-
-fn program(
-    mut input: Input,
-    file: &FileName,
-) -> std::result::Result<Module<Expression>, ProgramParseError> {
+fn program(mut input: Input) -> std::result::Result<Module<Expression>, ProgramParseError> {
     enum Item<Expr> {
         TypeDef(TypeDef),
         Declaration(Declaration),
@@ -213,9 +202,9 @@ fn program(
     let parser = repeat(
         0..,
         alt((
-            with_file(type_def, file).map(Item::TypeDef),
-            with_file(declaration, file).map(Item::Declaration),
-            with_file(definition, file).map(|(def, typ)| Item::Definition(def, typ)),
+            type_def.map(Item::TypeDef),
+            declaration.map(Item::Declaration),
+            definition.map(|(def, typ)| Item::Definition(def, typ)),
         ))
         .context(StrContext::Label("item")),
     )
@@ -322,8 +311,8 @@ pub fn parse_module(
     input: &str,
     file: FileName,
 ) -> std::result::Result<Module<Expression>, SyntaxError> {
-    let tokens = lex(&input);
-    let e = match program(Input::new(&tokens), &file) {
+    let tokens = lex(&input, &file);
+    let e = match program(Input::new(&tokens)) {
         Ok(x) => return Ok(x),
         Err(e) => e,
     };
@@ -332,9 +321,9 @@ pub fn parse_module(
         .get(e.offset())
         .unwrap_or(tokens.last().unwrap())
         .clone();
-    let error_tok_span = error_tok.span.clone();
+    let error_tok_span = error_tok.span();
     Err(SyntaxError {
-        span: error_tok_span,
+        span: error_tok_span.clone(),
         source_span: match error_tok_span {
             Span::None => SourceSpan::new(SourceOffset::from(0), input.len()),
             span @ Span::At { start, .. } => SourceSpan::new(
@@ -356,20 +345,20 @@ pub fn parse_module(
     })
 }
 
-pub fn parse_bytes(input: &str) -> Option<Vec<u8>> {
+pub fn parse_bytes(input: &str, file: &FileName) -> Option<Vec<u8>> {
     (literal_bytes_inner, winnow::combinator::eof)
-        .parse_next(&mut Input::new(&lex(input)))
+        .parse_next(&mut Input::new(&lex(input, file)))
         .map(|(b, _)| b)
         .ok()
 }
 
-fn type_def(input: &mut Input, file: &FileName) -> Result<TypeDef> {
+fn type_def(input: &mut Input) -> Result<TypeDef> {
     commit_after(
         t(TokenKind::Type),
         (global_name, type_params, t(TokenKind::Eq), typ),
     )
     .map(|(pre, (name, type_params, _, typ))| TypeDef {
-        span: pre.span.join(typ.span()).with_file(file.clone()),
+        span: pre.span.join(typ.span()),
         name,
         params: type_params.map_or_else(Vec::new, |(_, params)| params),
         typ,
@@ -378,10 +367,10 @@ fn type_def(input: &mut Input, file: &FileName) -> Result<TypeDef> {
     .parse_next(input)
 }
 
-fn declaration(input: &mut Input, file: &FileName) -> Result<Declaration> {
+fn declaration(input: &mut Input) -> Result<Declaration> {
     commit_after(t(TokenKind::Dec), (global_name, t(TokenKind::Colon), typ))
         .map(|(pre, (name, _, typ))| Declaration {
-            span: pre.span.join(typ.span()).with_file(file.clone()),
+            span: pre.span.join(typ.span()),
             name,
             typ,
         })
@@ -389,10 +378,7 @@ fn declaration(input: &mut Input, file: &FileName) -> Result<Declaration> {
         .parse_next(input)
 }
 
-fn definition(
-    input: &mut Input,
-    file: &FileName,
-) -> Result<(Definition<Expression>, Option<Type>)> {
+fn definition(input: &mut Input) -> Result<(Definition<Expression>, Option<Type>)> {
     commit_after(
         t(TokenKind::Def),
         (global_name, annotation, t(TokenKind::Eq), expression),
@@ -400,7 +386,7 @@ fn definition(
     .map(|(pre, (name, annotation, _, expression))| {
         (
             Definition {
-                span: pre.span.join(expression.span()).with_file(file.clone()),
+                span: pre.span.join(expression.span()),
                 name,
                 expression,
             },
@@ -439,7 +425,7 @@ where
             t(TokenKind::RCurly),
         ),
     )
-    .map(|(open, (branches, close))| (open.span.join(close.span), branches))
+    .map(|(open, (branches, close))| (open.span.join(close.span()), branches))
     .context(StrContext::Label("either/choice branches"))
 }
 
@@ -468,7 +454,7 @@ fn typ(input: &mut Input) -> Result<Type> {
 fn typ_var(input: &mut Input) -> Result<Type> {
     trace(
         "typ_var",
-        local_name.map(|name| Type::Var(name.span.clone(), name)),
+        local_name.map(|name| Type::Var(name.span(), name)),
     )
     .parse_next(input)
 }
@@ -480,7 +466,7 @@ fn typ_name(input: &mut Input) -> Result<Type> {
             Some((type_args_span, type_args)) => {
                 Type::Name(name.span.join(type_args_span), name, type_args)
             }
-            None => Type::Name(name.span.clone(), name, vec![]),
+            None => Type::Name(name.span(), name, vec![]),
         }),
     )
     .parse_next(input)
@@ -491,7 +477,7 @@ fn typ_box(input: &mut Input) -> Result<Type> {
         t(TokenKind::Box),
         typ.context(StrContext::Label("box type")),
     )
-    .map(|(pre, typ)| Type::Box(pre.span, Box::new(typ)))
+    .map(|(pre, typ)| Type::Box(pre.span(), Box::new(typ)))
     .parse_next(input)
 }
 
@@ -500,7 +486,7 @@ fn typ_chan(input: &mut Input) -> Result<Type> {
         t(TokenKind::Dual),
         typ.context(StrContext::Label("dual type")),
     )
-    .map(|(pre, typ)| typ.dual(pre.span))
+    .map(|(pre, typ)| typ.dual(pre.span()))
     .parse_next(input)
 }
 
@@ -509,7 +495,7 @@ fn typ_send(input: &mut Input) -> Result<Type> {
         .map(|(open, (args, _, then))| {
             let span = open.span.join(then.span());
             args.into_iter().rfold(then, |then, arg| {
-                Type::Pair(span, Box::new(arg), Box::new(then))
+                Type::Pair(span.clone(), Box::new(arg), Box::new(then))
             })
         })
         .parse_next(input)
@@ -520,7 +506,7 @@ fn typ_receive(input: &mut Input) -> Result<Type> {
         .map(|(open, (args, _, then))| {
             let span = open.span.join(then.span());
             args.into_iter().rfold(then, |then, arg| {
-                Type::Function(span, Box::new(arg), Box::new(then))
+                Type::Function(span.clone(), Box::new(arg), Box::new(then))
             })
         })
         .parse_next(input)
@@ -544,13 +530,13 @@ fn typ_choice(input: &mut Input) -> Result<Type> {
 
 fn typ_break(input: &mut Input) -> Result<Type> {
     t(TokenKind::Bang)
-        .map(|token| Type::Break(token.span))
+        .map(|token| Type::Break(token.span()))
         .parse_next(input)
 }
 
 fn typ_continue(input: &mut Input) -> Result<Type> {
     t(TokenKind::Quest)
-        .map(|token| Type::Continue(token.span))
+        .map(|token| Type::Continue(token.span()))
         .parse_next(input)
 }
 
@@ -587,8 +573,8 @@ fn typ_self(input: &mut Input) -> Result<Type> {
     .map(|(token, label)| {
         Type::Self_(
             match &label {
-                Some(label) => token.span.join(label.span),
-                None => token.span.clone(),
+                Some(label) => token.span.join(label.span()),
+                None => token.span(),
             },
             label,
         )
@@ -607,9 +593,9 @@ fn typ_send_type<'s>(input: &mut Input) -> Result<Type> {
     )
     .map(|((open, _), (names, _, then))| {
         let span = open.span.join(then.span());
-        names
-            .into_iter()
-            .rfold(then, |then, name| Type::Exists(span, name, Box::new(then)))
+        names.into_iter().rfold(then, |then, name| {
+            Type::Exists(span.clone(), name, Box::new(then))
+        })
     })
     .parse_next(input)
 }
@@ -625,9 +611,9 @@ fn typ_recv_type(input: &mut Input) -> Result<Type> {
     )
     .map(|((open, _), (names, _, then))| {
         let span = open.span.join(then.span());
-        names
-            .into_iter()
-            .rfold(then, |then, name| Type::Forall(span, name, Box::new(then)))
+        names.into_iter().rfold(then, |then, name| {
+            Type::Forall(span.clone(), name, Box::new(then))
+        })
     })
     .parse_next(input)
 }
@@ -637,7 +623,7 @@ fn type_params(input: &mut Input) -> Result<Option<(Span, Vec<LocalName>)>> {
         t(TokenKind::Lt),
         (list(local_name), t(TokenKind::Gt)),
     ))
-    .map(|opt| opt.map(|(open, (names, close))| (open.span.join(close.span), names)))
+    .map(|opt| opt.map(|(open, (names, close))| (open.span.join(close.span()), names)))
     .parse_next(input)
 }
 
@@ -646,7 +632,7 @@ fn type_args<'s>(input: &mut Input) -> Result<Option<(Span, Vec<Type>)>> {
         t(TokenKind::Lt),
         (list(typ), t(TokenKind::Gt)),
     ))
-    .map(|opt| opt.map(|(open, (types, close))| (open.span.join(close.span), types)))
+    .map(|opt| opt.map(|(open, (types, close))| (open.span.join(close.span()), types)))
     .parse_next(input)
 }
 
@@ -669,7 +655,7 @@ fn typ_branch_receive(input: &mut Input) -> Result<Type> {
     .map(|(open, (args, _, then))| {
         let span = open.span.join(then.span());
         args.into_iter().rfold(then, |then, arg| {
-            Type::Function(span, Box::new(arg), Box::new(then))
+            Type::Function(span.clone(), Box::new(arg), Box::new(then))
         })
     })
     .parse_next(input)
@@ -682,9 +668,9 @@ fn typ_branch_recv_type(input: &mut Input) -> Result<Type> {
     )
         .map(|((open, _), (names, _, then))| {
             let span = open.span.join(then.span());
-            names
-                .into_iter()
-                .rfold(then, |then, name| Type::Forall(span, name, Box::new(then)))
+            names.into_iter().rfold(then, |then, name| {
+                Type::Forall(span.clone(), name, Box::new(then))
+            })
         })
         .parse_next(input)
 }
@@ -712,7 +698,7 @@ fn pattern_name(input: &mut Input) -> Result<Pattern> {
             Pattern::Name(
                 match &annotation {
                     Some(typ) => name.span.join(typ.span()),
-                    None => name.span.clone(),
+                    None => name.span(),
                 },
                 name,
                 annotation,
@@ -729,7 +715,7 @@ fn pattern_receive(input: &mut Input) -> Result<Pattern> {
     .map(|(open, (patterns, _, rest))| {
         let span = open.span.join(rest.span());
         patterns.into_iter().rfold(rest, |rest, arg| {
-            Pattern::Receive(span, Box::new(arg), Box::new(rest))
+            Pattern::Receive(span.clone(), Box::new(arg), Box::new(rest))
         })
     })
     .parse_next(input)
@@ -737,7 +723,7 @@ fn pattern_receive(input: &mut Input) -> Result<Pattern> {
 
 fn pattern_continue(input: &mut Input) -> Result<Pattern> {
     t(TokenKind::Bang)
-        .map(|token| Pattern::Continue(token.span))
+        .map(|token| Pattern::Continue(token.span()))
         .parse_next(input)
 }
 
@@ -749,7 +735,7 @@ fn pattern_receive_type(input: &mut Input) -> Result<Pattern> {
     .map(|((open, _), (names, _, rest))| {
         let span = open.span.join(rest.span());
         names.into_iter().rfold(rest, |rest, name| {
-            Pattern::ReceiveType(span, name, Box::new(rest))
+            Pattern::ReceiveType(span.clone(), name, Box::new(rest))
         })
     })
     .parse_next(input)
@@ -773,7 +759,9 @@ fn expression(input: &mut Input) -> Result<Expression> {
 
 fn expr_grouped(input: &mut Input) -> Result<Expression> {
     (t(TokenKind::LCurly), expression, t(TokenKind::RCurly))
-        .map(|(open, expr, close)| Expression::Grouped(open.span.join(close.span), Box::new(expr)))
+        .map(|(open, expr, close)| {
+            Expression::Grouped(open.span.join(close.span()), Box::new(expr))
+        })
         .parse_next(input)
 }
 
@@ -786,7 +774,7 @@ fn expr_list(input: &mut Input) -> Result<Expression> {
         t(TokenKind::Star),
         (t(TokenKind::LParen), list(expression), t(TokenKind::RParen)),
     )
-    .map(|(pre, (_, items, post))| Expression::List(pre.span.join(post.span), items))
+    .map(|(pre, (_, items, post))| Expression::List(pre.span.join(post.span()), items))
     .parse_next(input)
 }
 
@@ -800,7 +788,7 @@ fn literal_int(input: &mut Input) -> Result<(Span, BigInt)> {
     t(TokenKind::Integer)
         .map(|token| {
             let s: String = token.raw.chars().filter(|c| *c != '_').collect();
-            (token.span, BigInt::parse_bytes(s.as_bytes(), 10).unwrap())
+            (token.span(), BigInt::parse_bytes(s.as_bytes(), 10).unwrap())
         })
         .parse_next(input)
 }
@@ -810,7 +798,7 @@ fn expr_literal_string(input: &mut Input) -> Result<Expression> {
         .map(|token| {
             // validated in lexer
             let value = unescaper::unescape(token.raw).unwrap();
-            Expression::Primitive(token.span, Primitive::String(Substr::from(value)))
+            Expression::Primitive(token.span(), Primitive::String(Substr::from(value)))
         })
         .parse_next(input)
 }
@@ -822,7 +810,7 @@ fn expr_literal_bytes(input: &mut Input) -> Result<Expression> {
     )
     .map(|((pre, _), (bytes, _, post))| {
         Expression::Primitive(
-            pre.span.join(post.span),
+            pre.span.join(post.span()),
             Primitive::Bytes(ByteView::new(&bytes)),
         )
     })
@@ -893,7 +881,7 @@ fn expr_do(input: &mut Input) -> Result<Expression> {
 
 fn expr_box(input: &mut Input) -> Result<Expression> {
     commit_after(t(TokenKind::Box), expression)
-        .map(|(pre, expression)| Expression::Box(pre.span, Box::new(expression)))
+        .map(|(pre, expression)| Expression::Box(pre.span(), Box::new(expression)))
         .parse_next(input)
 }
 
@@ -910,7 +898,7 @@ fn expr_fork(input: &mut Input) -> Result<Expression> {
     )
     .map(
         |(pre, (channel, annotation, open, process, close))| Expression::Fork {
-            span: pre.span.join(close.span),
+            span: pre.span.join(close.span()),
             channel,
             annotation,
             process: match process {
@@ -964,7 +952,7 @@ fn cons_send(input: &mut Input) -> Result<Construct> {
     .map(|(open, (args, _, then))| {
         let span = open.span.join(then.span());
         args.into_iter().rfold(then, |then, arg| {
-            Construct::Send(span, Box::new(arg), Box::new(then))
+            Construct::Send(span.clone(), Box::new(arg), Box::new(then))
         })
     })
     .parse_next(input)
@@ -978,7 +966,7 @@ fn cons_receive(input: &mut Input) -> Result<Construct> {
     .map(|(open, (patterns, _, then))| {
         let span = open.span.join(then.span());
         patterns.into_iter().rfold(then, |then, pattern| {
-            Construct::Receive(span, pattern, Box::new(then))
+            Construct::Receive(span.clone(), pattern, Box::new(then))
         })
     })
     .parse_next(input)
@@ -1003,7 +991,7 @@ fn cons_case(input: &mut Input) -> Result<Construct> {
 
 fn cons_break(input: &mut Input) -> Result<Construct> {
     t(TokenKind::Bang)
-        .map(|token| Construct::Break(token.span))
+        .map(|token| Construct::Break(token.span()))
         .parse_next(input)
 }
 
@@ -1034,8 +1022,8 @@ fn cons_loop(input: &mut Input) -> Result<Construct> {
         .map(|(token, label)| {
             Construct::Loop(
                 match &label {
-                    Some(label) => token.span.join(label.span),
-                    None => token.span.clone(),
+                    Some(label) => token.span.join(label.span()),
+                    None => token.span(),
                 },
                 label,
             )
@@ -1051,7 +1039,7 @@ fn cons_send_type(input: &mut Input) -> Result<Construct> {
     .map(|((open, _), (types, _, then))| {
         let span = open.span.join(then.span());
         types.into_iter().rfold(then, |then, typ| {
-            Construct::SendType(span, typ, Box::new(then))
+            Construct::SendType(span.clone(), typ, Box::new(then))
         })
     })
     .parse_next(input)
@@ -1065,7 +1053,7 @@ fn cons_recv_type(input: &mut Input) -> Result<Construct> {
     .map(|((open, _), (names, _, then))| {
         let span = open.span.join(then.span());
         names.into_iter().rfold(then, |then, name| {
-            Construct::ReceiveType(span, name, Box::new(then))
+            Construct::ReceiveType(span.clone(), name, Box::new(then))
         })
     })
     .parse_next(input)
@@ -1091,7 +1079,7 @@ fn cons_branch_receive(input: &mut Input) -> Result<ConstructBranch> {
     .map(|(open, (patterns, _, rest))| {
         let span = open.span.join(rest.span());
         patterns.into_iter().rfold(rest, |rest, pattern| {
-            ConstructBranch::Receive(span, pattern, Box::new(rest))
+            ConstructBranch::Receive(span.clone(), pattern, Box::new(rest))
         })
     })
     .parse_next(input)
@@ -1105,7 +1093,7 @@ fn cons_branch_recv_type(input: &mut Input) -> Result<ConstructBranch> {
     .map(|((open, _), (names, _, rest))| {
         let span = open.span.join(rest.span());
         names.into_iter().rfold(rest, |rest, name| {
-            ConstructBranch::ReceiveType(span, name, Box::new(rest))
+            ConstructBranch::ReceiveType(span.clone(), name, Box::new(rest))
         })
     })
     .parse_next(input)
@@ -1114,8 +1102,8 @@ fn cons_branch_recv_type(input: &mut Input) -> Result<ConstructBranch> {
 fn application(input: &mut Input) -> Result<Expression> {
     (
         alt((
-            global_name.map(|name| Expression::Global(name.span, name)),
-            local_name.map(|name| Expression::Variable(name.span, name)),
+            global_name.map(|name| Expression::Global(name.span(), name)),
+            local_name.map(|name| Expression::Variable(name.span(), name)),
             expr_grouped,
         )),
         apply,
@@ -1155,7 +1143,7 @@ fn apply_send(input: &mut Input) -> Result<Apply> {
         };
         let span = open.span.join(then.span());
         args.into_iter().rfold(then, |then, arg| {
-            Apply::Send(span, Box::new(arg), Box::new(then))
+            Apply::Send(span.clone(), Box::new(arg), Box::new(then))
         })
     })
     .parse_next(input)
@@ -1231,8 +1219,8 @@ fn apply_loop(input: &mut Input) -> Result<Apply> {
         .map(|((pre1, pre2), label)| {
             Apply::Loop(
                 match &label {
-                    Some(label) => pre1.span.join(label.span),
-                    None => pre1.span.join(pre2.span),
+                    Some(label) => pre1.span.join(label.span()),
+                    None => pre1.span.join(pre2.span()),
                 },
                 label,
             )
@@ -1251,9 +1239,9 @@ fn apply_send_type(input: &mut Input) -> Result<Apply> {
             None => Apply::Noop(close.span.only_end()),
         };
         let span = open.span.join(then.span());
-        types
-            .into_iter()
-            .rfold(then, |then, typ| Apply::SendType(span, typ, Box::new(then)))
+        types.into_iter().rfold(then, |then, typ| {
+            Apply::SendType(span.clone(), typ, Box::new(then))
+        })
     })
     .parse_next(input)
 }
@@ -1284,7 +1272,7 @@ fn apply_branch_receive(input: &mut Input) -> Result<ApplyBranch> {
     .map(|(open, (patterns, _, rest))| {
         let span = open.span.join(rest.span());
         patterns.into_iter().rfold(rest, |rest, pattern| {
-            ApplyBranch::Receive(span, pattern, Box::new(rest))
+            ApplyBranch::Receive(span.clone(), pattern, Box::new(rest))
         })
     })
     .parse_next(input)
@@ -1306,7 +1294,7 @@ fn apply_branch_recv_type(input: &mut Input) -> Result<ApplyBranch> {
     .map(|((open, _), (names, _, rest))| {
         let span = open.span.join(rest.span());
         names.into_iter().rfold(rest, |rest, name| {
-            ApplyBranch::ReceiveType(span, name, Box::new(rest))
+            ApplyBranch::ReceiveType(span.clone(), name, Box::new(rest))
         })
     })
     .parse_next(input)
@@ -1339,7 +1327,7 @@ fn proc_telltypes(input: &mut Input) -> Result<Process> {
     commit_after(t(TokenKind::Telltypes), opt(process))
         .map(|(token, process)| {
             Process::Telltypes(
-                token.span,
+                token.span.clone(),
                 match process {
                     Some(process) => Box::new(process),
                     None => Box::new(Process::Noop(token.span.only_end())),
@@ -1426,7 +1414,7 @@ fn cmd_send(input: &mut Input) -> Result<Command> {
         };
         let span = open.span.join(cmd.span());
         expressions.into_iter().rfold(cmd, |cmd, expression| {
-            Command::Send(span, expression, Box::new(cmd))
+            Command::Send(span.clone(), expression, Box::new(cmd))
         })
     })
     .parse_next(input)
@@ -1444,7 +1432,7 @@ fn cmd_receive(input: &mut Input) -> Result<Command> {
         };
         let span = open.span.join(cmd.span());
         patterns.into_iter().rfold(cmd, |cmd, pattern| {
-            Command::Receive(span, pattern, Box::new(cmd))
+            Command::Receive(span.clone(), pattern, Box::new(cmd))
         })
     })
     .parse_next(input)
@@ -1479,7 +1467,7 @@ fn cmd_case(input: &mut Input) -> Result<Command> {
 
 fn cmd_break(input: &mut Input) -> Result<Command> {
     t(TokenKind::Bang)
-        .map(|token| Command::Break(token.span))
+        .map(|token| Command::Break(token.span()))
         .parse_next(input)
 }
 
@@ -1487,10 +1475,7 @@ fn cmd_continue(input: &mut Input) -> Result<Command> {
     (t(TokenKind::Quest), opt(process))
         .map(|(token, process)| match process {
             Some(process) => Command::Continue(token.span.join(process.span()), Box::new(process)),
-            None => Command::Continue(
-                token.span.clone(),
-                Box::new(Process::Noop(token.span.only_end())),
-            ),
+            None => Command::Continue(token.span(), Box::new(Process::Noop(token.span.only_end()))),
         })
         .parse_next(input)
 }
@@ -1539,8 +1524,8 @@ fn cmd_loop(input: &mut Input) -> Result<Command> {
         .map(|((pre1, pre2), label)| {
             Command::Loop(
                 match &label {
-                    Some(label) => pre1.span.join(label.span),
-                    None => pre1.span.join(pre2.span),
+                    Some(label) => pre1.span.join(label.span()),
+                    None => pre1.span.join(pre2.span()),
                 },
                 label,
             )
@@ -1559,9 +1544,9 @@ fn cmd_send_type(input: &mut Input) -> Result<Command> {
             None => noop_cmd(close.span.only_end()),
         };
         let span = open.span.join(cmd.span());
-        types
-            .into_iter()
-            .rfold(cmd, |cmd, typ| Command::SendType(span, typ, Box::new(cmd)))
+        types.into_iter().rfold(cmd, |cmd, typ| {
+            Command::SendType(span.clone(), typ, Box::new(cmd))
+        })
     })
     .parse_next(input)
 }
@@ -1578,7 +1563,7 @@ fn cmd_recv_type(input: &mut Input) -> Result<Command> {
         };
         let span = open.span.join(cmd.span());
         names.into_iter().rfold(cmd, |cmd, name| {
-            Command::ReceiveType(span, name, Box::new(cmd))
+            Command::ReceiveType(span.clone(), name, Box::new(cmd))
         })
     })
     .parse_next(input)
@@ -1606,7 +1591,7 @@ fn cmd_branch_then(input: &mut Input) -> Result<CommandBranch> {
     )
     .map(|(pre, (open, process, close))| {
         CommandBranch::Then(
-            pre.span.join(close.span),
+            pre.span.join(close.span()),
             match process {
                 Some(process) => process,
                 None => Process::Noop(open.span.only_end()),
@@ -1626,7 +1611,7 @@ fn cmd_branch_bind_then(input: &mut Input) -> Result<CommandBranch> {
     )
         .map(|(name, (pre, (open, process, close)))| {
             CommandBranch::BindThen(
-                pre.span.join(close.span),
+                pre.span.join(close.span()),
                 name,
                 match process {
                     Some(process) => process,
@@ -1645,7 +1630,7 @@ fn cmd_branch_receive(input: &mut Input) -> Result<CommandBranch> {
     .map(|(open, (patterns, _, rest))| {
         let span = open.span.join(rest.span());
         patterns.into_iter().rfold(rest, |rest, pattern| {
-            CommandBranch::Receive(span, pattern, Box::new(rest))
+            CommandBranch::Receive(span.clone(), pattern, Box::new(rest))
         })
     })
     .parse_next(input)
@@ -1663,7 +1648,7 @@ fn cmd_branch_continue(input: &mut Input) -> Result<CommandBranch> {
     )
     .map(|(token, (_, open, process, close))| {
         CommandBranch::Continue(
-            token.span.join(close.span),
+            token.span.join(close.span()),
             match process {
                 Some(process) => process,
                 None => Process::Noop(open.span.only_end()),
@@ -1681,7 +1666,7 @@ fn cmd_branch_recv_type(input: &mut Input) -> Result<CommandBranch> {
     .map(|((open, _), (names, _, rest))| {
         let span = open.span.join(rest.span());
         names.into_iter().rfold(rest, |rest, name| {
-            CommandBranch::ReceiveType(span, name, Box::new(rest))
+            CommandBranch::ReceiveType(span.clone(), name, Box::new(rest))
         })
     })
     .parse_next(input)

--- a/src/par/process.rs
+++ b/src/par/process.rs
@@ -5,7 +5,7 @@ use super::{
 };
 use crate::{
     icombs::readback::Handle,
-    location::{FileSpan, Span, Spanning},
+    location::{Span, Spanning},
     par::program::CheckedModule,
 };
 use indexmap::IndexMap;
@@ -289,11 +289,14 @@ impl Process<Type> {
             } => {
                 consume(name.span(), NameWithType::named(name, typ.clone()));
                 if name == &LocalName::result() {
-                    consume(*span, NameWithType::unnamed(typ.clone().dual(Span::None)));
+                    consume(
+                        span.clone(),
+                        NameWithType::unnamed(typ.clone().dual(Span::None)),
+                    );
                 } else if name == &LocalName::object() {
-                    consume(*span, NameWithType::unnamed(typ.clone()));
+                    consume(span.clone(), NameWithType::unnamed(typ.clone()));
                 } else {
-                    consume(*span, NameWithType::named(name, typ.clone()));
+                    consume(span.clone(), NameWithType::named(name, typ.clone()));
                 }
                 command.types_at_spans(program, consume);
             }
@@ -448,17 +451,22 @@ impl<Typ: Clone> Expression<Typ> {
     ) -> (Arc<Self>, Captures) {
         match self {
             Self::Global(span, name, typ) => (
-                Arc::new(Self::Global(*span, name.clone(), typ.clone())),
+                Arc::new(Self::Global(span.clone(), name.clone(), typ.clone())),
                 Captures::new(),
             ),
             Self::Variable(span, name, typ) => (
-                Arc::new(Self::Variable(*span, name.clone(), typ.clone())),
+                Arc::new(Self::Variable(span.clone(), name.clone(), typ.clone())),
                 Captures::single(name.clone(), span.clone()),
             ),
             Self::Box(span, _, expression, typ) => {
                 let (expression, caps) = expression.fix_captures(loop_points);
                 (
-                    Arc::new(Self::Box(*span, caps.clone(), expression, typ.clone())),
+                    Arc::new(Self::Box(
+                        span.clone(),
+                        caps.clone(),
+                        expression,
+                        typ.clone(),
+                    )),
                     caps,
                 )
             }
@@ -475,7 +483,7 @@ impl<Typ: Clone> Expression<Typ> {
                 caps.remove(channel);
                 (
                     Arc::new(Self::Fork {
-                        span: *span,
+                        span: span.clone(),
                         captures: caps.clone(),
                         chan_name: channel.clone(),
                         chan_annotation: annotation.clone(),
@@ -500,13 +508,13 @@ impl<Typ: Clone> Expression<Typ> {
     pub fn optimize(&self) -> Arc<Self> {
         match self {
             Self::Global(span, name, typ) => {
-                Arc::new(Self::Global(*span, name.clone(), typ.clone()))
+                Arc::new(Self::Global(span.clone(), name.clone(), typ.clone()))
             }
             Self::Variable(span, name, typ) => {
-                Arc::new(Self::Variable(*span, name.clone(), typ.clone()))
+                Arc::new(Self::Variable(span.clone(), name.clone(), typ.clone()))
             }
             Self::Box(span, caps, expression, typ) => Arc::new(Self::Box(
-                *span,
+                span.clone(),
                 caps.clone(),
                 expression.optimize(),
                 typ.clone(),
@@ -542,8 +550,8 @@ impl<Typ: Clone> Expression<Typ> {
 pub struct NameWithType {
     pub name: Option<String>,
     pub typ: Type,
-    pub def_span: FileSpan,
-    pub decl_span: FileSpan,
+    pub def_span: Span,
+    pub decl_span: Span,
 }
 
 impl NameWithType {
@@ -551,8 +559,8 @@ impl NameWithType {
         NameWithType {
             name,
             typ,
-            def_span: FileSpan::NONE,
-            decl_span: FileSpan::NONE,
+            def_span: Span::None,
+            decl_span: Span::None,
         }
     }
     pub fn named(name: impl ToString, typ: Type) -> Self {
@@ -571,14 +579,11 @@ impl Expression<Type> {
     ) {
         match self {
             Self::Global(_, name, typ) => {
-                let def_span = match program.definitions.get(name) {
-                    Some(def) => def.span.with_span(def.name.span),
-                    None => FileSpan::NONE,
-                };
-                let decl_span = program
-                    .declarations
-                    .get(name)
-                    .map(|decl| decl.span.with_span(decl.name.span))
+                let def_span = (program.definitions.get(name))
+                    .map(|def| def.name.span())
+                    .unwrap_or_default();
+                let decl_span = (program.declarations.get(name))
+                    .map(|decl| decl.name.span())
                     .unwrap_or_else(|| def_span.clone());
                 consume(
                     name.span(),
@@ -594,7 +599,7 @@ impl Expression<Type> {
                 consume(name.span(), NameWithType::named(name, typ.clone()));
             }
             Self::Box(span, _, expression, typ) => {
-                consume(*span, NameWithType::unnamed(typ.clone()));
+                consume(span.clone(), NameWithType::unnamed(typ.clone()));
                 expression.types_at_spans(program, consume);
             }
             Self::Fork {

--- a/src/par/types/checking.rs
+++ b/src/par/types/checking.rs
@@ -758,7 +758,7 @@ impl Context {
                 if let Some(inference_subject) = inference_subject {
                     if captures.names.contains_key(inference_subject) {
                         return Err(TypeError::TypeMustBeKnownAtThisPoint(
-                            *span,
+                            span.clone(),
                             inference_subject.clone(),
                         ));
                     }
@@ -774,7 +774,7 @@ impl Context {
                 let expression =
                     self.check_expression(inference_subject, expression, &target_inner_type)?;
                 Ok(Arc::new(Expression::Box(
-                    *span,
+                    span.clone(),
                     captures.clone(),
                     expression,
                     target_type.clone(),
@@ -873,7 +873,7 @@ impl Context {
                 if let Some(inference_subject) = inference_subject {
                     if captures.names.contains_key(inference_subject) {
                         return Err(TypeError::TypeMustBeKnownAtThisPoint(
-                            *span,
+                            span.clone(),
                             inference_subject.clone(),
                         ));
                     }
@@ -881,10 +881,10 @@ impl Context {
                 let mut context = self.split();
                 self.capture(inference_subject, captures, true, &mut context)?;
                 let (expression, typ) = self.infer_expression(inference_subject, expression)?;
-                let typ = Type::Box(*span, Box::new(typ.clone()));
+                let typ = Type::Box(span.clone(), Box::new(typ.clone()));
                 Ok((
                     Arc::new(Expression::Box(
-                        *span,
+                        span.clone(),
                         captures.clone(),
                         expression,
                         typ.clone(),

--- a/src/par/types/context.rs
+++ b/src/par/types/context.rs
@@ -1,4 +1,4 @@
-use crate::location::{FileSpan, Span};
+use crate::location::Span;
 use crate::par::language::{GlobalName, LocalName};
 use crate::par::process::{Captures, Expression};
 use crate::par::types::{Type, TypeDefs, TypeError};
@@ -8,8 +8,8 @@ use std::sync::{Arc, RwLock};
 #[derive(Clone, Debug)]
 pub struct Context {
     pub type_defs: TypeDefs,
-    declarations: Arc<IndexMap<GlobalName, (FileSpan, Type)>>,
-    unchecked_definitions: Arc<IndexMap<GlobalName, (FileSpan, Arc<Expression<()>>)>>,
+    declarations: Arc<IndexMap<GlobalName, (Span, Type)>>,
+    unchecked_definitions: Arc<IndexMap<GlobalName, (Span, Arc<Expression<()>>)>>,
     checked_definitions: Arc<RwLock<IndexMap<GlobalName, CheckedDef>>>,
     current_deps: IndexSet<GlobalName>,
     pub variables: IndexMap<LocalName, Type>,
@@ -18,7 +18,7 @@ pub struct Context {
 
 #[derive(Clone, Debug)]
 struct CheckedDef {
-    span: FileSpan,
+    span: Span,
     def: Arc<Expression<Type>>,
     typ: Type,
 }
@@ -26,8 +26,8 @@ struct CheckedDef {
 impl Context {
     pub fn new(
         type_defs: TypeDefs,
-        declarations: IndexMap<GlobalName, (FileSpan, Type)>,
-        unchecked_definitions: IndexMap<GlobalName, (FileSpan, Arc<Expression<()>>)>,
+        declarations: IndexMap<GlobalName, (Span, Type)>,
+        unchecked_definitions: IndexMap<GlobalName, (Span, Arc<Expression<()>>)>,
     ) -> Self {
         Self {
             type_defs,
@@ -100,9 +100,7 @@ impl Context {
         Ok(checked_type)
     }
 
-    pub fn get_checked_definitions(
-        &self,
-    ) -> IndexMap<GlobalName, (FileSpan, Arc<Expression<Type>>)> {
+    pub fn get_checked_definitions(&self) -> IndexMap<GlobalName, (Span, Arc<Expression<Type>>)> {
         self.checked_definitions
             .read()
             .unwrap()
@@ -111,7 +109,7 @@ impl Context {
             .collect()
     }
 
-    pub fn get_declarations(&self) -> IndexMap<GlobalName, (FileSpan, Type)> {
+    pub fn get_declarations(&self) -> IndexMap<GlobalName, (Span, Type)> {
         (*self.declarations).clone()
     }
 

--- a/src/par/types/definitions.rs
+++ b/src/par/types/definitions.rs
@@ -1,4 +1,4 @@
-use crate::location::{FileSpan, Span};
+use crate::location::Span;
 use crate::par::language::{GlobalName, LocalName};
 use crate::par::types::{Type, TypeError};
 use indexmap::{IndexMap, IndexSet};
@@ -6,7 +6,7 @@ use std::sync::Arc;
 
 #[derive(Clone, Debug)]
 pub struct TypeDefs {
-    pub globals: Arc<IndexMap<GlobalName, (FileSpan, Vec<LocalName>, Type)>>,
+    pub globals: Arc<IndexMap<GlobalName, (Span, Vec<LocalName>, Type)>>,
     pub vars: IndexSet<LocalName>,
 }
 
@@ -21,7 +21,7 @@ impl Default for TypeDefs {
 
 impl TypeDefs {
     pub fn new_with_validation<'a>(
-        globals: impl Iterator<Item = (&'a FileSpan, &'a GlobalName, &'a Vec<LocalName>, &'a Type)>,
+        globals: impl Iterator<Item = (&'a Span, &'a GlobalName, &'a Vec<LocalName>, &'a Type)>,
     ) -> Result<Self, TypeError> {
         let mut globals_map = IndexMap::new();
         for (span, name, params, typ) in globals {
@@ -29,8 +29,8 @@ impl TypeDefs {
                 globals_map.insert(name.clone(), (span.clone(), params.clone(), typ.clone()))
             {
                 return Err(TypeError::TypeNameAlreadyDefined(
-                    span.span(),
-                    span1.span(),
+                    span.clone(),
+                    span1.clone(),
                     name.clone(),
                 ));
             }
@@ -76,12 +76,12 @@ impl TypeDefs {
         span: &Span,
         name: &GlobalName,
         args: &[Type],
-    ) -> Result<(&FileSpan, Type), TypeError> {
+    ) -> Result<(&Span, Type), TypeError> {
         match self.globals.get(name) {
             Some((span, params, typ)) => {
                 if params.len() != args.len() {
                     return Err(TypeError::WrongNumberOfTypeArgs(
-                        span.span(),
+                        span.clone(),
                         name.clone(),
                         params.len(),
                         args.len(),
@@ -109,12 +109,12 @@ impl TypeDefs {
         span: &Span,
         name: &GlobalName,
         args: &[Type],
-    ) -> Result<(&FileSpan, Type), TypeError> {
+    ) -> Result<(&Span, Type), TypeError> {
         match self.globals.get(name) {
             Some((span, params, typ)) => {
                 if params.len() != args.len() {
                     return Err(TypeError::WrongNumberOfTypeArgs(
-                        span.span(),
+                        span.clone(),
                         name.clone(),
                         params.len(),
                         args.len(),
@@ -139,7 +139,7 @@ impl TypeDefs {
         let mut deps_stack = deps_stack.clone();
         if !deps_stack.insert(name.clone()) {
             return Err(TypeError::DependencyCycle(
-                self.globals[name].0.span(),
+                self.globals[name].0.clone(),
                 deps_stack
                     .clone()
                     .into_iter()

--- a/src/par/types/display.rs
+++ b/src/par/types/display.rs
@@ -1,4 +1,4 @@
-use crate::location::{FileName, Span};
+use crate::location::Span;
 use crate::par::process::NameWithType;
 use crate::par::types::{PrimitiveType, Type, TypeDefs};
 use std::fmt;
@@ -360,19 +360,18 @@ impl Type {
             Self::Primitive(_, _) | Self::DualPrimitive(_, _) => {}
             Self::Var(_, _) | Self::DualVar(_, _) => {}
             Self::Name(span, name, args) | Self::DualName(span, name, args) => {
-                let (def_span, def_file, typ) = match self {
+                let (def_span, typ) = match self {
                     Self::Name(..) => type_defs.get_with_span(span, name, args),
                     _ => type_defs.get_dual_with_span(span, name, args),
                 }
-                .unwrap_or_else(|_| (Span::None, &FileName::Builtin, self.clone()));
+                .unwrap_or_else(|_| (&Span::None, self.clone()));
                 consume(
-                    *span,
+                    span.clone(),
                     NameWithType {
                         name: None,
                         typ,
-                        def_span,
-                        decl_span: def_span,
-                        def_file: def_file.clone(),
+                        def_span: def_span.clone(),
+                        decl_span: def_span.clone(),
                     },
                 );
                 for arg in args {

--- a/src/par/types/visit.rs
+++ b/src/par/types/visit.rs
@@ -179,7 +179,7 @@ fn get_args_polarity(
     name: &GlobalName,
     defs: &TypeDefs,
 ) -> Result<Vec<Polarity>, TypeError> {
-    let Some((_span, _, vars, body)) = defs.globals.get(name) else {
+    let Some((_span, vars, body)) = defs.globals.get(name) else {
         return Err(TypeError::GlobalNameNotDefined(span.clone(), name.clone()));
     };
 

--- a/src/playground.rs
+++ b/src/playground.rs
@@ -442,7 +442,7 @@ impl Playground {
         }
     }
 
-    const FILE_NAME: FileName = FileName::Path(arcstr::literal!("Playground.par"));
+    const FILE_NAME: FileName = FileName(arcstr::literal!("Playground.par"));
 
     fn recompile(&mut self) {
         stacker::grow(32 * 1024 * 1024, || {

--- a/src/readback.rs
+++ b/src/readback.rs
@@ -253,7 +253,7 @@ impl Element {
                             }
 
                             Request::Byte(mut input, callback) => {
-                                let input_byte = parse_bytes(&input)
+                                let input_byte = parse_bytes(&input, &"input".into())
                                     .filter(|b| b.len() == 1)
                                     .and_then(|b| b.get(0).copied());
                                 let entered = ui
@@ -279,7 +279,7 @@ impl Element {
                             }
 
                             Request::Bytes(mut input, callback) => {
-                                let input_bytes = parse_bytes(&input);
+                                let input_bytes = parse_bytes(&input, &"input".into());
                                 let entered = ui
                                     .horizontal(|ui| {
                                         ui.add(

--- a/src/test_runner.rs
+++ b/src/test_runner.rs
@@ -1,14 +1,11 @@
+use crate::icombs::{
+    readback::{TypedHandle, TypedReadback},
+    IcCompiled,
+};
 use crate::par::parse;
 use crate::playground::Compiled;
 use crate::spawn::TokioSpawn;
 use crate::test_assertion::{create_assertion_channel, AssertionResult};
-use crate::{
-    icombs::{
-        readback::{TypedHandle, TypedReadback},
-        IcCompiled,
-    },
-    location::FileName,
-};
 use colored::Colorize;
 use futures::task::SpawnExt;
 use std::path::{Path, PathBuf};
@@ -125,10 +122,7 @@ fn run_test_file(file: &Path, filter: &Option<String>) -> Vec<TestResult> {
     let code_with_imports = code.clone();
 
     let compiled = match stacker::grow(32 * 1024 * 1024, || {
-        Compiled::from_string(
-            &code_with_imports,
-            FileName::Path(file.to_string_lossy().into()),
-        )
+        Compiled::from_string(&code_with_imports, file.into())
     }) {
         Ok(compiled) => compiled,
         Err(err) => {


### PR DESCRIPTION
- Use u32 instead of usize for the fields of Point - for this to cause an issue would need a file larger than 4 billion characters, so this is basically a free size optimization on 64-bit platforms.
- Merge `span: Span, file: FileName` fields into a single `span: FileSpan` field. At some point later I think I'd like to go through and change all/most `span: Span` to `FileSpan`.