### PR TITLE
Made links in Commands relative but correct

### DIFF
--- a/docs/src/processes/commands/looping_and_branching.md
+++ b/docs/src/processes/commands/looping_and_branching.md
@@ -1,7 +1,7 @@
 # Looping & Branching
 
-We’ve now seen how commands work with [choice types](/types/choice.md) (via selection),
-and [function types](/types/function.md) (via sending). But those aren’t the only types that
+We’ve now seen how commands work with [choice types](../../types/choice.md) (via selection),
+and [function types](../../types/function.md) (via sending). But those aren’t the only types that
 come with their own command styles. Every type does.
 
 Let’s turn our attention to something more intricate: **recursive types.**
@@ -15,8 +15,8 @@ type List<a> = recursive either {
 }
 ```
 
-The `List` type is [recursive](/types/recursive.md), and contains an
-[`either`](/types/either.md), and within that, a [pair](/types/pair.md).
+The `List` type is [recursive](../../types/recursive.md), and contains an
+[`either`](../../types/either.md), and within that, a [pair](../../types/pair.md).
 
 To work with such a structure in process syntax, we’ll need to combine three kinds of commands:
 
@@ -69,7 +69,7 @@ not return something.
 
 There's another key difference: notice the `.item` branch has `=>` right after the branch name!
 There's no pattern. That's because in process syntax, binding the payload of an
-[either](/types/either.md) is optional. Normally, **the subject itself becomes the payload.**
+[either](../../types/either.md) is optional. Normally, **the subject itself becomes the payload.**
 However, it is possible to match the payload fully, if desired.
 
 So, inside the `.item` branch, `strings` now has the type `(String) List<String>` — it’s a pair, and
@@ -77,7 +77,7 @@ we want to peel off its first part, to add it to the string builder.
 
 There's **one last important detail,** and that's concerning **control flow.** If a `.case`
 branch process does not end (we'll learn about ending processes in the section about
-[`chan` expressions](/processes/chan_expression.md)), then it proceeds to the next line after the closing
+[`chan` expressions](../chan_expression.md)), then it proceeds to the next line after the closing
 parenthesis of the `.case` command. All local variables are kept.
 
 ## Receiving
@@ -117,7 +117,7 @@ tagging along the control flow of `strings`.
 ## Patterns in `.case` branches
 
 The `.item =>` branch can be made a little more pleasant. If the subject after .begin is a
-[pair](/types/pair.md), we’re allowed to use pattern matching directly in the `.case` branch.
+[pair](../../types/pair.md), we’re allowed to use pattern matching directly in the `.case` branch.
 
 That means this:
 
@@ -157,10 +157,10 @@ def TestConcat = Concat(*("A", "B", "C"))  // = "ABC"
 ```
 
 This beautifully ties together all the commands we've covered so far:
-- **Selection** for [choices](/types/choice.md).
-- **Sending** for [functions](/types/function.md).
-- **Branching** for [eithers](/types/either.md).
-- **Receiving** for [pairs](/types/pair.md). Here, in the form of a pattern.
+- **Selection** for [choices](../../types/choice.md).
+- **Sending** for [functions](../../types/function.md).
+- **Branching** for [eithers](../../types/either.md).
+- **Receiving** for [pairs](../../types/pair.md). Here, in the form of a pattern.
 
 The _receive commands_ is the least clearly useful here. Let's move to infinite sequences to see a
 more compelling use-case.

--- a/docs/src/processes/commands/receiving_where_it_shines.md
+++ b/docs/src/processes/commands/receiving_where_it_shines.md
@@ -33,7 +33,7 @@ def Fibonacci =
 
 The internal state of the sequence is a pair `(a) b`. On each `.next`, we emit `a` and update
 the pair. This is a clean and elegant use of corecursive iteration, as we've covered it in the
-section on [iterative types](/types/iterative.md).
+section on [iterative types](../../types/iterative.md).
 
 So far so good — but how do we use this value?
 
@@ -50,7 +50,7 @@ That means:
 
 We’ll need a way to loop **exactly 30 times.** But there’s a catch: In Par,
 **looping is only possible on recursive types.** There’s no built-in recursion on `Nat`, so we need
-to convert the number 30 into a [recursive](/types/recursive.md).
+to convert the number 30 into a [recursive](../../types/recursive.md).
 
 Good news: there’s a built-in helper for that! It's called `Nat.Repeat`, here's its type:
 

--- a/docs/src/processes/commands/selecting_and_sending.md
+++ b/docs/src/processes/commands/selecting_and_sending.md
@@ -10,7 +10,7 @@ type String.Builder = iterative choice {
 ```
 
 It's basically an object, in an OOP-fashion, with two methods: `.add` and `.build`. At the top
-level, it's an [iterative](/types/iterative.md) [choice](/types/choice.md): an object that
+level, it's an [iterative](../../types/iterative.md) [choice](../../types/choice.md): an object that
 can be repeatedly interacted with.
 
 We construct an empty `String.Builder` using the built-in definition of the same name:
@@ -25,12 +25,12 @@ def LetsBuildStrings = do {
 
 Now, we have a local variable `builder` of the type `String.Builder`.
 
-When learning about [iterative](/types/iterative.md) types, we learned that we can treat them
+When learning about [iterative](../../types/iterative.md) types, we learned that we can treat them
 as their underlying body. For `String.Builder`, it's a **choice type,** and the command for those is
 the **selection command.**
 
 All commands start with their subject. Here it's the `builder` variable. The selection command
-itself then looks the same as the usual [destruction of a choice](/types/choice.md#destruction).
+itself then looks the same as the usual [destruction of a choice](../../types/choice.md#destruction).
 
 ```par
 def LetsBuildStrings = do {
@@ -46,7 +46,7 @@ of the selected branch. Here's the one we selected:
   .add(String) => self,
 ```
 
-The argument on the left side of `=>` is just a syntax sugar for a [function](/types/function.md).
+The argument on the left side of `=>` is just a syntax sugar for a [function](../../types/function.md).
 De-sugared, it is:
 
 ```par


### PR DESCRIPTION
Fixed the previous pushed broken links in gh-pages.

Now links are still relative but correct. So they should work for Github pages :D