### PR TITLE
Make external link errors non-panicking

### DIFF
--- a/crates/par-core/src/backend/compiler.rs
+++ b/crates/par-core/src/backend/compiler.rs
@@ -1,15 +1,50 @@
 use crate::frontend_impl::language::{GlobalName, Universal};
 use crate::frontend_impl::types::Type;
+use crate::location::Span;
 use std::collections::HashMap;
 
 use crate::backend::flat::transpiler::{Transpiled, link_transpiled};
-use par_runtime::linker::{Linked, Unlinked};
+use par_runtime::linker::{LinkError, Linked, Unlinked};
 use std::fmt::Display;
 
 #[derive(Clone)]
 pub struct Compiled<Ext: Clone> {
     pub code: Transpiled<Ext>,
     pub name_to_ty: HashMap<GlobalName<Universal>, Type<Universal>>,
+}
+
+#[derive(Clone, Debug)]
+pub enum RuntimeCompilerError {
+    Inet(crate::backend::tree::compiler::Error),
+    Link(LinkError),
+}
+
+impl RuntimeCompilerError {
+    pub fn display(&self, code: &str) -> String {
+        match self {
+            Self::Inet(error) => error.display(code),
+            Self::Link(error) => error.to_string(),
+        }
+    }
+
+    pub fn spans(&self) -> (Span, Vec<Span>) {
+        match self {
+            Self::Inet(error) => error.spans(),
+            Self::Link(_) => (Span::None, vec![]),
+        }
+    }
+}
+
+impl From<crate::backend::tree::compiler::Error> for RuntimeCompilerError {
+    fn from(value: crate::backend::tree::compiler::Error) -> Self {
+        Self::Inet(value)
+    }
+}
+
+impl From<LinkError> for RuntimeCompilerError {
+    fn from(value: LinkError) -> Self {
+        Self::Link(value)
+    }
 }
 
 impl<Ext: Clone> Display for Compiled<Ext> {
@@ -22,7 +57,7 @@ impl Compiled<Unlinked> {
     pub fn compile_file(
         module: &crate::frontend_impl::program::CheckedModule<Universal>,
         max_interactions: u32,
-    ) -> Result<Self, crate::runtime_impl::RuntimeCompilerError> {
+    ) -> Result<Self, RuntimeCompilerError> {
         Ok(Self {
             code: Transpiled::compile_file(module, max_interactions)?,
             name_to_ty: module
@@ -33,11 +68,11 @@ impl Compiled<Unlinked> {
         })
     }
 
-    pub fn link(self) -> Compiled<Linked> {
-        Compiled {
-            code: link_transpiled(self.code),
+    pub fn link(self) -> Result<Compiled<Linked>, RuntimeCompilerError> {
+        Ok(Compiled {
+            code: link_transpiled(self.code)?,
             name_to_ty: self.name_to_ty,
-        }
+        })
     }
 }
 

--- a/crates/par-core/src/backend/flat/transpiler.rs
+++ b/crates/par-core/src/backend/flat/transpiler.rs
@@ -18,7 +18,7 @@ use par_runtime::flat::runtime::{
 
 use crate::runtime_impl::tree::Net;
 use par_runtime::flat::runtime::Global;
-use par_runtime::linker::{Linked, Unlinked, link_arena, link_package_ptr};
+use par_runtime::linker::{LinkError, Linked, Unlinked, link_arena, link_package_ptr};
 
 #[derive(Default)]
 pub(crate) struct NetTranspiler {
@@ -103,16 +103,18 @@ impl<Ext: Clone> Transpiled<Ext> {
     }
 }
 
-pub(crate) fn link_transpiled(transpiled: Transpiled<Unlinked>) -> Transpiled<Linked> {
-    Transpiled {
+pub(crate) fn link_transpiled(
+    transpiled: Transpiled<Unlinked>,
+) -> Result<Transpiled<Linked>, LinkError> {
+    Ok(Transpiled {
         type_defs: transpiled.type_defs,
-        arena: Arc::new(link_arena(transpiled.arena.as_ref())),
+        arena: Arc::new(link_arena(transpiled.arena.as_ref())?),
         name_to_package: transpiled
             .name_to_package
             .iter()
             .map(|(k, v)| (k.clone(), link_package_ptr(v)))
             .collect(),
-    }
+    })
 }
 impl NetTranspiler {
     fn map_variable(&mut self, id: usize) -> usize {

--- a/crates/par-core/src/runtime/mod.rs
+++ b/crates/par-core/src/runtime/mod.rs
@@ -1,4 +1,3 @@
 pub(crate) mod tree;
 
-pub use crate::backend::compiler::Compiled;
-pub use crate::backend::tree::compiler::Error as RuntimeCompilerError;
+pub use crate::backend::compiler::{Compiled, RuntimeCompilerError};

--- a/crates/par-runtime/src/linker.rs
+++ b/crates/par-runtime/src/linker.rs
@@ -1,8 +1,9 @@
-use crate::flat::arena::{Arena, Index, Indexable};
+use crate::flat::arena::{Arena, Index};
 use crate::flat::runtime::{
     ExternalFn, Global, GlobalCont, GlobalValue, Package, PackageBody, PackagePtr,
 };
 use crate::registry::{DefinitionRef, PackageRef, get_external_fn};
+use std::fmt::{self, Display};
 use std::sync::OnceLock;
 
 pub type Linked = ExternalFn;
@@ -19,6 +20,11 @@ pub struct Unlinked {
     pub path: Vec<String>,
     pub module: String,
     pub name: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct LinkError {
+    pub missing: Unlinked,
 }
 
 impl<'a> From<PackageRef<'a>> for PackageID {
@@ -41,9 +47,49 @@ impl<'a> From<DefinitionRef<'a>> for Unlinked {
     }
 }
 
-pub fn link_arena(arena: &Arena<Unlinked>) -> Arena<Linked> {
-    Arena {
-        nodes: arena.nodes.iter().map(link_global).collect(),
+impl Display for PackageID {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Local => write!(f, "<local>"),
+            Self::Package(name) => write!(f, "@{name}"),
+        }
+    }
+}
+
+impl Display for Unlinked {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let package_prefix = match &self.package {
+            PackageID::Local => String::new(),
+            PackageID::Package(name) => format!("@{name}/"),
+        };
+        let path_prefix = if self.path.is_empty() {
+            String::new()
+        } else {
+            format!("{}/", self.path.join("/"))
+        };
+        write!(
+            f,
+            "{}{}{}.{}",
+            package_prefix, path_prefix, self.module, self.name
+        )
+    }
+}
+
+impl Display for LinkError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "Missing external registration for `{}`", self.missing)
+    }
+}
+
+impl std::error::Error for LinkError {}
+
+pub fn link_arena(arena: &Arena<Unlinked>) -> Result<Arena<Linked>, LinkError> {
+    Ok(Arena {
+        nodes: arena
+            .nodes
+            .iter()
+            .map(link_global)
+            .collect::<Result<_, _>>()?,
         strings: arena.strings.clone(),
         string_to_location: arena
             .string_to_location
@@ -53,77 +99,78 @@ pub fn link_arena(arena: &Arena<Unlinked>) -> Arena<Linked> {
         case_branches: arena
             .case_branches
             .iter()
-            .map(|(index, package)| (Index(index.0.clone()), link_package_body(package)))
-            .collect(),
+            .map(|(index, package)| Ok((Index(index.0.clone()), link_package_body(package)?)))
+            .collect::<Result<_, _>>()?,
         packages: arena
             .packages
             .iter()
-            .map(|package| link_package(package))
-            .collect(),
+            .map(link_package)
+            .collect::<Result<_, _>>()?,
         redexes: arena
             .redexes
             .iter()
             .map(|(a, b)| (Index(a.0.clone()), Index(b.0.clone())))
             .collect(),
-    }
+    })
 }
 
-fn link_package(package: &OnceLock<Package<Unlinked>>) -> OnceLock<Package<Linked>> {
+fn link_package(
+    package: &OnceLock<Package<Unlinked>>,
+) -> Result<OnceLock<Package<Linked>>, LinkError> {
     let package = package.get().unwrap();
     let lock = OnceLock::new();
     lock.set(Package {
-        body: link_package_body(&package.body),
+        body: link_package_body(&package.body)?,
         num_vars: package.num_vars,
     })
     .unwrap();
-    lock
+    Ok(lock)
 }
 
-fn link_package_body(body: &PackageBody<Unlinked>) -> PackageBody<Linked> {
-    PackageBody {
+fn link_package_body(body: &PackageBody<Unlinked>) -> Result<PackageBody<Linked>, LinkError> {
+    Ok(PackageBody {
         root: Index(body.root.0.clone()),
         captures: Index(body.captures.0.clone()),
         debug_name: body.debug_name.clone(),
         redexes: Index(body.redexes.0.clone()),
-    }
+    })
 }
 
-fn link_global(node: &Global<Unlinked>) -> Global<Linked> {
-    match node {
-        Global::Variable(id) => Global::Variable(id.clone()),
+fn link_global(node: &Global<Unlinked>) -> Result<Global<Linked>, LinkError> {
+    Ok(match node {
+        Global::Variable(id) => Global::Variable(*id),
         Global::Package(package_ptr, global_ptr, fab_behavior) => Global::Package(
             Index(package_ptr.0.clone()),
             Index(global_ptr.0.clone()),
             fab_behavior.clone(),
         ),
-        Global::Destruct(cont) => Global::Destruct(link_global_cont(cont)),
-        Global::Value(value) => Global::Value(link_global_value(value)),
+        Global::Destruct(cont) => Global::Destruct(link_global_cont(cont)?),
+        Global::Value(value) => Global::Value(link_global_value(value)?),
         Global::Fanout(fanout) => Global::Fanout(Index(fanout.0.clone())),
-    }
+    })
 }
 
-fn link_global_value(p0: &GlobalValue<Unlinked>) -> GlobalValue<Linked> {
-    match p0 {
+fn link_global_value(p0: &GlobalValue<Unlinked>) -> Result<GlobalValue<Linked>, LinkError> {
+    Ok(match p0 {
         GlobalValue::Break => GlobalValue::Break,
         GlobalValue::Pair(a, b) => GlobalValue::Pair(Index(a.0.clone()), Index(b.0.clone())),
         GlobalValue::Either(s, v) => GlobalValue::Either(Index(s.0.clone()), Index(v.0.clone())),
         GlobalValue::ExternalFn(unlinked) => {
-            //TODO: make it an error
-            GlobalValue::ExternalFn(
-                get_external_fn(unlinked).expect("missing external {unlinked:?}"),
-            )
+            GlobalValue::ExternalFn(get_external_fn(unlinked).ok_or_else(|| LinkError {
+                missing: unlinked.clone(),
+            })?)
         }
         GlobalValue::ExternalArc(e) => GlobalValue::ExternalArc(e.clone()),
         GlobalValue::Primitive(p) => GlobalValue::Primitive(p.clone()),
-    }
+    })
 }
 
-fn link_global_cont(cont: &GlobalCont<Unlinked>) -> GlobalCont<Linked> {
-    match cont {
+fn link_global_cont(cont: &GlobalCont<Unlinked>) -> Result<GlobalCont<Linked>, LinkError> {
+    Ok(match cont {
         GlobalCont::Continue => GlobalCont::Continue,
         GlobalCont::Par(a, b) => GlobalCont::Par(Index(a.0.clone()), Index(b.0.clone())),
         GlobalCont::Choice(a, b) => GlobalCont::Choice(Index(a.0.clone()), Index(b.0.clone())),
-    }
+    })
 }
 
 pub fn link_package_ptr(package: &PackagePtr<Unlinked>) -> PackagePtr<Linked> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -134,11 +134,11 @@ fn build_runtime_package(
     let (checked, local_modules, sources) = build_checked_package(package_path)?;
     let rt_compiled = checked
         .compile_runtime(max_interactions)
+        .and_then(|compiled| compiled.link())
         .map_err(|error| BuildError::InetCompile {
             error,
             sources: sources.clone(),
-        })?
-        .link();
+        })?;
     Ok((checked, rt_compiled, local_modules))
 }
 
@@ -421,9 +421,7 @@ fn resolve_target_definition<'a>(
 fn check(package_path: PathBuf) -> Result<(), String> {
     println!("Checking package: {}", package_path.display());
 
-    let checked_result = stacker::grow(32 * 1024 * 1024, || {
-        build_runtime_package(&package_path, MAX_INTERACTIONS_DEFAULT)
-    });
+    let checked_result = stacker::grow(32 * 1024 * 1024, || build_checked_package(&package_path));
     if let Err(error) = checked_result {
         let error_string = error.display();
         eprintln!("{}", error_string.bright_red());

--- a/src/main.rs
+++ b/src/main.rs
@@ -421,8 +421,10 @@ fn resolve_target_definition<'a>(
 fn check(package_path: PathBuf) -> Result<(), String> {
     println!("Checking package: {}", package_path.display());
 
-    let checked_result = stacker::grow(32 * 1024 * 1024, || build_checked_package(&package_path));
-    if let Err(error) = checked_result {
+    let build_result = stacker::grow(32 * 1024 * 1024, || {
+        build_runtime_package(&package_path, MAX_INTERACTIONS_DEFAULT)
+    });
+    if let Err(error) = build_result {
         let error_string = error.display();
         eprintln!("{}", error_string.bright_red());
         return Err(error_string);

--- a/src/playground.rs
+++ b/src/playground.rs
@@ -250,8 +250,11 @@ impl BuildResult {
     }
 
     fn from_checked(pretty: String, checked: Arc<CheckedWorkspace>, max_interactions: u32) -> Self {
-        let rt_compiled = match checked.compile_runtime(max_interactions) {
-            Ok(rt_compiled) => rt_compiled.link(),
+        let rt_compiled = match checked
+            .compile_runtime(max_interactions)
+            .and_then(|compiled| compiled.link())
+        {
+            Ok(rt_compiled) => rt_compiled,
             Err(error) => {
                 return Self::InetError {
                     pretty,

--- a/src/test.rs
+++ b/src/test.rs
@@ -40,22 +40,30 @@ fn temp_package(name: &str, source: &str) -> PathBuf {
     root
 }
 
+fn missing_external_error(package: &PathBuf) -> String {
+    let error = match stacker::grow(32 * 1024 * 1024, || {
+        crate::build_runtime_package(package, 10_000)
+    }) {
+        Ok(_) => panic!("link should fail"),
+        Err(error) => error,
+    };
+    error.display()
+}
+
 #[test]
-fn check_allows_unresolved_external_definitions() -> Result<(), String> {
+fn check_reports_missing_external_registration() {
     let package = temp_package("check-external", "module Main\n\ndef Main : ! = external\n");
-    check(package)
+    let error = check(package).expect_err("check should fail");
+    assert!(
+        error.contains("Missing external registration for"),
+        "unexpected error: {error}"
+    );
 }
 
 #[test]
 fn runtime_link_reports_missing_external_registration() {
     let package = temp_package("link-external", "module Main\n\ndef Main : ! = external\n");
-    let error = match stacker::grow(32 * 1024 * 1024, || {
-        crate::build_runtime_package(&package, 10_000)
-    }) {
-        Ok(_) => panic!("link should fail"),
-        Err(error) => error,
-    };
-    let display = error.display();
+    let display = missing_external_error(&package);
     assert!(
         display.contains("Missing external registration for"),
         "unexpected error: {display}"

--- a/src/test.rs
+++ b/src/test.rs
@@ -1,6 +1,8 @@
 #![cfg(test)]
 
+use std::fs;
 use std::path::PathBuf;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use crate::check;
 
@@ -23,4 +25,39 @@ fn test_all_files() -> Result<(), String> {
     } else {
         Err("Some tests failed".to_string())
     }
+}
+
+fn temp_package(name: &str, source: &str) -> PathBuf {
+    let unique = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time before unix epoch")
+        .as_nanos();
+    let root = std::env::temp_dir().join(format!("par-lang-{name}-{unique}"));
+    fs::create_dir_all(root.join("src")).expect("failed to create temp package");
+    fs::write(root.join("Par.toml"), "[package]\nname = \"tmp\"\n")
+        .expect("failed to write manifest");
+    fs::write(root.join("src").join("Main.par"), source).expect("failed to write source");
+    root
+}
+
+#[test]
+fn check_allows_unresolved_external_definitions() -> Result<(), String> {
+    let package = temp_package("check-external", "module Main\n\ndef Main : ! = external\n");
+    check(package)
+}
+
+#[test]
+fn runtime_link_reports_missing_external_registration() {
+    let package = temp_package("link-external", "module Main\n\ndef Main : ! = external\n");
+    let error = match stacker::grow(32 * 1024 * 1024, || {
+        crate::build_runtime_package(&package, 10_000)
+    }) {
+        Ok(_) => panic!("link should fail"),
+        Err(error) => error,
+    };
+    let display = error.display();
+    assert!(
+        display.contains("Missing external registration for"),
+        "unexpected error: {display}"
+    );
 }

--- a/src/test_runner.rs
+++ b/src/test_runner.rs
@@ -91,14 +91,14 @@ fn build_for_run(
         error,
         sources: sources.clone(),
     })?;
-    let compiled =
-        checked
-            .compile_runtime(max_interactions)
-            .map_err(|error| BuildError::InetCompile {
-                error,
-                sources: sources.clone(),
-            })?;
-    Ok((checked.clone(), compiled.link(), checked.root_modules()))
+    let compiled = checked
+        .compile_runtime(max_interactions)
+        .and_then(|compiled| compiled.link())
+        .map_err(|error| BuildError::InetCompile {
+            error,
+            sources: sources.clone(),
+        })?;
+    Ok((checked.clone(), compiled, checked.root_modules()))
 }
 
 #[derive(Debug)]


### PR DESCRIPTION
This fixes two issues in the external registration refactor.

- ~~`par-lang check` stays on the checked-only path instead of compiling and linking runtime code.~~
- missing external registrations now surface as a normal link/runtime compiler error instead of panicking.

I also threaded the fallible link step through the playground and test runner, and added regression tests for both cases.

Verified with `cargo test`, plus manual `check`/`run` on a temp package containing `def Main : ! = external`.