### PR TITLE
Some fixes

### DIFF
--- a/crates/par-core/src/backend/flat/transpiler.rs
+++ b/crates/par-core/src/backend/flat/transpiler.rs
@@ -16,6 +16,7 @@ use par_runtime::flat::runtime::{
     ExternalArc, GlobalCont, GlobalValue, Package, PackageBody, PackagePtr,
 };
 
+use crate::frontend::language::PackageId;
 use crate::runtime_impl::tree::Net;
 use par_runtime::flat::runtime::Global;
 use par_runtime::linker::{Artifact, LinkError, Linked, Unlinked, link_arena, link_package_ptr};
@@ -42,14 +43,19 @@ pub struct Transpiled<Ext: Clone> {
     pub type_defs: TypeDefs<Universal>,
 }
 
-impl Into<Artifact<Unlinked>> for Transpiled<Unlinked> {
-    fn into(self) -> Artifact<Unlinked> {
+impl Transpiled<Unlinked> {
+    pub fn into_artifact(self, root_package: &PackageId) -> Artifact<Unlinked> {
         Artifact {
             arena: self.arena.clone(),
             definition_to_package: self
                 .name_to_package
                 .iter()
-                .map(|(k, v)| (k.to_string(), v.clone()))
+                .filter(|(k, v)| &k.module.package == root_package)
+                .map(|(k, v)| {
+                    let mut path = k.module.directories.clone();
+                    path.push(k.module.module.clone());
+                    (format!("{}.{}", path.join("/"), k.primary), v.clone())
+                })
                 .collect(),
         }
     }

--- a/crates/par-runtime/src/flat/reducer.rs
+++ b/crates/par-runtime/src/flat/reducer.rs
@@ -66,7 +66,7 @@ impl Reducer {
         )
     }
     // this function should only be called inside run, to avoid race conditions
-    fn net_handle(&mut self) -> NetHandle {
+    async fn net_handle(&mut self) -> NetHandle {
         if let Some(sender) = self.sender.upgrade() {
             NetHandle(
                 sender,
@@ -77,6 +77,21 @@ impl Reducer {
         } else {
             // all senders have been dropped, so we can just create a new one channel
             let (tx, rx) = mpsc::unbounded_channel();
+            // forward the old messages to the new channel
+            loop {
+                match self.inbox.try_recv() {
+                    Ok(msg) => {
+                        tx.send(msg).unwrap();
+                    }
+                    Err(mpsc::error::TryRecvError::Empty) => {
+                        unreachable!("All senders should have been dropped!")
+                    }
+                    Err(mpsc::error::TryRecvError::Disconnected) => {
+                        // it's guaranteed there will never be another message
+                        break;
+                    }
+                }
+            }
             self.inbox = rx;
             self.sender = tx.downgrade();
             NetHandle(tx, 0, self.num_handles.clone())
@@ -111,7 +126,7 @@ impl Reducer {
                             (UserData::ExternalFn(f), other) => {
                                 let handle = Handle::from_node(
                                     self.runtime.arena.clone(),
-                                    self.net_handle(),
+                                    self.net_handle().await,
                                     other,
                                 );
                                 self.spawner.spawn(f(handle.into())).unwrap();
@@ -119,7 +134,7 @@ impl Reducer {
                             (UserData::ExternalArc(f), other) => {
                                 let handle = Handle::from_node(
                                     self.runtime.arena.clone(),
-                                    self.net_handle(),
+                                    self.net_handle().await,
                                     other,
                                 );
                                 self.spawner.spawn((f.0).as_ref()(handle.into())).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -772,7 +772,7 @@ fn run_definition_vm(binary_path: PathBuf, target: Option<String>, print_stats: 
 }
 
 fn compile(package_path: PathBuf, max_interactions: u32) {
-    let (_checked, rt_compiled, _local_modules, _sources) =
+    let (checked, rt_compiled, _local_modules, _sources) =
         match build_unlinked_package(&package_path, max_interactions) {
             Ok((checked, rt_compiled, local_modules, sources)) => {
                 (checked, rt_compiled, local_modules, sources)
@@ -783,7 +783,9 @@ fn compile(package_path: PathBuf, max_interactions: u32) {
             }
         };
 
-    let artifact: Artifact<Unlinked> = rt_compiled.code.into();
+    let artifact: Artifact<Unlinked> = rt_compiled
+        .code
+        .into_artifact(checked.workspace().root_package());
     let file = File::create("compiled.pvm").expect("Failed to create file");
     let writer = BufWriter::new(file);
     bincode::serialize_into(writer, &artifact).expect("Failed to serialize");


### PR DESCRIPTION
This PR fixes two bugs.

- The first, is a nasty bug in the reducer, where when all senders drop, we drop the mpsc channel, possibly dropping queued messages.

- The second, is a bug in how definitions are serialized in "compile". Due to the recent addition of user packages, the full package path was accidentally written into the binary, making it incompatible with "run". Instead, it now only adds definitions belonging to the root package, and so module path is relative to that, just like in "run".