### PR TITLE
remove type assertions in compiler

### DIFF
--- a/src/language_server/instance.rs
+++ b/src/language_server/instance.rs
@@ -147,7 +147,7 @@ impl Instance {
             }
         }
 
-        for (name, definition) in &checked.definitions {
+        for (name, (definition, typ)) in &checked.definitions {
             if let (Some((name_start, name_end)), Some((start, end))) =
                 (name.span.points(), definition.span.points())
             {

--- a/src/par/process.rs
+++ b/src/par/process.rs
@@ -676,7 +676,7 @@ impl Expression<Type> {
         match self {
             Self::Global(_, name, typ) => {
                 let def_span = (program.definitions.get(name))
-                    .map(|def| def.name.span())
+                    .map(|(def, _typ)| def.name.span())
                     .unwrap_or_default();
                 let decl_span = (program.declarations.get(name))
                     .map(|decl| decl.name.span())

--- a/src/par/program.rs
+++ b/src/par/program.rs
@@ -27,7 +27,7 @@ pub struct Module<Expr> {
 pub struct CheckedModule {
     pub type_defs: TypeDefs,
     pub declarations: IndexMap<GlobalName, Declaration>,
-    pub definitions: IndexMap<GlobalName, Definition<Arc<process::Expression<Type>>>>,
+    pub definitions: IndexMap<GlobalName, (Definition<Arc<process::Expression<Type>>>, Type)>,
 }
 
 #[derive(Clone, Debug)]
@@ -229,14 +229,17 @@ impl Module<Arc<process::Expression<()>>> {
             definitions: context
                 .get_checked_definitions()
                 .into_iter()
-                .map(|(name, (span, expression))| {
+                .map(|(name, (span, expression, typ))| {
                     (
                         name.clone(),
-                        Definition {
-                            span,
-                            name,
-                            expression,
-                        },
+                        (
+                            Definition {
+                                span,
+                                name,
+                                expression,
+                            },
+                            typ,
+                        ),
                     )
                 })
                 .collect(),
@@ -286,7 +289,7 @@ impl TypeOnHover {
             };
             let file_hovers = files.entry(file).or_default();
             let def_span = (program.definitions.get(name))
-                .map(|def| def.name.span())
+                .map(|(def, _typ)| def.name.span())
                 .unwrap_or_default();
             file_hovers.push(
                 name.span(),
@@ -304,7 +307,7 @@ impl TypeOnHover {
                 });
         }
 
-        for (name, definition) in &program.definitions {
+        for (name, (definition, _typ)) in &program.definitions {
             let Some(file) = definition.span.file() else {
                 continue;
             };

--- a/src/par/types/context.rs
+++ b/src/par/types/context.rs
@@ -88,12 +88,23 @@ impl Context {
         Ok(checked_type)
     }
 
-    pub fn get_checked_definitions(&self) -> IndexMap<GlobalName, (Span, Arc<Expression<Type>>)> {
+    pub fn get_checked_definitions(
+        &self,
+    ) -> IndexMap<GlobalName, (Span, Arc<Expression<Type>>, Type)> {
         self.checked_definitions
             .read()
             .unwrap()
             .iter()
-            .map(|(name, checked)| (name.clone(), (checked.span.clone(), checked.def.clone())))
+            .map(|(name, checked)| {
+                (
+                    name.clone(),
+                    (
+                        checked.span.clone(),
+                        checked.def.clone(),
+                        checked.typ.clone(),
+                    ),
+                )
+            })
             .collect()
     }
 


### PR DESCRIPTION
Currently the icombs compiler verifies types are correct during compilation.
Making changes to the type system harder.
This mostly disables that.