### PR TITLE
builtin: make `Debug.Log` write to stderr instead of stdout

### DIFF
--- a/src/par/builtin/debug.rs
+++ b/src/par/builtin/debug.rs
@@ -23,6 +23,6 @@ pub fn external_module() -> Module<Arc<process::Expression<()>>> {
 
 async fn debug_log(mut handle: Handle) {
     let string = handle.receive().string().await;
-    println!("{}", string.as_str());
+    eprintln!("{}", string.as_str());
     handle.break_();
 }


### PR DESCRIPTION
Usually stderr is used for logs and debug messages instead of stdout. The [`dbg!()`](https://doc.rust-lang.org/stable/std/macro.dbg.html) macro in Rust also writes to stderr.