### PR TITLE
Fix byte literal parsing

### DIFF
--- a/docs/src/structure/primitive_types.md
+++ b/docs/src/structure/primitive_types.md
@@ -219,8 +219,7 @@ that multiple decimal values are allowed, and are delimited by spaces:
 
 ```par
 def Bytes1 = <<65 91>>  // inferred as `Bytes`
-def Bytes2 = << >>      // zero-byte sequence
-// def Bytes3 = <<>>    // This triggers syntax error for now, but we intend to fix it
+def Bytes2 = <<>>       // zero-byte sequence
 ```
 
 A `Bytes` can also be broken down to a list of `Byte`s:

--- a/src/par/parse.rs
+++ b/src/par/parse.rs
@@ -850,6 +850,18 @@ fn expr_literal_string(input: &mut Input) -> Result<Expression> {
 }
 
 fn expr_literal_bytes(input: &mut Input) -> Result<Expression> {
+    alt((expr_literal_bytes_empty, expr_literal_bytes_nonempty)).parse_next(input)
+}
+
+fn expr_literal_bytes_empty(input: &mut Input) -> Result<Expression> {
+    commit_after((t(TokenKind::Lt), t(TokenKind::Link)), t(TokenKind::Gt))
+        .map(|((pre, _), post)| {
+            Expression::Primitive(pre.span.join(post.span()), Primitive::Bytes(Bytes::new()))
+        })
+        .parse_next(input)
+}
+
+fn expr_literal_bytes_nonempty(input: &mut Input) -> Result<Expression> {
     commit_after(
         (t(TokenKind::Lt), t(TokenKind::Lt)),
         (literal_bytes_inner, t(TokenKind::Gt), t(TokenKind::Gt)),


### PR DESCRIPTION
Fixes a parser bug that rejects the empty byte literal `<<>>` (turns out that this sequence was tokenized into `Lt`-`Link`-`Gt` instead of `Lt`-`Lt`-`Gt`-`Gt`).