### PR TITLE
feat: special cases for either/choice subtyping

### DIFF
--- a/src/par/types/assignability.rs
+++ b/src/par/types/assignability.rs
@@ -509,6 +509,7 @@ impl Type {
                     cyclic_points,
                 )?
             }
+            (Self::Either(_, branches1), _) if branches1.is_empty() => true,
             (Self::Either(_, branches1), Self::Either(_, branches2)) => {
                 for (branch, t1) in branches1 {
                     let Some(t2) = branches2.get(branch) else {
@@ -529,6 +530,7 @@ impl Type {
                 }
                 true
             }
+            (_, Self::Choice(_, branches2)) if branches2.is_empty() => true,
             (Self::Choice(_, branches1), Self::Choice(_, branches2)) => {
                 for (branch, t2) in branches2 {
                     let Some(t1) = branches1.get(branch) else {

--- a/src/par/types/tests.rs
+++ b/src/par/types/tests.rs
@@ -1,6 +1,6 @@
 #[cfg(test)]
 mod tests {
-    use crate::par::types::Type;
+    use crate::par::types::{Type, TypeDefs};
 
     #[test]
     fn test_iterative_box_choice() {
@@ -82,5 +82,23 @@ mod tests {
             }
             _ => panic!("Expected Iterative types"),
         }
+    }
+
+    #[test]
+    fn test_empty_either_subtype_of_any() {
+        let type_defs = TypeDefs::default();
+        let empty_either = Type::either(vec![]);
+        let any_type = Type::string();
+        
+        assert!(empty_either.is_assignable_to(&any_type, &type_defs).unwrap());
+    }
+
+    #[test]
+    fn test_any_subtype_of_empty_choice() {
+        let type_defs = TypeDefs::default();
+        let any_type = Type::int();
+        let empty_choice = Type::choice(vec![]);
+        
+        assert!(any_type.is_assignable_to(&empty_choice, &type_defs).unwrap());
     }
 }


### PR DESCRIPTION
Added short guards to ensure that `either {} <: other` and `self <: choice {}` for all other, self. added a test case for each.