### PR TITLE
If there's an error, only report that error

### DIFF
--- a/crates/par-core/src/frontend_impl/program.rs
+++ b/crates/par-core/src/frontend_impl/program.rs
@@ -1,7 +1,7 @@
-use std::{collections::HashMap, sync::Arc};
+use std::{collections::HashMap, fmt::Debug, sync::Arc};
 
 use arcstr::ArcStr;
-use indexmap::{IndexMap, IndexSet};
+use indexmap::IndexMap;
 
 use crate::location::{FileName, Point, Span, Spanning};
 
@@ -237,19 +237,11 @@ impl<S: Clone> Module<Arc<process::Expression<(), S>>, S> {
     where
         S: Eq + std::hash::Hash,
     {
-        let mut errors: IndexSet<TypeError<S>> = IndexSet::new();
-
-        let type_defs = match TypeDefs::new_with_validation(
+        let (type_defs, mut errors) = TypeDefs::new_with_validation(
             self.type_defs
                 .iter()
                 .map(|d| (&d.span, &d.name, &d.params, &d.typ)),
-        ) {
-            Ok(td) => td,
-            Err(e) => {
-                errors.insert(e);
-                TypeDefs::default()
-            }
-        };
+        );
 
         let mut unchecked_definitions = IndexMap::new();
         for Definition { span, name, body } in &self.definitions {

--- a/crates/par-core/src/frontend_impl/types/definitions.rs
+++ b/crates/par-core/src/frontend_impl/types/definitions.rs
@@ -30,16 +30,17 @@ impl<S: Clone + Eq + std::hash::Hash> TypeDefs<S> {
                 &'a Type<S>,
             ),
         >,
-    ) -> Result<Self, TypeError<S>>
+    ) -> (Self, IndexSet<TypeError<S>>)
     where
         S: 'a,
     {
         let mut globals_map = IndexMap::new();
+        let mut errors = IndexSet::new();
         for (span, name, params, typ) in globals {
             if let Some((span1, _, _)) =
                 globals_map.insert(name.clone(), (span.clone(), params.clone(), typ.clone()))
             {
-                return Err(TypeError::TypeNameAlreadyDefined(
+                errors.insert(TypeError::TypeNameAlreadyDefined(
                     span.clone(),
                     span1.clone(),
                     name.clone(),
@@ -58,16 +59,20 @@ impl<S: Clone + Eq + std::hash::Hash> TypeDefs<S> {
         }
 
         for (name, _) in type_defs.globals.iter() {
-            type_defs.validate_acyclic(name, &Default::default(), &deps_map)?
+            if let Err(e) = type_defs.validate_acyclic(name, &Default::default(), &deps_map) {
+                errors.insert(e);
+            }
         }
 
         for (_, (_, params, typ)) in type_defs.globals.iter() {
             let mut type_defs = type_defs.clone();
             type_defs.extend_vars(params.iter().cloned());
-            type_defs.validate_type(typ)?;
+            if let Err(e) = type_defs.validate_type(typ) {
+                errors.insert(e);
+            }
         }
 
-        Ok(type_defs)
+        (type_defs, errors)
     }
 
     pub fn get(

--- a/crates/par-core/src/frontend_impl/types/tests.rs
+++ b/crates/par-core/src/frontend_impl/types/tests.rs
@@ -57,8 +57,9 @@ mod tests {
             ]),
         );
         let params = vec![TypeParameter::any(key), TypeParameter::any(value)];
-        let defs = TypeDefs::new_with_validation([(&span, &map_name, &params, &body)].into_iter())
-            .unwrap();
+        let (defs, errors) =
+            TypeDefs::new_with_validation([(&span, &map_name, &params, &body)].into_iter());
+        assert!(errors.is_empty(), "errors: {errors:?}");
         (defs, map_name)
     }
 


### PR DESCRIPTION
Previously, if you typoed one name, every single identifier in the workspace would be marked as an error. Now, instead of throwing away the `TypeDefs` if there's an error in `TypeDefs::new_with_validation`, we keep it and just report the errors in addition.