### PR TITLE
update rust edition to 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["crates/par-core", "crates/par-builtin"]
 [package]
 name = "par-lang"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 repository = "https://github.com/faiface/par-lang"
 
 [features]

--- a/crates/par-builtin/Cargo.toml
+++ b/crates/par-builtin/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "par-builtin"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [dependencies]
 par-core = { path = "../par-core" }

--- a/crates/par-builtin/src/builtin.rs
+++ b/crates/par-builtin/src/builtin.rs
@@ -18,7 +18,7 @@ mod url;
 
 use std::sync::Arc;
 
-use par_core::frontend::{process, Module};
+use par_core::frontend::{Module, process};
 use par_core::source::FileName;
 use par_core::testing::import_test_module;
 

--- a/crates/par-builtin/src/builtin/bench.rs
+++ b/crates/par-builtin/src/builtin/bench.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use futures::FutureExt;
 
-use par_core::frontend::{process, Definition, Module, Type};
+use par_core::frontend::{Definition, Module, Type, process};
 
 pub(super) fn external_module() -> Module<Arc<process::Expression<()>>> {
     Module {

--- a/crates/par-builtin/src/builtin/boxmap.rs
+++ b/crates/par-builtin/src/builtin/boxmap.rs
@@ -7,7 +7,7 @@ use arcstr::literal;
 use im::OrdMap;
 use num_bigint::BigInt;
 use par_core::{
-    frontend::{process, Definition, Module, Type},
+    frontend::{Definition, Module, Type, process},
     runtime::Handle,
 };
 

--- a/crates/par-builtin/src/builtin/byte.rs
+++ b/crates/par-builtin/src/builtin/byte.rs
@@ -4,7 +4,7 @@ use arcstr::literal;
 use num_bigint::BigInt;
 
 use par_core::{
-    frontend::{process, Definition, Module, Type, TypeDef},
+    frontend::{Definition, Module, Type, TypeDef, process},
     runtime::Handle,
 };
 

--- a/crates/par-builtin/src/builtin/char_.rs
+++ b/crates/par-builtin/src/builtin/char_.rs
@@ -4,7 +4,7 @@ use arcstr::literal;
 use num_bigint::BigInt;
 
 use par_core::{
-    frontend::{process, Definition, Module, Type, TypeDef},
+    frontend::{Definition, Module, Type, TypeDef, process},
     runtime::Handle,
 };
 

--- a/crates/par-builtin/src/builtin/console.rs
+++ b/crates/par-builtin/src/builtin/console.rs
@@ -1,12 +1,12 @@
 use std::{
-    io::{stdin, stdout, Write},
+    io::{Write, stdin, stdout},
     sync::Arc,
 };
 
 use arcstr::literal;
 
 use par_core::{
-    frontend::{process, Definition, Module, ParString, Type},
+    frontend::{Definition, Module, ParString, Type, process},
     runtime::Handle,
 };
 

--- a/crates/par-builtin/src/builtin/debug.rs
+++ b/crates/par-builtin/src/builtin/debug.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use par_core::{
-    frontend::{process, Definition, Module, Type},
+    frontend::{Definition, Module, Type, process},
     runtime::Handle,
 };
 

--- a/crates/par-builtin/src/builtin/http.rs
+++ b/crates/par-builtin/src/builtin/http.rs
@@ -3,8 +3,8 @@ use std::{
     net::SocketAddr,
     str::FromStr,
     sync::{
-        atomic::{AtomicBool, Ordering as AtomicOrdering},
         Arc,
+        atomic::{AtomicBool, Ordering as AtomicOrdering},
     },
     time::Duration,
 };
@@ -12,16 +12,16 @@ use std::{
 use arcstr::literal;
 use bytes::Bytes;
 use futures::{
-    channel::{mpsc, oneshot},
     SinkExt, StreamExt,
+    channel::{mpsc, oneshot},
 };
 use http_body::Frame;
 use http_body_util::{self as body_util, BodyExt, Full, StreamBody};
 use hyper::{
-    body::Incoming,
-    http::{header::HOST, HeaderName, HeaderValue, StatusCode},
-    service::service_fn,
     Request, Response,
+    body::Incoming,
+    http::{HeaderName, HeaderValue, StatusCode, header::HOST},
+    service::service_fn,
 };
 use hyper_util::rt::TokioIo;
 use num_bigint::BigInt;
@@ -30,7 +30,7 @@ use url::Url as ParsedUrl;
 
 use crate::builtin::{list::readback_list, url::provide_url_value};
 use par_core::{
-    frontend::{process, Definition, Module, ParString, Type},
+    frontend::{Definition, Module, ParString, Type, process},
     runtime::Handle,
 };
 

--- a/crates/par-builtin/src/builtin/int.rs
+++ b/crates/par-builtin/src/builtin/int.rs
@@ -1,7 +1,7 @@
 use arcstr::literal;
 use num_bigint::BigInt;
 use par_core::{
-    frontend::{process, Definition, Module, ParString, Type, TypeDef},
+    frontend::{Definition, Module, ParString, Type, TypeDef, process},
     runtime::Handle,
 };
 use std::{cmp::Ordering, sync::Arc};

--- a/crates/par-builtin/src/builtin/map.rs
+++ b/crates/par-builtin/src/builtin/map.rs
@@ -4,7 +4,7 @@ use crate::builtin::list::readback_list;
 use arcstr::literal;
 use num_bigint::BigInt;
 use par_core::{
-    frontend::{process, Definition, Module, Type},
+    frontend::{Definition, Module, Type, process},
     runtime::Handle,
 };
 use std::sync::Arc;

--- a/crates/par-builtin/src/builtin/nat.rs
+++ b/crates/par-builtin/src/builtin/nat.rs
@@ -3,7 +3,7 @@ use num_bigint::BigInt;
 use std::{cmp::Ordering, sync::Arc};
 
 use par_core::{
-    frontend::{process, Definition, Module, ParString, Type, TypeDef},
+    frontend::{Definition, Module, ParString, Type, TypeDef, process},
     runtime::Handle,
 };
 

--- a/crates/par-builtin/src/builtin/os.rs
+++ b/crates/par-builtin/src/builtin/os.rs
@@ -8,7 +8,7 @@ use bytes::Bytes;
 use futures::future::BoxFuture;
 use num_bigint::BigInt;
 use par_core::{
-    frontend::{process, Definition, Module, ParString, Type},
+    frontend::{Definition, Module, ParString, Type, process},
     runtime::Handle,
 };
 use tokio::{

--- a/crates/par-builtin/src/builtin/string.rs
+++ b/crates/par-builtin/src/builtin/string.rs
@@ -6,10 +6,10 @@ use num_bigint::BigInt;
 use crate::builtin::{
     char_::CharClass,
     list::readback_list,
-    parser::{provide_string_parser, ReaderRemainder},
+    parser::{ReaderRemainder, provide_string_parser},
 };
 use par_core::{
-    frontend::{process, Definition, Module, ParString, Type, TypeDef},
+    frontend::{Definition, Module, ParString, Type, TypeDef, process},
     runtime::Handle,
 };
 

--- a/crates/par-builtin/src/builtin/time.rs
+++ b/crates/par-builtin/src/builtin/time.rs
@@ -1,6 +1,6 @@
 use num_bigint::BigInt;
 use par_core::{
-    frontend::{process, Definition, Module, Type},
+    frontend::{Definition, Module, Type, process},
     runtime::Handle,
 };
 use std::sync::Arc;

--- a/crates/par-builtin/src/builtin/url.rs
+++ b/crates/par-builtin/src/builtin/url.rs
@@ -5,7 +5,7 @@ use percent_encoding::percent_decode_str;
 use url::Url as ParsedUrl;
 
 use par_core::{
-    frontend::{process, Definition, Module, ParString, Type},
+    frontend::{Definition, Module, ParString, Type, process},
     runtime::Handle,
 };
 

--- a/crates/par-core/Cargo.toml
+++ b/crates/par-core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "par-core"
 version = "0.1.0"
-edition = "2021"
+edition = "2024"
 
 [features]
 # Kept for compatibility with existing cfgs in the codebase.

--- a/crates/par-core/src/api.rs
+++ b/crates/par-core/src/api.rs
@@ -86,5 +86,5 @@ pub mod execution {
 }
 
 pub mod testing {
-    pub use crate::test_assertion::{import_test_module, provide_test, AssertionResult};
+    pub use crate::test_assertion::{AssertionResult, import_test_module, provide_test};
 }

--- a/crates/par-core/src/par/captures.rs
+++ b/crates/par-core/src/par/captures.rs
@@ -374,8 +374,8 @@ impl CaptureAnalysis {
                     caps,
                 )
             }
-            Command::Loop(label, _, _) => {
-                if let Some(begin_id) = env.resolve(label) {
+            Command::Loop(label, _, _) => match env.resolve(label) {
+                Some(begin_id) => {
                     let driver = self
                         .begin_drivers
                         .get(&begin_id)
@@ -386,13 +386,12 @@ impl CaptureAnalysis {
                         Command::Loop(label.clone(), driver, loop_caps.clone()),
                         loop_caps,
                     )
-                } else {
-                    (
-                        Command::Loop(label.clone(), LocalName::invalid(), Captures::new()),
-                        Captures::new(),
-                    )
                 }
-            }
+                _ => (
+                    Command::Loop(label.clone(), LocalName::invalid(), Captures::new()),
+                    Captures::new(),
+                ),
+            },
             Command::SendType(argument, process) => {
                 let (process, caps) = self.fix_process(process, env);
                 (Command::SendType(argument.clone(), process), caps)

--- a/crates/par-core/src/par/language.rs
+++ b/crates/par-core/src/par/language.rs
@@ -7,7 +7,7 @@ use std::{
     sync::Arc,
 };
 
-use arcstr::{literal, ArcStr};
+use arcstr::{ArcStr, literal};
 
 use super::{
     primitive::Primitive,
@@ -521,13 +521,12 @@ impl CompileError {
             Self::MatchingCatchDisabled(span, CatchDisabledReason::DifferentProcess) => {
                 mk_report(span, "Matching `catch` is in a different process.")
             }
-            Self::MatchingCatchDisabled(
-                span,
-                CatchDisabledReason::ValuePartiallyConstructed,
-            ) => mk_report(
-                span,
-                "The expression the matching `catch` would return from has its result already partially constructed.",
-            ),
+            Self::MatchingCatchDisabled(span, CatchDisabledReason::ValuePartiallyConstructed) => {
+                mk_report(
+                    span,
+                    "The expression the matching `catch` would return from has its result already partially constructed.",
+                )
+            }
             Self::NoSuchPollPoint(span, None) => {
                 mk_report(span, "No unlabeled `poll`/`repoll` point is in scope here.")
             }

--- a/crates/par-core/src/par/lexer.rs
+++ b/crates/par-core/src/par/lexer.rs
@@ -1,11 +1,11 @@
 use crate::location::{FileName, Point, Span};
 use core::str::FromStr;
 use winnow::{
+    Parser, Result,
     combinator::{alt, not, opt, peek, preceded, repeat},
     error::{EmptyError, ParserError},
     stream::{ParseSlice, TokenSlice},
     token::{any, literal, take, take_while},
-    Parser, Result,
 };
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]

--- a/crates/par-core/src/par/parse.rs
+++ b/crates/par-core/src/par/parse.rs
@@ -3,7 +3,7 @@ use super::{
         Apply, ApplyBranch, ApplyBranches, Command, CommandBranch, CommandBranches, Condition,
         Construct, ConstructBranch, ConstructBranches, Expression, GlobalName, Pattern, Process,
     },
-    lexer::{lex, Input, Token, TokenKind},
+    lexer::{Input, Token, TokenKind, lex},
     primitive::Primitive,
 };
 use crate::par::{
@@ -23,12 +23,12 @@ use num_bigint::BigInt;
 use std::collections::BTreeMap;
 use winnow::token::literal;
 use winnow::{
+    Parser,
     combinator::{alt, cut_err, not, opt, peek, preceded, repeat, separated, terminated, trace},
     error::{
         AddContext, ContextError, ErrMode, ModalError, ParserError, StrContext, StrContextValue,
     },
     stream::{Accumulate, Stream},
-    Parser,
 };
 
 #[derive(Debug, Clone, Default, PartialEq)]
@@ -103,7 +103,7 @@ where
 
 /// Like `t` for but for `n` tokens.
 macro_rules! tn {
-    ($s:literal: $($t:expr),+) => {
+    ($s:literal: $($t:expr_2021),+) => {
         ($($t),+).context(StrContext::Expected(StrContextValue::Description($s)))
     };
 }

--- a/crates/par-core/src/par/types/checking.rs
+++ b/crates/par-core/src/par/types/checking.rs
@@ -1609,7 +1609,7 @@ impl Context {
                 return Err(TypeError::TypeMustBeKnownAtThisPoint(
                     span.clone(),
                     subject.clone(),
-                ))
+                ));
             }
 
             Command::ReceiveType(parameter, process) => {
@@ -1937,7 +1937,7 @@ fn merge_path_contexts(
                         name.clone(),
                         acc.clone(),
                         next.clone(),
-                    ))
+                    ));
                 }
             };
         }

--- a/crates/par-core/src/par/types/core.rs
+++ b/crates/par-core/src/par/types/core.rs
@@ -1,7 +1,7 @@
 use super::super::language::{GlobalName, LocalName};
 use crate::location::{Span, Spanning};
 use crate::par::types::visit::Polarity;
-use crate::par::types::{visit, TypeDefs, TypeError};
+use crate::par::types::{TypeDefs, TypeError, visit};
 use arcstr::ArcStr;
 use im::HashSet;
 use std::collections::BTreeMap;

--- a/crates/par-core/src/par/types/definitions.rs
+++ b/crates/par-core/src/par/types/definitions.rs
@@ -1,6 +1,6 @@
 use crate::location::Span;
 use crate::par::language::{GlobalName, LocalName};
-use crate::par::types::{visit, Type, TypeError};
+use crate::par::types::{Type, TypeError, visit};
 use indexmap::{IndexMap, IndexSet};
 use std::sync::Arc;
 

--- a/crates/par-core/src/par/types/implicit.rs
+++ b/crates/par-core/src/par/types/implicit.rs
@@ -68,14 +68,17 @@ pub(crate) fn infer_holes(
 
     for name in names {
         let hole = holes_map.get(&name).unwrap();
-        if let Some(solved_type) = solve_constraints(hole, type_defs, span)? {
-            res.insert(name.clone(), solved_type);
-        } else {
-            return Err(TypeError::CannotAssignFromTo(
-                span.clone(),
-                typ.clone(),
-                pattern.clone(),
-            ));
+        match solve_constraints(hole, type_defs, span)? {
+            Some(solved_type) => {
+                res.insert(name.clone(), solved_type);
+            }
+            _ => {
+                return Err(TypeError::CannotAssignFromTo(
+                    span.clone(),
+                    typ.clone(),
+                    pattern.clone(),
+                ));
+            }
         }
     }
     Ok(res)

--- a/crates/par-core/src/par/types/tests.rs
+++ b/crates/par-core/src/par/types/tests.rs
@@ -90,9 +90,11 @@ mod tests {
         let empty_either = Type::either(vec![]);
         let any_type = Type::string();
 
-        assert!(empty_either
-            .is_assignable_to(&any_type, &type_defs)
-            .unwrap());
+        assert!(
+            empty_either
+                .is_assignable_to(&any_type, &type_defs)
+                .unwrap()
+        );
     }
 
     #[test]
@@ -101,8 +103,10 @@ mod tests {
         let any_type = Type::int();
         let empty_choice = Type::choice(vec![]);
 
-        assert!(any_type
-            .is_assignable_to(&empty_choice, &type_defs)
-            .unwrap());
+        assert!(
+            any_type
+                .is_assignable_to(&empty_choice, &type_defs)
+                .unwrap()
+        );
     }
 }

--- a/crates/par-core/src/par/types/validation.rs
+++ b/crates/par-core/src/par/types/validation.rs
@@ -1,7 +1,7 @@
+use super::TypeDefs;
 use super::core::Type;
 use super::error::TypeError;
 use super::visit;
-use super::TypeDefs;
 
 impl Type {
     pub fn is_linear(&self, type_defs: &TypeDefs) -> Result<bool, TypeError> {

--- a/crates/par-core/src/runtime/flat/arena.rs
+++ b/crates/par-core/src/runtime/flat/arena.rs
@@ -116,7 +116,7 @@ macro_rules! slice_indexable {
         impl Indexable for [$element] {
             type Store = (usize, usize);
             fn get<'s>(store: &'s Arena, index: Index<Self>) -> &'s Self {
-                &store.$field[index.0 .0..index.0 .0 + index.0 .1]
+                &store.$field[index.0.0..index.0.0 + index.0.1]
             }
             fn alloc_clone<'s>(store: &'s mut Arena, data: &Self) -> Index<Self> {
                 let start = store.$field.len();
@@ -127,12 +127,12 @@ macro_rules! slice_indexable {
         impl Iterator for Index<[$element]> {
             type Item = Index<$element>;
             fn next(&mut self) -> Option<Index<$element>> {
-                if self.0 .1 == 0 {
+                if self.0.1 == 0 {
                     None
                 } else {
-                    let ret = Index(self.0 .0);
-                    self.0 .0 += 1;
-                    self.0 .1 -= 1;
+                    let ret = Index(self.0.0);
+                    self.0.0 += 1;
+                    self.0.1 -= 1;
                     Some(ret)
                 }
             }
@@ -165,7 +165,7 @@ sized_indexable!(nodes, Global);
 impl Indexable for str {
     type Store = (usize, usize);
     fn get<'s>(store: &'s Arena, index: Index<Self>) -> &'s Self {
-        &store.strings[index.0 .0..index.0 .0 + index.0 .1]
+        &store.strings[index.0.0..index.0.0 + index.0.1]
     }
     fn alloc_clone<'s>(store: &'s mut Arena, data: &Self) -> Index<Self> {
         let start = store.strings.len();

--- a/crates/par-core/src/runtime/flat/transpiler.rs
+++ b/crates/par-core/src/runtime/flat/transpiler.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use super::readback::Handle;
 use super::reducer::NetHandle;
-use crate::par::types::{visit, Type, TypeDefs, TypeError};
+use crate::par::types::{Type, TypeDefs, TypeError, visit};
 
 use std::sync::OnceLock;
 
@@ -259,7 +259,7 @@ impl ProgramTranspiler {
                     })
                     .collect();
                 self.current_net_mut().num_vars = maximum_casebranch_length;
-                table.sort_by_key(|x| x.0 .0);
+                table.sort_by_key(|x| x.0.0);
                 let tree = self.transpile_tree_and_alloc(*captures);
                 Global::Destruct(GlobalCont::Choice(
                     tree,

--- a/crates/par-core/src/runtime/tree/net.rs
+++ b/crates/par-core/src/runtime/tree/net.rs
@@ -494,11 +494,12 @@ impl Net {
             self.rewrites.last_busy_start = Some(Instant::now());
         }
 
-        let reduced = if let Some((a, b)) = self.redexes.pop_front() {
-            self.interact(a, b);
-            true
-        } else {
-            false
+        let reduced = match self.redexes.pop_front() {
+            Some((a, b)) => {
+                self.interact(a, b);
+                true
+            }
+            _ => false,
         };
 
         if !reduced {

--- a/crates/par-core/src/test_assertion.rs
+++ b/crates/par-core/src/test_assertion.rs
@@ -1,5 +1,5 @@
-use std::sync::mpsc;
 use std::sync::Arc;
+use std::sync::mpsc;
 
 use crate::location::Span;
 use crate::par::language::GlobalName;

--- a/src/language_server/instance.rs
+++ b/src/language_server/instance.rs
@@ -3,7 +3,7 @@ use crate::language_server::data::ToLspPosition;
 use lsp_types::{self as lsp, Uri};
 use par_builtin::import_builtins;
 use par_core::frontend::{
-    lower, parse, type_check, CheckedModule, ParseAndCompileError, TypeError, TypeOnHover,
+    CheckedModule, ParseAndCompileError, TypeError, TypeOnHover, lower, parse, type_check,
 };
 use par_core::source::FileName;
 use std::collections::HashMap;
@@ -45,8 +45,8 @@ impl Instance {
         let pos = params.text_document_position_params.position;
 
         let payload = match self.type_on_hover.as_ref() {
-            Some(type_on_hover) => {
-                if let Some(name_info) = type_on_hover.query(&self.file, pos.line, pos.character) {
+            Some(type_on_hover) => match type_on_hover.query(&self.file, pos.line, pos.character) {
+                Some(name_info) => {
                     let mut buf = String::new();
                     if let Some(name) = name_info.name {
                         write!(&mut buf, "{}: ", name).unwrap();
@@ -56,10 +56,11 @@ impl Instance {
                         language: "par".to_owned(),
                         value: buf,
                     })
-                } else {
+                }
+                _ => {
                     return None;
                 }
-            }
+            },
             None => lsp::MarkedString::String("Not compiled".to_string()),
         };
 

--- a/src/language_server/server.rs
+++ b/src/language_server/server.rs
@@ -1,5 +1,5 @@
 use super::io::IO;
-use crate::language_server::feedback::{diagnostic_for_error, FeedbackBookKeeper};
+use crate::language_server::feedback::{FeedbackBookKeeper, diagnostic_for_error};
 use crate::language_server::instance::Instance;
 use lsp_server::Connection;
 use lsp_types::notification::DidSaveTextDocument;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,14 @@
 #[cfg(feature = "playground")]
 use crate::playground::Playground;
-use clap::{arg, command, value_parser, Command};
+use clap::{Command, arg, command, value_parser};
 use colored::Colorize;
 #[cfg(feature = "playground")]
 use eframe::egui;
 use par_builtin::import_builtins;
 use par_core::{
     frontend::{
-        compile_runtime, lower, parse, set_miette_hook, type_check, ParseAndCompileError, Type,
-        TypeError,
+        ParseAndCompileError, Type, TypeError, compile_runtime, lower, parse, set_miette_hook,
+        type_check,
     },
     runtime::RuntimeCompilerError,
 };

--- a/src/playground.rs
+++ b/src/playground.rs
@@ -16,8 +16,8 @@ use par_builtin::import_builtins;
 use par_core::{
     execution::TokioSpawn,
     frontend::{
-        compile_runtime, language::GlobalName, lower, parse, process, type_check, CheckedModule,
-        Module, ParseAndCompileError, Type, TypeError, TypeOnHover,
+        CheckedModule, Module, ParseAndCompileError, Type, TypeError, TypeOnHover, compile_runtime,
+        language::GlobalName, lower, parse, process, type_check,
     },
     runtime::{Compiled, RuntimeCompilerError, TypedHandle},
     source::FileName,
@@ -135,7 +135,7 @@ impl BuildResult {
             Err(error) => {
                 return Self::ParseAndCompileError {
                     error: ParseAndCompileError::Parse(error),
-                }
+                };
             }
         };
         let mut lowered = match lower(parsed) {
@@ -143,7 +143,7 @@ impl BuildResult {
             Err(error) => {
                 return Self::ParseAndCompileError {
                     error: ParseAndCompileError::Compile(error),
-                }
+                };
             }
         };
         imports(&mut lowered);
@@ -189,7 +189,7 @@ impl BuildResult {
                     checked,
                     type_on_hover,
                     error,
-                }
+                };
             }
         };
         Self::Ok {

--- a/src/readback.rs
+++ b/src/readback.rs
@@ -8,7 +8,7 @@ use futures::{
 };
 use num_bigint::BigInt;
 use par_core::{
-    frontend::{parse_bytes, ParString, Primitive},
+    frontend::{ParString, Primitive, parse_bytes},
     runtime::{Rewrites, TypedHandle, TypedReadback},
 };
 use std::sync::{Arc, Mutex};

--- a/src/test_runner.rs
+++ b/src/test_runner.rs
@@ -2,15 +2,15 @@ use colored::Colorize;
 use par_builtin::import_builtins;
 use par_core::{
     frontend::{
-        compile_runtime, language::GlobalName, lower, parse, set_miette_hook, type_check,
-        CheckedModule, ParseAndCompileError, Type, TypeError,
+        CheckedModule, ParseAndCompileError, Type, TypeError, compile_runtime,
+        language::GlobalName, lower, parse, set_miette_hook, type_check,
     },
     runtime::{Compiled, RuntimeCompilerError},
-    testing::{provide_test, AssertionResult},
+    testing::{AssertionResult, provide_test},
 };
 use std::path::{Path, PathBuf};
-use std::sync::mpsc;
 use std::sync::Arc;
+use std::sync::mpsc;
 use std::time::{Duration, Instant};
 use std::{fmt::Display, fs};
 use tokio::runtime::Runtime;


### PR DESCRIPTION
Updates the rust edition to 2024.
This enables [if-let chains and such](https://rust-lang.github.io/rfcs/2497-if-let-chains.html)

All the code changes were cerated by `cargo fix --edition`, so it might be safe to skip reviewing, given that it still builds and tests pass.
The changes were not strictly necessary, but they're a nice touch so why not.
The changes to imports are `cargo fmt` who the heck know why :D


