### PR TITLE
Fix broken code snippets in docs

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -15,4 +15,4 @@ mathjax-support = true
 edit-url-template = "https://github.com/par-team/par-lang/edit/main/docs/{path}"
 
 [output.html.code.hidelines]
-par = "?"
+par = "# "

--- a/docs/src/nondeterminism/fan_pattern.md
+++ b/docs/src/nondeterminism/fan_pattern.md
@@ -8,7 +8,7 @@ module Main
 import @core/List
 
 dec MergeTwoLists : <a>[List<a>] [List<a>] List<a>
-def MergeTwoLists = [left, right] poll(left, right) {
+def MergeTwoLists = <a>[left] [right] poll(left, right) {
   list => list.case {
     .end! => submit(),
     .item(x) xs => .item(x) submit(xs),

--- a/docs/src/nondeterminism/poll_submit.md
+++ b/docs/src/nondeterminism/poll_submit.md
@@ -82,7 +82,7 @@ dec PollSum : [List<Int>] Int
 def PollSum = [nums] poll(nums) {
   list => list.case {
     .end! => submit(),
-    .item(x) xs => x + submit(xs),
+    .item(x) xs => x + {submit(xs)},
   }
   else => 0,
 }
@@ -126,7 +126,7 @@ dec PollSumTwo : [List<Int>, List<Int>] Int
 def PollSumTwo = [nums1, nums2] poll(nums1, nums2) {
   list => list.case {
     .end! => submit(),
-    .item(x) xs => x + submit(xs),
+    .item(x) xs => x + {submit(xs)},
   }
   else => 0,
 }
@@ -152,7 +152,7 @@ The empty `submit()` in the `.end!` branch now makes sense! Just because one of 
 
 ```par
 dec MergeTwoLists : <a>[List<a>] [List<a>] List<a>
-def MergeTwoLists = [left, right] poll(left, right) {
+def MergeTwoLists = <a>[left] [right] poll(left, right) {
   list => list.case {
     .end! => submit(),
     .item(x) xs => .item(x) submit(xs),

--- a/docs/src/processes/chan_expression.md
+++ b/docs/src/processes/chan_expression.md
@@ -116,7 +116,8 @@ import {
 
 dec HashesOrNothing : [Nat] String
 def HashesOrNothing = [n] chan result {
-  {n == 0}.case {
+  let isZero = n == 0
+  isZero.case {
     .true! => {
       result <> "<nothing>"
     }
@@ -138,7 +139,7 @@ def HashesOrNothing = [n] chan result {
 
 Let’s break this down:
 
-- `n == 0` returns a `Bool`, which is an [`either`](../types/either.md) with branches
+- `n == 0` (aka `iszero`) returns a `Bool`, which is an [`either`](../types/either.md) with branches
   `.true!` and `.false!`.
 - In the `.true!` branch, we immediately perform a link — returning `"<nothing>"`. Note, that
   this _ends_ the process.

--- a/docs/src/quality_of_life/error_handling.md
+++ b/docs/src/quality_of_life/error_handling.md
@@ -296,7 +296,7 @@ This works for more complex command chains too. Consider this type for polling d
 ```par
 type Poll<e, a> = iterative choice {
   .close => Result<e, !>,
-  .poll => Result<e, (a) self>,
+  .next => Result<e, (a) self>,
 }
 ```
 
@@ -304,7 +304,7 @@ You can poll an element and handle errors seamlessly:
 
 ```par
 // source : Poll<Os.Error, String>
-source.poll.try[value]
+source.next.try[value]
 ```
 
 After this command, `source` maintains its `Poll<Os.Error, String>` type and value contains the successfully polled `String`.

--- a/docs/src/quality_of_life/error_handling.md
+++ b/docs/src/quality_of_life/error_handling.md
@@ -32,7 +32,7 @@ def Main: ! = chan exit {
   let console = Console.Open
 
   let path = Os.Path("logs.txt")
-  path.createOrAppendToFile.case {
+  Os.CreateOrAppendToFile(path).case {
     .err e => {
       console.print(e)
       console.close
@@ -104,7 +104,7 @@ def Main: ! = chan exit {
   let console = Console.Open
 
   let path = Os.Path("logs.txt")
-  path.createOrAppendToFile.case {
+  Os.CreateOrAppendToFile(path).case {
     .err e => {
       console.print(e)
       console.close
@@ -168,7 +168,7 @@ def Main: ! = chan exit {
   }
 
   let path = Os.Path("logs.txt")
-  let try writer = path.createOrAppendToFile
+  let try writer = Os.CreateOrAppendToFile(path)
   
   writer.write("[INFO] First new log\n").try
   writer.write("[INFO] Second new log\n").try
@@ -316,7 +316,7 @@ After this command, `source` maintains its `Poll<Os.Error, String>` type and val
 You might think this would work:
 
 ```par
-let writer = path.createOrAppendToFile.try
+let writer = Os.CreateOrAppendToFile(path).try
 ```
 
 However, this causes a type error. The reason reveals something fundamental about Par's evaluation model.
@@ -324,10 +324,10 @@ However, this causes a type error. The reason reveals something fundamental abou
 Par evaluates expressions concurrently with the processes that use them. When you write:
 
 ```par
-let writer = path.createOrAppendToFile.try
+let writer = Os.CreateOrAppendToFile(path).try
 ```
 
-The expression `path.createOrAppendToFile` runs concurrently with the process doing the `let`. If the expression were to fail on `.try`, the main process might already be executing other commands — there's no sound way to "rewind" that execution.
+The expression `Os.CreateOrAppendToFile(path)` runs concurrently with the process doing the `let`. If the expression were to fail on `.try`, the main process might already be executing other commands — there's no sound way to "rewind" that execution.
 
 This is why `try` and `throw` can only be used in the same process as their corresponding `catch`, not in nested expressions or processes.
 
@@ -336,13 +336,13 @@ This is why `try` and `throw` can only be used in the same process as their corr
 The solution is to use `try` in the pattern itself:
 
 ```par
-let try writer = path.createOrAppendToFile
+let try writer = Os.CreateOrAppendToFile(path)
 ```
 
 This moves the error handling into the correct process. The desugaring is:
 
 ```par
-let writer = path.createOrAppendToFile
+let writer = Os.CreateOrAppendToFile(path)
 writer.case {
   .err e => {
     throw e
@@ -516,10 +516,10 @@ def Main: ! = chan exit {
     exit!
   }
 
-  let try reader = Os.Path(src).openFile
+  let try reader = Os.OpenFile(Os.Path(src))
   catch@w e => { reader.close; throw e }
 
-  let try@w writer = Os.Path(dst).createOrReplaceFile
+  let try@w writer = Os.CreateOrReplaceFile(Os.Path(dst))
   catch@r e => { writer.close; throw e }
 
   reader.begin.read.try@r.case {
@@ -556,7 +556,7 @@ import {
 dec ReadAll : [Os.Path] Result<Os.Error, Bytes>
 def ReadAll = [path] chan return {
   catch e => { return <> .err e }
-  let try reader = path.openFile
+  let try reader = Os.OpenFile(path)
   let parser = Bytes.ParserFromReader(reader)
   let try contents = parser.remainder
   return <> .ok contents

--- a/docs/src/quality_of_life/pipes.md
+++ b/docs/src/quality_of_life/pipes.md
@@ -28,7 +28,7 @@ let result = Square(Add(3, Double(4)))  // = 196
 With pipes you can say the same thing in the order you want to read it:
 
 ```par
-let result = 3
+let result = {3}
   -> Add(Double(4))
   -> Square
 ```

--- a/docs/src/structure/let_expressions.md
+++ b/docs/src/structure/let_expressions.md
@@ -43,7 +43,7 @@ We'll learn more about those soon.
 > The annotation does not follow a variable. But this is good:
 >
 > ```par
-> let (a: Nat, b: Nat)! = (3, 4) in ...      // Okay.
+> let (a: Nat, b: Nat)! = (3, 4)! in ...      // Okay.
 > ```
 
 **Now, onto types and their expressions!**

--- a/docs/src/structure/primitive_types.md
+++ b/docs/src/structure/primitive_types.md
@@ -132,9 +132,12 @@ def No = .false!
 Boolean expressions use `and`, `or`, and `not`:
 
 ```par
-def Both = .true! and .false!
-def Either = .true! or .false!
-def Neither = not .true!
+def Yes : Bool = .true!
+def No : Bool = .false!
+
+def Both = Yes and No
+def Either = Yes or No
+def Neither = not Yes
 ```
 
 These same words have extra power in conditions: they short-circuit, and can carry bindings from
@@ -230,7 +233,10 @@ to loop a known number of times.
 ```par
 module Main
 
-import @core/Int
+import {
+  @core/Nat
+  @core/Int
+}
 
 def Absolute: Nat = Int.Abs(-12)
 def Modulo: Nat = Int.Mod(-13, 5)

--- a/docs/src/types/either.md
+++ b/docs/src/types/either.md
@@ -20,7 +20,7 @@ type StringOrNumber = either {
 }
 
 def Str: StringOrNumber = .string "Hello!"
-def Num: StringOrNumber = .number 42,
+def Num: StringOrNumber = .number 42
 ```
 
 An either type is spelled with the keyword `either`, followed by curly braces enclosing a

--- a/docs/src/types/forall.md
+++ b/docs/src/types/forall.md
@@ -3,7 +3,7 @@
 What about _generic_ functions? Or generic values?
 
 We already know about [generic types](../structure/definitions_and_declarations.md). For example, here's
-a typical optional type, as present in many languages:
+a typical optional type, as present in many languages and also supported by Par as built-in type:
 
 ```par
 type Option<a> = either {
@@ -24,6 +24,7 @@ module Main
 import {
   @core/Int
   @core/String
+  @core/Option
 }
 
 def None: Option<String> = .none!

--- a/docs/src/types/recursive.md
+++ b/docs/src/types/recursive.md
@@ -393,7 +393,7 @@ eventually reversing the whole list. In Haskell, this requires a helper recursiv
 In Par, it doesn't!
 
 ```par
-dec Reverse : [type a, List<Int>] List<Int>
+dec Reverse : [type a, List<a>] List<a>
 def Reverse = [type a, list]
   let acc: List<a> = .end!
   in list.begin.case {


### PR DESCRIPTION
The [Error Handling](https://par.run/book/quality_of_life/error_handling) chapter contained code that didn't compile because its `.poll` branch is now a keyword:

```
  × Syntax error
    ╭─[9:3]
  8 │   .close => Result<e, !>,
  9 │   .poll => Result<e, (a) self>,
    ·   ▲
 10 │ }
    ╰────
  help: invalid either/choice branches
        expected `}`
```

This is the only code I'm aware of that the new `poll` keyword breaks.

This PR updates the branch to avoid that keyword. I chose `.next` as its new name, which is consistent to `Sequence<a>` in the [Iterative](https://par.run/book/types/iterative) chapter.