### PR TITLE
fix windows using invalid type

### DIFF
--- a/src/par/builtin/os.rs
+++ b/src/par/builtin/os.rs
@@ -263,7 +263,7 @@ fn os_to_bytes(os: &OsStr) -> Bytes {
 }
 
 #[cfg(windows)]
-fn os_to_bytes(os: &OsStr) -> ByteView {
+fn os_to_bytes(os: &OsStr) -> Bytes {
     use std::os::windows::ffi::OsStrExt;
     let wide: Vec<u16> = os.encode_wide().collect();
     let mut bytes = Vec::with_capacity(wide.len() * 2);
@@ -271,12 +271,12 @@ fn os_to_bytes(os: &OsStr) -> ByteView {
         bytes.push((w & 0xFF) as u8);
         bytes.push((w >> 8) as u8);
     }
-    ByteView::from(bytes)
+    Bytes::from(bytes)
 }
 
 #[cfg(not(any(unix, windows)))]
-fn os_to_bytes(os: &OsStr) -> ByteView {
-    ByteView::from(os.to_string_lossy().as_ref())
+fn os_to_bytes(os: &OsStr) -> Bytes {
+    Bytes::from(os.to_string_lossy().as_ref())
 }
 
 async fn provide_bytes_reader_from_async(mut handle: Handle, mut reader: impl AsyncRead + Unpin) {


### PR DESCRIPTION
Didn't look too deeply at this. I'm guessing that `ByteView` was valid at some point in the past but no longer exists. This seems to fix compilation failing because `Bytes` doesn't exist.