### PR TITLE
Improve Result/Option

### DIFF
--- a/crates/par-builtin/packages/basic/src/Console.par
+++ b/crates/par-builtin/packages/basic/src/Console.par
@@ -8,7 +8,7 @@
 export module Console
 
 import {
-  @core/Option
+  @core/Result
   @core/String
 }
 
@@ -33,7 +33,7 @@ export {
   type Console = iterative choice {
     .close => !,
     .print(String) => self,
-    .prompt(String) => (Option<String>) self,
+    .prompt(String) => (Result<!, String>) self,
   }
 
   // Opens a new `Console` connected to stdin/stdout.

--- a/crates/par-builtin/packages/basic/src/Os.par
+++ b/crates/par-builtin/packages/basic/src/Os.par
@@ -28,7 +28,7 @@ export {
   // - `.name` — get the file name component as bytes.
   // - `.absolute` — get the absolute path as bytes.
   // - `.parts` — get all path components as a list of byte sequences.
-  // - `.parent` — get the parent path, or `.err!` if at root.
+  // - `.parent` — get the parent path, or `.none!` if at root.
   // - `.append(part)` — return a path with one more path component.
   type Path = iterative@append recursive@parent box choice {
     .name => Bytes,

--- a/crates/par-builtin/packages/core/src/Float.par
+++ b/crates/par-builtin/packages/core/src/Float.par
@@ -4,6 +4,7 @@ export module Float
 import {
   Bool
   Int
+  Option
   String
 }
 
@@ -40,10 +41,8 @@ export {
   dec ToInt : [Float] Int
 
   // Parses a float literal or one of `NaN`, `Inf`, `-Inf`, `Infinity`, `-Infinity`.
-  dec FromString : [String] either {
-    .ok Float,
-    .err!,
-  }
+  // Returns `.none!` when the string is not valid.
+  dec FromString : [String] Option<Float>
 
   // Negates a float.
   dec Neg : [Float] Float

--- a/crates/par-builtin/packages/core/src/Int.par
+++ b/crates/par-builtin/packages/core/src/Int.par
@@ -4,6 +4,7 @@ export module Int
 import {
   List
   Nat
+  Option
   String
 }
 
@@ -37,11 +38,8 @@ export {
   dec Range : [Int, Int] List<Int>
 
   // Parses a decimal string into an integer.
-  // Returns `.err!` when the string is not a valid integer.
-  dec FromString : [String] either {
-    .ok Int,
-    .err!,
-  }
+  // Returns `.none!` when the string is not a valid integer.
+  dec FromString : [String] Option<Int>
 }
 
 def Mod = external

--- a/crates/par-builtin/packages/core/src/Json.par
+++ b/crates/par-builtin/packages/core/src/Json.par
@@ -37,7 +37,7 @@ export {
   // A `Format<a>` exposes a single `.parse` operation that returns `.ok value`
   // on success or `.err!` on mismatch.
   type Format<a> = box choice {
-    .parse(Json) => Option<a>
+    .parse(Json) => Result<!, a>
   }
 
   // A reusable parser specialized to JSON objects.
@@ -45,7 +45,7 @@ export {
   // Use `Json.Object(...)` to lift an `ObjectFormat<a>` into a full
   // `Format<a>`.
   type ObjectFormat<a> = box choice {
-    .parseObject(BoxMap.Readonly<CoreString, Json>) => Option<a>,
+    .parseObject(BoxMap.Readonly<CoreString, Json>) => Result<!, a>,
   }
 
   // Encodes a `Json` value into compact JSON text.
@@ -70,7 +70,7 @@ export {
   //
   // The mapping function returns `.ok value` to accept the parsed result or
   // `.err!` to reject it.
-  dec Then : <a>[Format<a>] [type b, box [a] Option<b>] Format<b>
+  dec Then : <a>[Format<a>] [type b, box [a] Result<!, b>] Format<b>
 
   // Matches exactly one JSON value.
   dec Literal : [Json] Format<!>
@@ -107,7 +107,7 @@ export {
 
   // Parses an optional object field with the given format.
   //
-  // Missing fields produce `.ok .err!`. Present fields must parse successfully.
+  // Missing fields produce `.ok .none!`. Present fields must parse successfully.
   dec OptionalField : [CoreString] <a>[Format<a>] ObjectFormat<Option<a>>
 
   // Runs two object formats against the same object and returns both results.
@@ -158,8 +158,8 @@ export {
   // ```
   dec Tagged : [type a, CoreString, CoreList<(Json) <b>(ObjectFormat<b>) box [b] a>] Format<a>
 
-  // Accepts JSON `null` as `.ok .err!`, otherwise parses with the given format
-  // and wraps the result in `.ok`.
+  // Accepts JSON `null` as `.ok .none!`, otherwise parses with the given format
+  // and wraps the result in `.some`.
   dec OrNull : <a>[Format<a>] Format<Option<a>>
 }
 
@@ -260,7 +260,7 @@ def Empty = box case {
 
 def Field = [key] <a>[format] box case {
   .parseObject(object) => if {
-    not object.get(key) is .ok json => .err!,
+    not object.get(key) is .some json => .err!,
     not format.parse(json) is .ok value => .err!,
     else => .ok value,
   }
@@ -268,11 +268,11 @@ def Field = [key] <a>[format] box case {
 
 def OptionalField = [key] <a>[format] box case {
   .parseObject(object) => object.get(key).case {
-    .ok json => format.parse(json).case {
-      .ok value => .ok .ok value,
+    .some json => format.parse(json).case {
+      .ok value => .ok .some value,
       .err! => .err!,
     },
-    .err! => .ok .err!,
+    .none! => .ok .none!,
   }
 }
 
@@ -296,7 +296,7 @@ def Union = [type a, variants] box case {
 
 def Tagged = [type a, tagKey, variants] box case {
   .parse(json) => if {
-    json is .object o and o.get(tagKey) is .ok actualTag => variants.begin.case {
+    json is .object o and o.get(tagKey) is .some actualTag => variants.begin.case {
       .item((tag) <b>(format) map) rest => if {
         tag->Equals(actualTag) => format.parseObject(o).case {
           .ok value => .ok map(value),
@@ -312,9 +312,9 @@ def Tagged = [type a, tagKey, variants] box case {
 
 def OrNull = <a>[format] box case {
   .parse(json) => json.case {
-    .null! => .ok .err!,
+    .null! => .ok .none!,
     else json => format.parse(json).case {
-      .ok value => .ok .ok value,
+      .ok value => .ok .some value,
       .err! => .err!,
     },
   }

--- a/crates/par-builtin/packages/core/src/Nat.par
+++ b/crates/par-builtin/packages/core/src/Nat.par
@@ -4,6 +4,7 @@ export module Nat
 import {
   Int
   List
+  Option
   String
 }
 
@@ -52,11 +53,8 @@ export {
   dec Range : [Nat, Nat] List<Nat>
 
   // Parses a decimal string into a natural number.
-  // Returns `.err!` when the string is not a valid non-negative integer.
-  dec FromString : [String] either {
-    .ok Nat,
-    .err!,
-  }
+  // Returns `.none!` when the string is not a valid non-negative integer.
+  dec FromString : [String] Option<Nat>
 }
 
 def Mod = external

--- a/crates/par-builtin/packages/core/src/Option.par
+++ b/crates/par-builtin/packages/core/src/Option.par
@@ -1,14 +1,54 @@
-// `Option<a>` is `Result<!, a>`.
+// `Option<a>` is either `.some a` or `.none!`.
 //
-// - `.ok value` carries a value.
-// - `.err!` means no value is available.
+// - `.some a` carries a value.
+// - `.none!` means no value is available.
 export module Option
 
 import {
+  Bool
+  List
   Result
 }
 
 export {
-  // An optional value, defined as `Result<!, a>`.
-  type Option<a> = Result<!, a>
+  // An optional value, either `.some a` or `.none!`.
+  type Option<a> = either {
+    .some a,
+    .none!,
+  }
+
+  dec Map : <a>[Option<a>] [type b, box [a] b] Option<b>
+
+  dec FlatMap : <a>[Option<a>] [type b, box [a] Option<b>] Option<b>
+
+  dec Filter : <a: box>[Option<a>] [box [a] Bool] Option<a>
+
+  dec ToList : <a>[Option<a>] List<a>
+
+  dec ToResult : <a>[Option<a>] <e: box>[e] Result<e, a>
+}
+
+def Map = <a>[option] [type b, f] option.case {
+  .some a => .some f(a),
+  .none! => .none!,
+}
+
+def FlatMap = <a>[option] [type b, f] option.case {
+  .some a => f(a),
+  .none! => .none!,
+}
+
+def Filter = <a: box>[option] [p] if {
+  option is .some value and p(value) => .some value,
+  else => .none!,
+}
+
+def ToList = <a>[option] option.case {
+  .some a => .item(a) .end!,
+  .none! => .end!,
+}
+
+def ToResult = <a>[option] <e: box>[e] option.case {
+  .some a => .ok a,
+  .none! => .err e,
 }

--- a/crates/par-builtin/packages/core/src/Option.par
+++ b/crates/par-builtin/packages/core/src/Option.par
@@ -17,14 +17,19 @@ export {
     .none!,
   }
 
+  // Transforms the contained value, if present.
   dec Map : <a>[Option<a>] [type b, box [a] b] Option<b>
 
+  // Transforms the contained value with a computation that may return no value.
   dec FlatMap : <a>[Option<a>] [type b, box [a] Option<b>] Option<b>
 
+  // Keeps the contained value only if it satisfies the predicate.
   dec Filter : <a: box>[Option<a>] [box [a] Bool] Option<a>
 
+  // Converts `.some value` to a singleton list and `.none!` to an empty list.
   dec ToList : <a>[Option<a>] List<a>
 
+  // Converts `.some value` to `.ok value` and `.none!` to the provided error.
   dec ToResult : <a>[Option<a>] <e: box>[e] Result<e, a>
 }
 

--- a/crates/par-builtin/packages/core/src/Result.par
+++ b/crates/par-builtin/packages/core/src/Result.par
@@ -21,16 +21,23 @@ export {
   // Extracts the `.ok` branch from a `Result<either {}, a>`.
   dec Always : <a>[Result<either {}, a>] a
 
+  // Transforms the `.ok` value, if present.
   dec Map : <e, a>[Result<e, a>] [type b, box [a] b] Result<e, b>
 
+  // Transforms the `.err` value, if present.
   dec MapErr : <e1, a>[Result<e1, a>] [type e2, box [e1] e2] Result<e2, a>
 
+  // Transforms the `.ok` value with a computation that may itself fail.
   dec FlatMap : <e, a>[Result<e, a>] [type b, box [a] Result<e, b>] Result<e, b>
 
+  // Keeps a successful value only if it satisfies the predicate, otherwise
+  // replaces it with the provided error.
   dec Filter : <e, a: box>[Result<e, a>] [box e, box [a] Bool] Result<e, a>
 
+  // Converts `.ok value` to a singleton list and `.err _` to an empty list.
   dec ToList : <e: box, a>[Result<e, a>] List<a>
 
+  // Converts `.ok value` to `.some value` and `.err _` to `.none!`.
   dec ToOption : <e: box, a>[Result<e, a>] Option<a>
 }
 

--- a/crates/par-builtin/packages/core/src/Result.par
+++ b/crates/par-builtin/packages/core/src/Result.par
@@ -5,6 +5,12 @@
 // ```
 export module Result
 
+import {
+  Bool
+  List
+  Option
+}
+
 export {
   // A value that is either `.ok a` or `.err e`.
   type Result<e, a> = either {
@@ -14,9 +20,54 @@ export {
 
   // Extracts the `.ok` branch from a `Result<either {}, a>`.
   dec Always : <a>[Result<either {}, a>] a
+
+  dec Map : <e, a>[Result<e, a>] [type b, box [a] b] Result<e, b>
+
+  dec MapErr : <e1, a>[Result<e1, a>] [type e2, box [e1] e2] Result<e2, a>
+
+  dec FlatMap : <e, a>[Result<e, a>] [type b, box [a] Result<e, b>] Result<e, b>
+
+  dec Filter : <e, a: box>[Result<e, a>] [box e, box [a] Bool] Result<e, a>
+
+  dec ToList : <e: box, a>[Result<e, a>] List<a>
+
+  dec ToOption : <e: box, a>[Result<e, a>] Option<a>
 }
 
 def Always = <a>[result] result.case {
   .ok value => value,
   .err impossible => impossible.case {},
+}
+
+def Map = <e, a>[result] [type b, f] result.case {
+  .ok a => .ok f(a),
+  .err e => .err e,
+}
+
+def MapErr = <e1, a>[result] [type e2, f] result.case {
+  .ok a => .ok a,
+  .err e => .err f(e),
+}
+
+def FlatMap = <e, a>[result] [type b, f] result.case {
+  .ok a => f(a),
+  .err e => .err e,
+}
+
+def Filter = <e, a: box>[result] [e1, p] result.case {
+  .ok a => if {
+    p(a) => .ok a,
+    else => .err e1,
+  }
+  .err e => .err e,
+}
+
+def ToList = <e: box, a>[result] result.case {
+  .ok a => .item(a) .end!,
+  .err _ => .end!,
+}
+
+def ToOption = <e: box, a>[result] result.case {
+  .ok a => .some a,
+  .err _ => .none!,
 }

--- a/crates/par-builtin/src/builtin/boxmap.rs
+++ b/crates/par-builtin/src/builtin/boxmap.rs
@@ -88,11 +88,11 @@ fn provide_boxmap(handle: Handle, map: OrdMap<Data, Arc<Mutex<Handle>>>) {
                     let key = handle.receive_data().await;
                     match map.get(&key) {
                         Some(value) => {
-                            handle.signal(literal!("ok"));
+                            handle.signal(literal!("some"));
                             return handle.link(value.lock().await.duplicate());
                         }
                         None => {
-                            handle.signal(literal!("err"));
+                            handle.signal(literal!("none"));
                             return handle.break_();
                         }
                     }

--- a/crates/par-builtin/src/builtin/float.rs
+++ b/crates/par-builtin/src/builtin/float.rs
@@ -396,11 +396,11 @@ async fn float_from_string(mut handle: Handle) {
     let string = handle.receive().string().await;
     match parse_float_text(string.as_str()) {
         Some(value) => {
-            handle.signal(literal!("ok"));
+            handle.signal(literal!("some"));
             handle.provide_float(value);
         }
         None => {
-            handle.signal(literal!("err"));
+            handle.signal(literal!("none"));
             handle.break_();
         }
     }

--- a/crates/par-builtin/src/builtin/int.rs
+++ b/crates/par-builtin/src/builtin/int.rs
@@ -149,11 +149,11 @@ async fn int_from_string(mut handle: Handle) {
     let string = handle.receive().string().await;
     match string.as_str().parse::<BigInt>() {
         Ok(num) => {
-            handle.signal(literal!("ok"));
+            handle.signal(literal!("some"));
             handle.provide_int(num);
         }
         Err(_) => {
-            handle.signal(literal!("err"));
+            handle.signal(literal!("none"));
             handle.break_();
         }
     };

--- a/crates/par-builtin/src/builtin/json.rs
+++ b/crates/par-builtin/src/builtin/json.rs
@@ -229,11 +229,11 @@ fn provide_object(handle: Handle, entries: BTreeMap<String, JsonValue>) {
                     let key = handle.receive().string().await;
                     match entries.get(key.as_str()) {
                         Some(value) => {
-                            handle.signal(literal!("ok"));
+                            handle.signal(literal!("some"));
                             provide_json_value(handle, value.clone());
                         }
                         None => {
-                            handle.signal(literal!("err"));
+                            handle.signal(literal!("none"));
                             handle.break_();
                         }
                     }

--- a/crates/par-builtin/src/builtin/map.rs
+++ b/crates/par-builtin/src/builtin/map.rs
@@ -81,11 +81,11 @@ async fn provide_map(mut handle: Handle, mut map: BTreeMap<Data, Handle>) {
                 handle.send().concurrently(|mut handle| async move {
                     match removed {
                         Some(value) => {
-                            handle.signal(literal!("ok"));
+                            handle.signal(literal!("some"));
                             handle.link(value);
                         }
                         None => {
-                            handle.signal(literal!("err"));
+                            handle.signal(literal!("none"));
                             handle.break_();
                         }
                     }

--- a/crates/par-builtin/src/builtin/nat.rs
+++ b/crates/par-builtin/src/builtin/nat.rs
@@ -180,15 +180,15 @@ async fn nat_from_string(mut handle: Handle) {
     match string.as_str().parse::<BigInt>() {
         Ok(num) => {
             if num >= BigInt::ZERO {
-                handle.signal(literal!("ok"));
+                handle.signal(literal!("some"));
                 handle.provide_nat(num);
             } else {
-                handle.signal(literal!("err"));
+                handle.signal(literal!("none"));
                 handle.break_();
             }
         }
         Err(_) => {
-            handle.signal(literal!("err"));
+            handle.signal(literal!("none"));
             handle.break_();
         }
     };

--- a/crates/par-builtin/src/builtin/os.rs
+++ b/crates/par-builtin/src/builtin/os.rs
@@ -176,11 +176,11 @@ fn provide_path(handle: Handle, path: PathBuf) {
                 }
                 "parent" => match path.parent() {
                     Some(p) => {
-                        handle.signal(arcstr::literal!("ok"));
+                        handle.signal(arcstr::literal!("some"));
                         provide_path(handle, p.to_path_buf());
                     }
                     None => {
-                        handle.signal(arcstr::literal!("err"));
+                        handle.signal(arcstr::literal!("none"));
                         handle.break_();
                     }
                 },
@@ -576,11 +576,11 @@ async fn envmap_new(handle: Handle) {
                 match std::env::var_os(name_os) {
                     Some(val) => {
                         let bytes = os_to_bytes(&val);
-                        handle.signal(literal!("ok"));
+                        handle.signal(literal!("some"));
                         return handle.provide_bytes(bytes);
                     }
                     None => {
-                        handle.signal(literal!("err"));
+                        handle.signal(literal!("none"));
                         return handle.break_();
                     }
                 }

--- a/crates/par-core/src/frontend_impl/language.rs
+++ b/crates/par-core/src/frontend_impl/language.rs
@@ -3111,8 +3111,8 @@ impl Context {
                 typ: (),
                 command: process::Command::Case(
                     Arc::from([
-                        LocalName::from(literal!("err")),
-                        LocalName::from(literal!("ok")),
+                        LocalName::from(literal!("none")),
+                        LocalName::from(literal!("some")),
                     ]),
                     Box::from([
                         Arc::new(process::Process::Let {

--- a/docs/src/quality_of_life/error_handling.md
+++ b/docs/src/quality_of_life/error_handling.md
@@ -567,27 +567,33 @@ This function uses `Bytes.ParserFromReader` to convert the chunked `Bytes.Reader
 
 ## Providing defaults with `default`
 
-Sometimes you don’t want to propagate an error — you want to replace it with a fallback and keep going. The `default` sugar does exactly that, and unlike `try`, it is completely standalone: it does not require a surrounding `catch`, and it is valid even in nested expression positions.
+Sometimes you don’t want to branch on a missing optional value — you want to replace it with a fallback and keep going. The `default` sugar does exactly that for `Option` values.
+
+This is separate from `try`/`catch`: `try` unwraps `Result` values and propagates `.err`, while `default` unwraps `Option` values and replaces `.none!`. If you have a `Result` and want to ignore the error, convert it first with `Result.ToOption`.
 
 - Postfix form (expressions/commands):
 
   ```par
-  let r1: Result<!, Int> = .ok 7
-  let r2: Result<!, Int> = .err!
+  let r1: Option<Int> = .some 7
+  let r2: Option<Int> = .none!
 
   let x = r1.default(0)   // x = 7
   let y = r2.default(0)   // y = 0
+
+  let result: Result<String, Int> = .err "not a number"
+  let option = Result.ToOption(result)
+  let z = option.default(0)  // z = 0
   ```
 
-  This desugars to a `.case` on the subject: on `.ok` it continues with the unwrapped value, on `.err` it evaluates the fallback expression and uses that value instead. Because it is a local rewrite, it can be used directly in `let` bindings and other expression contexts.
+  This desugars to a `.case` on the subject: on `.some` it continues with the unwrapped value, on `.none` it evaluates the fallback expression and uses that value instead. Because it is a local rewrite, it can be used directly in `let` bindings and other expression contexts.
 
 - Pattern form (including in receives):
 
   ```par
-  let default(0) n = Nat.FromString("oops")
+  let default(0) n = .none!
   ```
 
-  The pattern binds on `.ok`, and binds the fallback expression on `.err`.
+  The pattern binds on `.some`, and binds the fallback expression on `.none`.
 
   Here’s a practical example that shows why the pattern form is particularly useful with receive commands. It counts word occurrences using a map; when a key is missing, it starts from `0`:
 
@@ -606,4 +612,4 @@ Sometimes you don’t want to propagate an error — you want to replace it with
   } in counts.list
   ```
 
-  In the `.item` branch, `counts.entry(word)` returns a `Result<!, Nat>` via a receive; `default(0)` seamlessly handles the missing case and binds `count` to `0`.
+  In the `.item` branch, `counts.entry(word)` returns an `Option<Nat>` via a receive; `default(0)` seamlessly handles the missing case and binds `count` to `0`.

--- a/docs/src/quality_of_life/error_handling.md
+++ b/docs/src/quality_of_life/error_handling.md
@@ -590,7 +590,7 @@ This is separate from `try`/`catch`: `try` unwraps `Result` values and propagate
 - Pattern form (including in receives):
 
   ```par
-  let default(0) n = .none!
+  let default(0) n = Nat.FromString("oops")
   ```
 
   The pattern binds on `.some`, and binds the fallback expression on `.none`.

--- a/docs/src/quality_of_life/if.md
+++ b/docs/src/quality_of_life/if.md
@@ -75,7 +75,10 @@ type Result<e, a> = either {
   .ok a,
 }
 
-type Option<a> = Result<!, a>
+type Option<a> = either {
+  .none!,
+  .some a,
+}
 ```
 
 An `is` condition checks an `either` and binds its payload. Its shape is:
@@ -140,8 +143,8 @@ condition and inside the branch.
 ```par
 dec CountStatus : [Option<Nat>] String
 def CountStatus = [count] if {
-  count is .ok n and n == 0 => "zero",
-  count is .ok _ => "non-zero",
+  count is .some n and n == 0 => "zero",
+  count is .some _ => "non-zero",
   else => "missing",
 }
 ```
@@ -149,12 +152,12 @@ def CountStatus = [count] if {
 Step by step:
 
 - Try the first branch.
-  - First evaluate `count is .ok n`. If it fails, the whole `and` fails.
+  - First evaluate `count is .some n`. If it fails, the whole `and` fails.
   - If it succeeds, `n` is bound and Par evaluates `n == 0`.
   - Only if both parts succeed does the branch return `"zero"`.
-- If the first branch fails, try the second branch `count is .ok _`, which
+- If the first branch fails, try the second branch `count is .some _`, which
   matches any present value and returns `"non-zero"`.
-- If both branches fail, `count` must be `.err!`, so `else` returns `"missing"`.
+- If both branches fail, `count` must be `.none!`, so `else` returns `"missing"`.
 
 ### `and` with two bindings
 

--- a/docs/src/quality_of_life/pipes.md
+++ b/docs/src/quality_of_life/pipes.md
@@ -100,8 +100,8 @@ returns a head and a tail:
 ```par
 dec Pop : [List<Nat>] (Option<Nat>) List<Nat>
 def Pop = [list] list.case {
-  .end! => (.err!) .end!,
-  .item(x) xs => (.ok x) xs,
+  .end! => (.none!) .end!,
+  .item(x) xs => (.some x) xs,
 }
 
 let numbers = *(10, 20, 30)

--- a/examples/src/AdventOfCode/2019/Day1/Day1.par
+++ b/examples/src/AdventOfCode/2019/Day1/Day1.par
@@ -5,6 +5,7 @@ import {
   @core/Int
   @core/List
   @core/Nat
+  @core/Option
   @core/Result
   @core/String
   @basic/Console
@@ -92,7 +93,9 @@ def Main = chan exit {
   }
 
   let lines = StringLines(input)
-  ListMapTry(type String, type !, type Nat, lines, box Nat.FromString).case {
+  ListMapTry(type String, type !, type Nat, lines, box [line]
+    Nat.FromString(line)->Option.ToResult(!)
+  ).case {
     .err! => {
       console.print("invalid input")
       console.close

--- a/examples/src/Downloader.par
+++ b/examples/src/Downloader.par
@@ -10,7 +10,6 @@ import {
   @core/Nat
   @core/Option
   @core/String
-  @core/Result
   @core/Url
   @core/Debug
   @basic/Http
@@ -92,8 +91,7 @@ def DownloadFile = [(sourceUrl, dest)!] chan yield {
   let default(0) totalSize =
     headers.get("content-length")
       ->Option.Map(type String, box String.FromBytes)
-      ->Option.Map(type Result<!, Nat>, box Nat.FromString)
-      ->Option.FlatMap(type Nat, box [r] Result.ToOption(r))
+      ->Option.FlatMap(type Nat, box Nat.FromString)
   yield.item((dest) .started totalSize)
 
   let bytesSinceLastEvent = 0

--- a/examples/src/Downloader.par
+++ b/examples/src/Downloader.par
@@ -8,7 +8,9 @@ import {
   @core/List
   @core/Map
   @core/Nat
+  @core/Option
   @core/String
+  @core/Result
   @core/Url
   @core/Debug
   @basic/Http
@@ -87,10 +89,11 @@ def DownloadFile = [(sourceUrl, dest)!] chan yield {
   let try@clearResp file = Os.CreateNewFile(dest)
   catch@clearFile err => { file.close; throw err }
 
-  let default(0) totalSize = catch ! => .err! in
-    headers.get("content-length").try
-      ->String.FromBytes
-      ->Nat.FromString
+  let default(0) totalSize =
+    headers.get("content-length")
+      ->Option.Map(type String, box String.FromBytes)
+      ->Option.Map(type Result<!, Nat>, box Nat.FromString)
+      ->Option.FlatMap(type Nat, box [r] Result.ToOption(r))
   yield.item((dest) .started totalSize)
 
   let bytesSinceLastEvent = 0
@@ -202,7 +205,7 @@ def NewProgressTracker: ProgressTracker = do {
 
   .file(name) => do {
     filesInProgress.entry(name)[entry]
-    if not entry is .ok(startTime, expected, downloaded)! => {
+    if not entry is .some(startTime, expected, downloaded)! => {
       let startTime = Time.Now(!)
       let expected = 0
       let downloaded = 0

--- a/examples/src/PlaygroundChat.par
+++ b/examples/src/PlaygroundChat.par
@@ -121,7 +121,7 @@ def ServeChat = [api] do {
       messages.entry(username)[pending]
     } in if {
       // If it's present, it means another user with the same username is logged in.
-      pending is .ok pending => do {
+      pending is .some pending => do {
         // Restore the map.
         messages.put(pending)
         // Deny the login.
@@ -142,7 +142,7 @@ def ServeChat = [api] do {
       // If we have no bugs in the fanning, the entry will always be present.
       // The type system can't guarantee that, so let's just handle the opposite
       // case by defaulting to an empty list builder. But, this should not happen.
-      if not pending is .ok pending => {
+      if not pending is .some pending => {
         let pending = List.Builder(type (String) String)
       }
     } in client.case {
@@ -168,7 +168,7 @@ def ServeChat = [api] do {
           messages.entry(to)[pending]
           if {
             // If it exists, the user it logged in.
-            pending is .ok pending => {
+            pending is .some pending => {
               // Add the message to their pending messages.
               messages.put(pending.add((username) content))
               // Notify the client that the message was sent successfully.

--- a/playground-examples/src/JsonParsing.par
+++ b/playground-examples/src/JsonParsing.par
@@ -35,10 +35,11 @@ def SomeValidAndInvalidActions : List<String> = *(
   `{"action": "decrement", "delta": 10}`,
 )
 
-def ParsedActions : List<Option<Action>> =
+def ParsedActions : List<Result<!, Action>> =
   SomeValidAndInvalidActions
     ->List.Map(type Result<Json.Error, Json>, box Json.Decode)
-    ->List.Map(type Option<Action>, box [result] {
-      catch _ => .err! in
-        result.try->{ActionFormat.parse}
+    ->List.Map(type Result<!, Action>, box [result] {
+      result
+        ->Result.MapErr(type !, box [_] !)
+        ->Result.FlatMap(type Action, box ActionFormat.parse)
     })

--- a/playground-examples/src/PlaygroundChat.par
+++ b/playground-examples/src/PlaygroundChat.par
@@ -124,7 +124,7 @@ def ServeChat = [api] do {
       messages.entry(username)[pending]
     } in if {
       // If it's present, it means another user with the same username is logged in.
-      pending is .ok pending => do {
+      pending is .some pending => do {
         // Restore the map.
         messages.put(pending)
         // Deny the login.
@@ -145,7 +145,7 @@ def ServeChat = [api] do {
       // If we have no bugs in the fanning, the entry will always be present.
       // The type system can't guarantee that, so let's just handle the opposite
       // case by defaulting to an empty list builder. But, this should not happen.
-      if not pending is .ok pending => {
+      if not pending is .some pending => {
         let pending = List.Builder(type (String) String)
       }
     } in client.case {
@@ -171,7 +171,7 @@ def ServeChat = [api] do {
           messages.entry(to)[pending]
           if {
             // If it exists, the user is logged in.
-            pending is .ok pending => {
+            pending is .some pending => {
               // Add the message to their pending messages.
               messages.put(pending.add((username) content))
               // Notify the client that the message was sent successfully.

--- a/tests/src/CoreModernization.par
+++ b/tests/src/CoreModernization.par
@@ -3,6 +3,8 @@ module CoreModernization
 import {
   @core/Bool
   @core/BoxMap
+  @core/Float
+  @core/Int
   @core/Json
   @core/List
   @core/Map
@@ -126,6 +128,16 @@ def TestBoxMapConstructors : [Test] ! = [test] do {
     .assert("BoxMap.New starts empty", empty.size == 0 and empty.list == {*()})
     .assert("BoxMap.put returns an updated map", inserted.get(KeyC) is .some value and value == "two")
     .assert("BoxMap.delete returns an updated map", deleted.get(KeyB) is .none!)
+} in !
+
+def TestNumberParsingOptions : [Test] ! = [test] do {
+  test
+    .assert("Int.FromString returns .some for valid integers", Int.FromString("-42") is .some n and n == -42)
+    .assert("Int.FromString returns .none! for invalid integers", Int.FromString("x") is .none!)
+    .assert("Nat.FromString returns .some for valid naturals", Nat.FromString("42") is .some n and n == 42)
+    .assert("Nat.FromString returns .none! for negative integers", Nat.FromString("-1") is .none!)
+    .assert("Float.FromString returns .some for valid floats", Float.FromString("1.5") is .some n and Float.Equals(n, 1.5, 0.0))
+    .assert("Float.FromString returns .none! for invalid floats", Float.FromString("x") is .none!)
 } in !
 
 def TestJsonEqualsWithoutListEquals : [Test] ! = [test] do {

--- a/tests/src/CoreModernization.par
+++ b/tests/src/CoreModernization.par
@@ -37,8 +37,8 @@ def MapPutList = [!] do {
   let map = Map.New(type Key, type String)
   map.entry(KeyA)[entry]
   entry.case {
-    .ok old => { map.put(old) },
-    .err! => { map.put("one") },
+    .some old => { map.put(old) },
+    .none! => { map.put("one") },
   }
   let entries = map.list
 } in entries
@@ -106,7 +106,7 @@ def TestMapConstructors : [Test] ! = [test] do {
   let (emptySize) emptyEntries = MapSizeThenList(empty)
 
   test
-    .assert("Map.FromList keeps the last duplicate key", entry is .ok value and value == "new")
+    .assert("Map.FromList keeps the last duplicate key", entry is .some value and value == "new")
     .assert("Map.FromList lists entries in data-key order", entries == {*((KeyB) "zero")})
     .assert("Map.New starts empty", emptySize == 0 and emptyEntries == {*()})
     .assert("Map.entry can insert into a new map", MapPutList(!) == {*((KeyA) "one")})
@@ -120,12 +120,12 @@ def TestBoxMapConstructors : [Test] ! = [test] do {
   let deleted = inserted.delete(KeyB)
 
   test
-    .assert("BoxMap.FromList keeps the last duplicate key", map.get(KeyA) is .ok value and value == "new")
-    .assert("BoxMap.FromList exposes plain values from get", map.get(KeyB) is .ok value and value == "zero")
+    .assert("BoxMap.FromList keeps the last duplicate key", map.get(KeyA) is .some value and value == "new")
+    .assert("BoxMap.FromList exposes plain values from get", map.get(KeyB) is .some value and value == "zero")
     .assert("BoxMap.FromList lists entries in data-key order", map.list == {*((KeyB) "zero", (KeyA) "new")})
     .assert("BoxMap.New starts empty", empty.size == 0 and empty.list == {*()})
-    .assert("BoxMap.put returns an updated map", inserted.get(KeyC) is .ok value and value == "two")
-    .assert("BoxMap.delete returns an updated map", deleted.get(KeyB) is .err!)
+    .assert("BoxMap.put returns an updated map", inserted.get(KeyC) is .some value and value == "two")
+    .assert("BoxMap.delete returns an updated map", deleted.get(KeyB) is .none!)
 } in !
 
 def TestJsonEqualsWithoutListEquals : [Test] ! = [test] do {


### PR DESCRIPTION
Switches `@core/Option` type to use `.some`/`.none` instead of `.ok`/`.err`. Update docs as well.