### PR TITLE
Improve dev experience for builtin packages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2260,7 +2260,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3087,6 +3087,7 @@ dependencies = [
  "miette",
  "par-builtin",
  "par-core",
+ "par-runtime",
  "pathdiff",
  "percent-encoding",
  "pulldown-cmark",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -271,6 +271,9 @@ name = "arcstr"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03918c3dbd7701a85c6b9887732e2921175f26c350b4563841d0958c21d57e6d"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "arrayref"

--- a/crates/par-builtin/packages/basic/Par.toml
+++ b/crates/par-builtin/packages/basic/Par.toml
@@ -1,2 +1,6 @@
 [package]
 name = "basic"
+__builtin = true
+
+[dependencies]
+core = "../core"

--- a/crates/par-builtin/packages/core/Par.toml
+++ b/crates/par-builtin/packages/core/Par.toml
@@ -1,2 +1,3 @@
 [package]
 name = "core"
+__builtin = true

--- a/crates/par-builtin/src/builtin.rs
+++ b/crates/par-builtin/src/builtin.rs
@@ -26,40 +26,42 @@ use std::collections::{BTreeMap, btree_map::Entry};
 use std::env;
 use std::path::PathBuf;
 
-use arcstr::literal;
 use par_core::frontend::language::PackageId;
 use par_core::frontend::{TypeDef, get_external_type_defs};
 use par_core::source::FileName;
 use par_core::workspace::{
-    ExternalModule, LoadedPackageFile, ModulePath, WorkspacePackage, parse_loaded_files,
+    ExternalModule, LoadedPackageFile, ModulePath, WorkspaceDiscoveryError, WorkspacePackage,
+    WorkspacePackages, parse_loaded_files,
 };
+use par_runtime::registry::BuiltinPackage;
 use par_runtime::registry::PackageRef;
 
-pub fn builtin_packages() -> Vec<WorkspacePackage> {
-    let mut packages = Vec::new();
+pub fn builtin_packages() -> impl Iterator<Item = WorkspacePackage> {
     // skip if NOSTD is set.
-    if env::var("NOSTD").ok().is_none() {
-        packages.push(core_package());
-
-        #[cfg(not(target_family = "wasm"))]
-        packages.push(basic_package());
-    }
-
-    packages
+    let enable_builtins = env::var("NOSTD").ok().is_none();
+    let packages = enable_builtins.then(|| {
+        [
+            core_package(),
+            #[cfg(not(target_family = "wasm"))]
+            basic_package(),
+        ]
+    });
+    packages.into_iter().flatten()
 }
 
 fn core_package() -> WorkspacePackage {
     let parsed = parse_builtin_sources("core", CORE_SOURCE_FILES);
-    let externals = load_external_type_defs("core");
-    WorkspacePackage::new(PackageId::Special(literal!("core")), parsed).with_externals(externals)
+    let externals = load_external_type_defs(BuiltinPackage::Core);
+    WorkspacePackage::new(PackageId::Builtin(BuiltinPackage::Core), parsed)
+        .with_externals(externals)
 }
 
 #[cfg(not(target_family = "wasm"))]
 fn basic_package() -> WorkspacePackage {
     let parsed = parse_builtin_sources("basic", BASIC_SOURCE_FILES);
-    let externals = load_external_type_defs("basic");
-    WorkspacePackage::new(PackageId::Special(literal!("basic")), parsed)
-        .with_dependency("core", PackageId::Special(literal!("core")))
+    let externals = load_external_type_defs(BuiltinPackage::Basic);
+    WorkspacePackage::new(PackageId::Builtin(BuiltinPackage::Basic), parsed)
+        .with_dependency("core", PackageId::Builtin(BuiltinPackage::Core))
         .with_externals(externals)
 }
 
@@ -196,9 +198,9 @@ fn parse_builtin_sources(
     parse_loaded_files(files).expect("embedded builtin package should parse")
 }
 
-fn load_external_type_defs(name: &str) -> BTreeMap<ModulePath, ExternalModule> {
+fn load_external_type_defs(name: BuiltinPackage) -> BTreeMap<ModulePath, ExternalModule> {
     let mut externals = BTreeMap::<ModulePath, ExternalModule>::new();
-    for type_def in get_external_type_defs(&PackageRef::Special(name)) {
+    for type_def in get_external_type_defs(PackageRef::Builtin(name)) {
         let module_path = ModulePath {
             directories: type_def.path.path.iter().map(|s| s.to_string()).collect(),
             module: type_def.path.module.into(),
@@ -223,4 +225,34 @@ fn load_external_type_defs(name: &str) -> BTreeMap<ModulePath, ExternalModule> {
         }
     }
     externals
+}
+
+pub fn inject_builtin_packages(
+    workspace_packages: &mut WorkspacePackages,
+) -> Result<(), WorkspaceDiscoveryError> {
+    for package in &mut workspace_packages.packages {
+        if let PackageId::Builtin(name) = package.id {
+            package.externals = load_external_type_defs(name);
+            continue;
+        }
+
+        for &builtin in BuiltinPackage::ALL {
+            match package.dependencies.entry(builtin.to_string()) {
+                Entry::Vacant(v) => {
+                    v.insert(PackageId::Builtin(builtin));
+                }
+                Entry::Occupied(_) => {
+                    return Err(WorkspaceDiscoveryError::DependencyAliasCollision {
+                        package: package.id.clone(),
+                        alias: builtin.to_string(),
+                    });
+                }
+            }
+        }
+    }
+
+    if !matches!(workspace_packages.root_package, PackageId::Builtin(_)) {
+        workspace_packages.packages.extend(builtin_packages());
+    }
+    Ok(())
 }

--- a/crates/par-builtin/src/builtin.rs
+++ b/crates/par-builtin/src/builtin.rs
@@ -26,14 +26,13 @@ use std::collections::{BTreeMap, btree_map::Entry};
 use std::env;
 use std::path::PathBuf;
 
-use par_core::frontend::language::PackageId;
 use par_core::frontend::{TypeDef, get_external_type_defs};
 use par_core::source::FileName;
 use par_core::workspace::{
     ExternalModule, LoadedPackageFile, ModulePath, WorkspaceDiscoveryError, WorkspacePackage,
     WorkspacePackages, parse_loaded_files,
 };
-use par_runtime::registry::BuiltinPackage;
+use par_runtime::pkgid::{BuiltinPackage, PackageId};
 use par_runtime::registry::PackageRef;
 
 pub fn builtin_packages() -> impl Iterator<Item = WorkspacePackage> {

--- a/crates/par-builtin/src/builtin/bench.rs
+++ b/crates/par-builtin/src/builtin/bench.rs
@@ -4,7 +4,7 @@ use par_runtime::registry::{DefinitionRef, ExternalDef, PackageRef};
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Bench",
         name: "BlackBox"

--- a/crates/par-builtin/src/builtin/boxmap.rs
+++ b/crates/par-builtin/src/builtin/boxmap.rs
@@ -11,7 +11,7 @@ use par_runtime::registry::{DefinitionRef, ExternalDef, PackageRef};
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "BoxMap",
         name: "New"
@@ -21,7 +21,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "BoxMap",
         name: "FromList"

--- a/crates/par-builtin/src/builtin/byte.rs
+++ b/crates/par-builtin/src/builtin/byte.rs
@@ -8,7 +8,7 @@ use par_runtime::registry::{DefinitionRef, ExternalDef, PackageRef};
 
 inventory::submit!(ExternalTypeDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Byte",
         name: "Byte"
@@ -18,7 +18,7 @@ inventory::submit!(ExternalTypeDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Byte",
         name: "Code"
@@ -28,7 +28,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Byte",
         name: "Is"

--- a/crates/par-builtin/src/builtin/bytes.rs
+++ b/crates/par-builtin/src/builtin/bytes.rs
@@ -24,7 +24,7 @@ use par_runtime::registry::{DefinitionRef, ExternalDef, PackageRef};
 
 inventory::submit!(ExternalTypeDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Bytes",
         name: "Bytes"
@@ -34,7 +34,7 @@ inventory::submit!(ExternalTypeDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Bytes",
         name: "Builder"
@@ -44,7 +44,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Bytes",
         name: "Parser"
@@ -54,7 +54,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Bytes",
         name: "ParserFromReader"
@@ -64,7 +64,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Bytes",
         name: "Reader"
@@ -74,7 +74,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Bytes",
         name: "EmptyReader"
@@ -84,7 +84,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Bytes",
         name: "PipeReader"
@@ -94,7 +94,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Bytes",
         name: "Length"

--- a/crates/par-builtin/src/builtin/char_.rs
+++ b/crates/par-builtin/src/builtin/char_.rs
@@ -8,7 +8,7 @@ use par_runtime::registry::{DefinitionRef, ExternalDef, PackageRef};
 
 inventory::submit!(ExternalTypeDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Char",
         name: "Char"
@@ -18,7 +18,7 @@ inventory::submit!(ExternalTypeDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Char",
         name: "Code"
@@ -28,7 +28,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Char",
         name: "Is"

--- a/crates/par-builtin/src/builtin/console.rs
+++ b/crates/par-builtin/src/builtin/console.rs
@@ -49,7 +49,7 @@ async fn console_open(mut handle: Handle) {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("basic"),
+        package: PackageRef::BASIC,
         path: &[],
         module: "Console",
         name: "Open"

--- a/crates/par-builtin/src/builtin/data.rs
+++ b/crates/par-builtin/src/builtin/data.rs
@@ -5,7 +5,7 @@ use par_runtime::registry::{DefinitionRef, ExternalDef, PackageRef};
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Data",
         name: "ToString"
@@ -15,7 +15,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Data",
         name: "Compare"

--- a/crates/par-builtin/src/builtin/debug.rs
+++ b/crates/par-builtin/src/builtin/debug.rs
@@ -9,7 +9,7 @@ async fn debug_log(mut handle: Handle) {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Debug",
         name: "Log"

--- a/crates/par-builtin/src/builtin/float.rs
+++ b/crates/par-builtin/src/builtin/float.rs
@@ -12,7 +12,7 @@ use par_runtime::registry::{DefinitionRef, ExternalDef, PackageRef};
 
 inventory::submit!(ExternalTypeDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Float",
         name: "Float"
@@ -22,7 +22,7 @@ inventory::submit!(ExternalTypeDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Float",
         name: "NaN_"
@@ -32,7 +32,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Float",
         name: "Inf_"
@@ -42,7 +42,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Float",
         name: "NegInf_"
@@ -52,7 +52,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Float",
         name: "Pi_"
@@ -62,7 +62,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Float",
         name: "E_"
@@ -72,7 +72,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Float",
         name: "IsNaN"
@@ -82,7 +82,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Float",
         name: "IsFinite"
@@ -92,7 +92,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Float",
         name: "IsInfinite"
@@ -102,7 +102,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Float",
         name: "FromInt"
@@ -112,7 +112,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Float",
         name: "ToInt"
@@ -122,7 +122,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Float",
         name: "FromString"
@@ -132,7 +132,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Float",
         name: "Neg"
@@ -142,7 +142,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Float",
         name: "Abs"
@@ -152,7 +152,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Float",
         name: "Floor"
@@ -162,7 +162,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Float",
         name: "Ceil"
@@ -172,7 +172,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Float",
         name: "Round"
@@ -182,7 +182,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Float",
         name: "Pow"
@@ -192,7 +192,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Float",
         name: "Min"
@@ -202,7 +202,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Float",
         name: "Max"
@@ -212,7 +212,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Float",
         name: "Clamp"
@@ -222,7 +222,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Float",
         name: "Equals"
@@ -232,7 +232,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Float",
         name: "Sqrt"
@@ -242,7 +242,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Float",
         name: "Exp"
@@ -252,7 +252,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Float",
         name: "Ln"
@@ -262,7 +262,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Float",
         name: "Sin"
@@ -272,7 +272,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Float",
         name: "Cos"
@@ -282,7 +282,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Float",
         name: "Tan"
@@ -292,7 +292,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Float",
         name: "Atan2"

--- a/crates/par-builtin/src/builtin/http.rs
+++ b/crates/par-builtin/src/builtin/http.rs
@@ -36,7 +36,7 @@ use par_runtime::registry::{DefinitionRef, ExternalDef, PackageRef};
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("basic"),
+        package: PackageRef::BASIC,
         path: &[],
         module: "Http",
         name: "Fetch"
@@ -46,7 +46,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("basic"),
+        package: PackageRef::BASIC,
         path: &[],
         module: "Http",
         name: "Listen"

--- a/crates/par-builtin/src/builtin/int.rs
+++ b/crates/par-builtin/src/builtin/int.rs
@@ -9,7 +9,7 @@ use par_runtime::registry::{DefinitionRef, ExternalDef, PackageRef};
 
 inventory::submit!(ExternalTypeDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Int",
         name: "Int"
@@ -19,7 +19,7 @@ inventory::submit!(ExternalTypeDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Int",
         name: "Mod"
@@ -29,7 +29,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Int",
         name: "Min"
@@ -39,7 +39,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Int",
         name: "Max"
@@ -49,7 +49,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Int",
         name: "Abs"
@@ -59,7 +59,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Int",
         name: "Clamp"
@@ -69,7 +69,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Int",
         name: "Range"
@@ -79,7 +79,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Int",
         name: "FromString"

--- a/crates/par-builtin/src/builtin/json.rs
+++ b/crates/par-builtin/src/builtin/json.rs
@@ -10,7 +10,7 @@ use serde_json::{Map, Number, Value};
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Json",
         name: "Encode"
@@ -20,7 +20,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Json",
         name: "Decode"

--- a/crates/par-builtin/src/builtin/list.rs
+++ b/crates/par-builtin/src/builtin/list.rs
@@ -6,7 +6,7 @@ use std::future::Future;
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "List",
         name: "Sort"
@@ -16,7 +16,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "List",
         name: "SortDesc"
@@ -26,7 +26,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "List",
         name: "SortBy"
@@ -36,7 +36,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "List",
         name: "SortDescBy"
@@ -46,7 +46,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "List",
         name: "SortLinearBy"
@@ -56,7 +56,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "List",
         name: "SortLinearDescBy"

--- a/crates/par-builtin/src/builtin/map.rs
+++ b/crates/par-builtin/src/builtin/map.rs
@@ -8,7 +8,7 @@ use par_runtime::registry::{DefinitionRef, ExternalDef, PackageRef};
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Map",
         name: "New"
@@ -18,7 +18,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Map",
         name: "FromList"

--- a/crates/par-builtin/src/builtin/nat.rs
+++ b/crates/par-builtin/src/builtin/nat.rs
@@ -11,7 +11,7 @@ use par_runtime::registry::{DefinitionRef, ExternalDef, PackageRef};
 
 inventory::submit!(ExternalTypeDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Nat",
         name: "Nat"
@@ -21,7 +21,7 @@ inventory::submit!(ExternalTypeDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Nat",
         name: "Mod"
@@ -31,7 +31,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Nat",
         name: "Min"
@@ -41,7 +41,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Nat",
         name: "Max"
@@ -51,7 +51,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Nat",
         name: "Clamp"
@@ -61,7 +61,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Nat",
         name: "Repeat"
@@ -71,7 +71,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Nat",
         name: "RepeatLazy"
@@ -81,7 +81,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Nat",
         name: "Range"
@@ -91,7 +91,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Nat",
         name: "FromString"

--- a/crates/par-builtin/src/builtin/number.rs
+++ b/crates/par-builtin/src/builtin/number.rs
@@ -6,7 +6,7 @@ use par_runtime::registry::{DefinitionRef, ExternalDef, PackageRef};
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Number",
         name: "Zero_"
@@ -16,7 +16,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Number",
         name: "Add"
@@ -26,7 +26,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Number",
         name: "Sub"
@@ -36,7 +36,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Number",
         name: "Mul"
@@ -46,7 +46,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Number",
         name: "Div"
@@ -56,7 +56,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Number",
         name: "Neg"

--- a/crates/par-builtin/src/builtin/os.rs
+++ b/crates/par-builtin/src/builtin/os.rs
@@ -18,7 +18,7 @@ use tokio::{
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("basic"),
+        package: PackageRef::BASIC,
         path: &[],
         module: "Os",
         name: "Path"
@@ -28,7 +28,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("basic"),
+        package: PackageRef::BASIC,
         path: &[],
         module: "Os",
         name: "Stdin"
@@ -38,7 +38,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("basic"),
+        package: PackageRef::BASIC,
         path: &[],
         module: "Os",
         name: "Stdout"
@@ -48,7 +48,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("basic"),
+        package: PackageRef::BASIC,
         path: &[],
         module: "Os",
         name: "Stderr"
@@ -58,7 +58,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("basic"),
+        package: PackageRef::BASIC,
         path: &[],
         module: "Os",
         name: "OpenFile"
@@ -68,7 +68,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("basic"),
+        package: PackageRef::BASIC,
         path: &[],
         module: "Os",
         name: "CreateOrReplaceFile"
@@ -78,7 +78,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("basic"),
+        package: PackageRef::BASIC,
         path: &[],
         module: "Os",
         name: "CreateNewFile"
@@ -88,7 +88,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("basic"),
+        package: PackageRef::BASIC,
         path: &[],
         module: "Os",
         name: "AppendToFile"
@@ -98,7 +98,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("basic"),
+        package: PackageRef::BASIC,
         path: &[],
         module: "Os",
         name: "CreateOrAppendToFile"
@@ -108,7 +108,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("basic"),
+        package: PackageRef::BASIC,
         path: &[],
         module: "Os",
         name: "CreateDir"
@@ -118,7 +118,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("basic"),
+        package: PackageRef::BASIC,
         path: &[],
         module: "Os",
         name: "ListDir"
@@ -128,7 +128,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("basic"),
+        package: PackageRef::BASIC,
         path: &[],
         module: "Os",
         name: "TraverseDir"
@@ -138,7 +138,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("basic"),
+        package: PackageRef::BASIC,
         path: &[],
         module: "Os",
         name: "Env"

--- a/crates/par-builtin/src/builtin/string.rs
+++ b/crates/par-builtin/src/builtin/string.rs
@@ -16,7 +16,7 @@ use par_runtime::registry::{DefinitionRef, ExternalDef, PackageRef};
 
 inventory::submit!(ExternalTypeDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "String",
         name: "String"
@@ -26,7 +26,7 @@ inventory::submit!(ExternalTypeDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "String",
         name: "Builder"
@@ -36,7 +36,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "String",
         name: "Parser"
@@ -46,7 +46,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "String",
         name: "ParserFromReader"
@@ -56,7 +56,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "String",
         name: "Quote"
@@ -66,7 +66,7 @@ inventory::submit!(ExternalDef {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "String",
         name: "FromBytes"

--- a/crates/par-builtin/src/builtin/time.rs
+++ b/crates/par-builtin/src/builtin/time.rs
@@ -14,7 +14,7 @@ async fn time_now(mut handle: Handle) {
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("basic"),
+        package: PackageRef::BASIC,
         path: &[],
         module: "Time",
         name: "Now"

--- a/crates/par-builtin/src/builtin/url.rs
+++ b/crates/par-builtin/src/builtin/url.rs
@@ -8,7 +8,7 @@ use par_runtime::registry::{DefinitionRef, ExternalDef, PackageRef};
 
 inventory::submit!(ExternalDef {
     path: DefinitionRef {
-        package: PackageRef::Special("core"),
+        package: PackageRef::CORE,
         path: &[],
         module: "Url",
         name: "FromString"

--- a/crates/par-builtin/src/lib.rs
+++ b/crates/par-builtin/src/lib.rs
@@ -2,4 +2,4 @@
 
 mod builtin;
 
-pub use builtin::builtin_packages;
+pub use builtin::{builtin_packages, inject_builtin_packages};

--- a/crates/par-core/src/backend/flat/transpiler.rs
+++ b/crates/par-core/src/backend/flat/transpiler.rs
@@ -16,10 +16,10 @@ use par_runtime::flat::runtime::{
     ExternalArc, GlobalCont, GlobalValue, Package, PackageBody, PackagePtr,
 };
 
-use crate::frontend::language::PackageId;
 use crate::runtime_impl::tree::Net;
 use par_runtime::flat::runtime::Global;
 use par_runtime::linker::{Artifact, LinkError, Linked, Unlinked, link_arena, link_package_ptr};
+use par_runtime::pkgid::PackageId;
 
 #[derive(Default)]
 pub(crate) struct NetTranspiler {

--- a/crates/par-core/src/backend/tree/compiler.rs
+++ b/crates/par-core/src/backend/tree/compiler.rs
@@ -4,7 +4,6 @@ use std::{
     sync::Arc,
 };
 
-use crate::frontend::language::PackageId;
 use crate::frontend_impl::process::VariableUsage;
 use crate::frontend_impl::program::DefinitionBody;
 use crate::frontend_impl::types::core::get_primitive_type;
@@ -24,7 +23,7 @@ use crate::{
 use arcstr::ArcStr;
 use indexmap::{IndexMap, IndexSet};
 use par_runtime::fan_behavior::FanBehavior;
-use par_runtime::linker::{PackageID, Unlinked};
+use par_runtime::linker::Unlinked;
 use par_runtime::poll::POLL_TOKEN;
 use std::hash::Hash;
 
@@ -325,12 +324,7 @@ impl Compiler {
                 DefinitionBody::Par(expr) => expr,
                 DefinitionBody::External(_) => {
                     let def_ref = Unlinked {
-                        package: match &name.module.package {
-                            PackageId::Builtin(pkg) => PackageID::Builtin(*pkg),
-                            PackageId::Special(name) => PackageID::Special(name.to_string()),
-                            PackageId::Local(name) => PackageID::Local(name.to_string()),
-                            PackageId::Remote(name) => PackageID::Remote(name.to_string()),
-                        },
+                        package: name.module.package.clone(),
                         path: name.module.directories.clone(),
                         module: name.module.module.clone(),
                         name: name.primary.clone(),

--- a/crates/par-core/src/backend/tree/compiler.rs
+++ b/crates/par-core/src/backend/tree/compiler.rs
@@ -259,7 +259,7 @@ struct PollInfo {
 }
 
 fn poll_token_tree() -> Tree<Unlinked> {
-    Tree::External(POLL_TOKEN.clone().into())
+    Tree::External(POLL_TOKEN.into())
 }
 
 impl Tree<Unlinked> {
@@ -326,6 +326,7 @@ impl Compiler {
                 DefinitionBody::External(_) => {
                     let def_ref = Unlinked {
                         package: match &name.module.package {
+                            PackageId::Builtin(pkg) => PackageID::Builtin(*pkg),
                             PackageId::Special(name) => PackageID::Special(name.to_string()),
                             PackageId::Local(name) => PackageID::Local(name.to_string()),
                             PackageId::Remote(name) => PackageID::Remote(name.to_string()),

--- a/crates/par-core/src/frontend_impl/language.rs
+++ b/crates/par-core/src/frontend_impl/language.rs
@@ -17,10 +17,8 @@ use crate::{
     location::{Span, Spanning},
 };
 use arcstr::{ArcStr, literal};
-use par_runtime::{
-    primitive::{ParString, Primitive},
-    registry::BuiltinPackage,
-};
+use par_runtime::pkgid::PackageId;
+use par_runtime::primitive::{ParString, Primitive};
 
 #[derive(Clone, Debug)]
 pub struct LocalName {
@@ -144,14 +142,6 @@ pub enum Resolved {
         module: String,
     },
     BuiltinOperator(BuiltinOperatorModule),
-}
-
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub enum PackageId {
-    Builtin(BuiltinPackage),
-    Special(ArcStr),
-    Local(ArcStr),
-    Remote(ArcStr),
 }
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -678,12 +668,10 @@ impl Display for Unresolved {
 
 impl Display for Universal {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match &self.package {
-            PackageId::Builtin(name) => write!(f, "@{name}")?,
-            PackageId::Special(name) => write!(f, "@{name}")?,
-            PackageId::Local(name) | PackageId::Remote(name) => {
-                write!(f, "\"{name}\"")?;
-            }
+        if self.package.is_regular() {
+            write!(f, "\"{}\"", self.package.name())?;
+        } else {
+            write!(f, "@{}", self.package.name())?;
         }
 
         write!(f, "/")?;
@@ -691,17 +679,6 @@ impl Display for Universal {
             write!(f, "{}", self.module)
         } else {
             write!(f, "{}/{}", self.directories.join("/"), self.module)
-        }
-    }
-}
-
-impl Display for PackageId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            PackageId::Builtin(name) => write!(f, "@{name}"),
-            PackageId::Special(name) | PackageId::Local(name) | PackageId::Remote(name) => {
-                write!(f, "@{name}")
-            }
         }
     }
 }

--- a/crates/par-core/src/frontend_impl/language.rs
+++ b/crates/par-core/src/frontend_impl/language.rs
@@ -17,7 +17,10 @@ use crate::{
     location::{Span, Spanning},
 };
 use arcstr::{ArcStr, literal};
-use par_runtime::primitive::{ParString, Primitive};
+use par_runtime::{
+    primitive::{ParString, Primitive},
+    registry::BuiltinPackage,
+};
 
 #[derive(Clone, Debug)]
 pub struct LocalName {
@@ -145,6 +148,7 @@ pub enum Resolved {
 
 #[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum PackageId {
+    Builtin(BuiltinPackage),
     Special(ArcStr),
     Local(ArcStr),
     Remote(ArcStr),
@@ -675,6 +679,7 @@ impl Display for Unresolved {
 impl Display for Universal {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match &self.package {
+            PackageId::Builtin(name) => write!(f, "@{name}")?,
             PackageId::Special(name) => write!(f, "@{name}")?,
             PackageId::Local(name) | PackageId::Remote(name) => {
                 write!(f, "\"{name}\"")?;
@@ -693,6 +698,7 @@ impl Display for Universal {
 impl Display for PackageId {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            PackageId::Builtin(name) => write!(f, "@{name}"),
             PackageId::Special(name) | PackageId::Local(name) | PackageId::Remote(name) => {
                 write!(f, "@{name}")
             }

--- a/crates/par-core/src/frontend_impl/types/registry.rs
+++ b/crates/par-core/src/frontend_impl/types/registry.rs
@@ -3,6 +3,8 @@ use crate::frontend::language::Unresolved;
 use par_runtime::registry::{DefinitionRef, PackageRef};
 use std::collections::HashMap;
 use std::sync::LazyLock;
+
+#[derive(Clone)]
 pub struct ExternalTypeDef {
     pub path: DefinitionRef<'static>,
     pub typ: Type<Unresolved>,
@@ -10,29 +12,18 @@ pub struct ExternalTypeDef {
 
 inventory::collect!(ExternalTypeDef);
 
-static REGISTRY: LazyLock<HashMap<PackageRef, HashMap<DefinitionRef, Type<Unresolved>>>> =
-    LazyLock::new(|| {
-        let mut map = HashMap::new();
-        for def in inventory::iter::<ExternalTypeDef> {
-            if !map.contains_key(&def.path.package) {
-                map.insert(def.path.package.clone(), HashMap::new());
-            }
-            map.get_mut(&def.path.package)
-                .unwrap()
-                .insert(def.path.clone(), def.typ.clone());
-        }
-        map
-    });
+type Registry = HashMap<PackageRef<'static>, Vec<&'static ExternalTypeDef>>;
 
-pub fn get_external_type_defs(package: &PackageRef) -> Vec<ExternalTypeDef> {
-    if let Some(map) = REGISTRY.get(package) {
-        map.iter()
-            .map(|(path, typ)| ExternalTypeDef {
-                path: path.clone(),
-                typ: typ.clone(),
-            })
-            .collect()
-    } else {
-        Vec::new()
+static REGISTRY: LazyLock<Registry> = LazyLock::new(|| {
+    let mut map: Registry = HashMap::new();
+    for def in inventory::iter::<ExternalTypeDef> {
+        map.entry(def.path.package).or_default().push(def);
     }
+    map
+});
+
+pub fn get_external_type_defs(
+    package: PackageRef,
+) -> impl Iterator<Item = &'static ExternalTypeDef> {
+    REGISTRY.get(&package).into_iter().flatten().copied()
 }

--- a/crates/par-core/src/frontend_impl/types/tests.rs
+++ b/crates/par-core/src/frontend_impl/types/tests.rs
@@ -1,13 +1,14 @@
 #[cfg(test)]
 mod tests {
     use crate::frontend_impl::language::{
-        GlobalName, LocalName, PackageId, TypeConstraint, TypeParameter, Universal,
+        GlobalName, LocalName, TypeConstraint, TypeParameter, Universal,
     };
     use crate::frontend_impl::types::implicit::infer_holes;
     use crate::frontend_impl::types::{GlobalNameWriter, Type, TypeDefs, TypeError};
     use crate::location::Span;
     use crate::workspace::render_type_in_scope;
     use arcstr::{ArcStr, literal};
+    use par_runtime::pkgid::PackageId;
     use std::fmt::{self, Write};
 
     struct TestNameWriter;

--- a/crates/par-core/src/workspace.rs
+++ b/crates/par-core/src/workspace.rs
@@ -1,8 +1,8 @@
 use crate::frontend::lower;
 use crate::frontend::parse_source_file;
 use crate::frontend_impl::language::{
-    BuiltinOperatorModule, CompileError, GlobalName, PackageId, Resolved, ResolvedPackageRef,
-    TypeParameter, Universal, Unresolved,
+    BuiltinOperatorModule, CompileError, GlobalName, Resolved, ResolvedPackageRef, TypeParameter,
+    Universal, Unresolved,
 };
 use crate::frontend_impl::parse::SyntaxError;
 use crate::frontend_impl::process;
@@ -19,7 +19,7 @@ use crate::runtime_impl::{Compiled, RuntimeCompilerError};
 use arcstr::ArcStr;
 use indexmap::{IndexMap, IndexSet};
 use par_runtime::linker::Unlinked;
-use par_runtime::registry::BuiltinPackage;
+use par_runtime::pkgid::{BuiltinPackage, PackageId};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet, HashMap, btree_map::Entry};
 use std::fmt::{self, Display, Formatter, Write};
@@ -1517,7 +1517,7 @@ impl PackageGraph {
         let root_package = discovery.discover(
             layout,
             root_dir.clone(),
-            PackageId::from_local_path(&root_dir)?,
+            package_id_from_local_path(&root_dir)?,
         )?;
         Ok(discovery.finish(root_package))
     }
@@ -1562,17 +1562,15 @@ fn normalized_package_path(path: &Path) -> String {
     path.to_string_lossy().replace('\\', "/")
 }
 
-impl PackageId {
-    pub fn from_local_path(path: &Path) -> Result<Self, WorkspaceDiscoveryError> {
-        let canonical = canonicalize_path(path)?;
-        Ok(Self::Local(ArcStr::from(normalized_package_path(
-            &canonical,
-        ))))
-    }
+pub fn package_id_from_local_path(path: &Path) -> Result<PackageId, WorkspaceDiscoveryError> {
+    let canonical = canonicalize_path(path)?;
+    Ok(PackageId::Local(ArcStr::from(normalized_package_path(
+        &canonical,
+    ))))
+}
 
-    pub fn from_remote_source(source: &RemoteDependencySource) -> Self {
-        Self::Remote(ArcStr::from(source.as_str()))
-    }
+pub fn package_id_from_remote_source(source: &RemoteDependencySource) -> PackageId {
+    PackageId::Remote(ArcStr::from(source.as_str()))
 }
 
 fn normalized_path_key(path: &Path) -> String {
@@ -1693,7 +1691,7 @@ impl<'a, H: MissingRemotePackageHandler> PackageGraphDiscovery<'a, H> {
                     let dependency_id = self.discover(
                         dependency_layout,
                         dependency_root.clone(),
-                        PackageId::from_local_path(&dependency_root)?,
+                        package_id_from_local_path(&dependency_root)?,
                     )?;
                     dependencies.insert(alias.clone(), dependency_id);
                 }
@@ -1733,7 +1731,7 @@ impl<'a, H: MissingRemotePackageHandler> PackageGraphDiscovery<'a, H> {
                     let dependency_id = self.discover(
                         dependency_layout,
                         dependency_root,
-                        PackageId::from_remote_source(dependency),
+                        package_id_from_remote_source(dependency),
                     )?;
                     dependencies.insert(alias.clone(), dependency_id);
                 }
@@ -3209,13 +3207,13 @@ def Main = !
         let canonical_root = canonicalize_path(&root).unwrap();
         assert_eq!(
             workspace_packages.root_package,
-            PackageId::from_local_path(&canonical_root).unwrap()
+            package_id_from_local_path(&canonical_root).unwrap()
         );
 
         let workspace = assemble_workspace(workspace_packages).unwrap();
         assert_eq!(
             workspace.root_package(),
-            &PackageId::from_local_path(&canonical_root).unwrap()
+            &package_id_from_local_path(&canonical_root).unwrap()
         );
         assert_eq!(
             workspace
@@ -3724,7 +3722,7 @@ url = \"github.com/example/root\"
         let canonical_root = canonicalize_path(&root).unwrap();
         assert_eq!(
             workspace_packages.root_package,
-            PackageId::from_local_path(&canonical_root).unwrap()
+            package_id_from_local_path(&canonical_root).unwrap()
         );
     }
 

--- a/crates/par-core/src/workspace.rs
+++ b/crates/par-core/src/workspace.rs
@@ -19,6 +19,7 @@ use crate::runtime_impl::{Compiled, RuntimeCompilerError};
 use arcstr::ArcStr;
 use indexmap::{IndexMap, IndexSet};
 use par_runtime::linker::Unlinked;
+use par_runtime::registry::BuiltinPackage;
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet, HashMap, btree_map::Entry};
 use std::fmt::{self, Display, Formatter, Write};
@@ -278,6 +279,7 @@ impl Display for RemoteDependencySource {
 pub struct PackageManifest {
     pub name: String,
     pub dependencies: BTreeMap<String, DependencySpec>,
+    pub builtin: bool,
 }
 
 impl PackageManifest {
@@ -297,6 +299,7 @@ impl PackageManifest {
 
         Ok(Self {
             name: manifest.package.name,
+            builtin: manifest.package.__builtin,
             dependencies: manifest
                 .dependencies
                 .into_iter()
@@ -324,6 +327,7 @@ impl PackageManifest {
         let manifest = ManifestToml {
             package: ManifestPackageToml {
                 name: self.name.clone(),
+                __builtin: self.builtin,
             },
             dependencies: self
                 .dependencies
@@ -351,6 +355,8 @@ struct ManifestToml {
 #[derive(Debug, Serialize, Deserialize)]
 struct ManifestPackageToml {
     name: String,
+    #[serde(default)]
+    __builtin: bool,
 }
 
 #[derive(Debug, Clone)]
@@ -613,6 +619,15 @@ pub enum WorkspaceDiscoveryError {
     PackageCycle {
         cycle: Vec<PathBuf>,
     },
+    UnknownBuiltinPackage {
+        name: String,
+    },
+    DirectDependencyOnBuiltin {
+        package: PackageId,
+    },
+    BuiltinDependencyOnNonBuiltin {
+        package: PackageId,
+    },
 }
 
 impl Display for WorkspaceDiscoveryError {
@@ -739,6 +754,18 @@ impl Display for WorkspaceDiscoveryError {
                     .join(" -> ");
                 write!(f, "Package dependency cycle detected: {cycle}")
             }
+            Self::UnknownBuiltinPackage { name } => {
+                write!(f, "Unknown builtin package {name}")
+            }
+            Self::DirectDependencyOnBuiltin { package } => {
+                write!(f, "Cannot directly depend on builtin package {package}")
+            }
+            Self::BuiltinDependencyOnNonBuiltin { package } => {
+                write!(
+                    f,
+                    "Builtin package cannot depend on non-builtin package {package}"
+                )
+            }
         }
     }
 }
@@ -759,7 +786,10 @@ impl WorkspaceDiscoveryError {
             | Self::RemoteDependencyMaterializationError { .. }
             | Self::DependencyAliasCollision { .. }
             | Self::DuplicatePackageId { .. }
-            | Self::PackageCycle { .. } => (Span::None, vec![]),
+            | Self::PackageCycle { .. }
+            | Self::UnknownBuiltinPackage { .. }
+            | Self::DirectDependencyOnBuiltin { .. }
+            | Self::BuiltinDependencyOnNonBuiltin { .. } => (Span::None, vec![]),
         }
     }
 
@@ -778,7 +808,10 @@ impl WorkspaceDiscoveryError {
             | Self::RemoteDependencyMaterializationError { .. }
             | Self::DependencyAliasCollision { .. }
             | Self::DuplicatePackageId { .. }
-            | Self::PackageCycle { .. } => message_report(self.to_string()),
+            | Self::PackageCycle { .. }
+            | Self::UnknownBuiltinPackage { .. }
+            | Self::DirectDependencyOnBuiltin { .. }
+            | Self::BuiltinDependencyOnNonBuiltin { .. } => message_report(self.to_string()),
         }
     }
 }
@@ -1553,6 +1586,7 @@ struct PackageGraphDiscovery<'a, H> {
     package_ids_by_root: BTreeMap<PathBuf, PackageId>,
     roots_by_package_id: BTreeMap<PackageId, PathBuf>,
     packages_by_root: BTreeMap<PathBuf, DiscoveredPackage>,
+    root_builtin: bool,
 }
 
 impl<'a, H: MissingRemotePackageHandler> PackageGraphDiscovery<'a, H> {
@@ -1564,6 +1598,7 @@ impl<'a, H: MissingRemotePackageHandler> PackageGraphDiscovery<'a, H> {
             package_ids_by_root: BTreeMap::new(),
             roots_by_package_id: BTreeMap::new(),
             packages_by_root: BTreeMap::new(),
+            root_builtin: false,
         }
     }
 
@@ -1605,9 +1640,30 @@ impl<'a, H: MissingRemotePackageHandler> PackageGraphDiscovery<'a, H> {
         &mut self,
         layout: PackageLayout,
         canonical_root: PathBuf,
-        package_id: PackageId,
+        mut package_id: PackageId,
     ) -> Result<PackageId, WorkspaceDiscoveryError> {
         let manifest = PackageManifest::read_from(&layout.manifest_path)?;
+
+        if manifest.builtin {
+            let builtin = BuiltinPackage::from_str(&manifest.name).ok_or_else(|| {
+                WorkspaceDiscoveryError::UnknownBuiltinPackage {
+                    name: manifest.name.clone(),
+                }
+            })?;
+            if self.visiting.len() == 1 {
+                // this is the root package
+                self.root_builtin = true
+            } else if !self.root_builtin {
+                return Err(WorkspaceDiscoveryError::DirectDependencyOnBuiltin {
+                    package: package_id,
+                });
+            }
+            package_id = PackageId::Builtin(builtin);
+        } else if self.root_builtin {
+            return Err(WorkspaceDiscoveryError::BuiltinDependencyOnNonBuiltin {
+                package: package_id,
+            });
+        }
 
         if let Some(first_root) = self.roots_by_package_id.get(&package_id) {
             if first_root != &canonical_root {
@@ -1961,17 +2017,17 @@ fn universalize_module_path(
             })
         }
         Resolved::BuiltinOperator(BuiltinOperatorModule::Data) => Ok(Universal {
-            package: PackageId::Special(arcstr::literal!("core")),
+            package: PackageId::Builtin(BuiltinPackage::Core),
             directories: vec![],
             module: String::from("Data"),
         }),
         Resolved::BuiltinOperator(BuiltinOperatorModule::Number) => Ok(Universal {
-            package: PackageId::Special(arcstr::literal!("core")),
+            package: PackageId::Builtin(BuiltinPackage::Core),
             directories: vec![],
             module: String::from("Number"),
         }),
         Resolved::BuiltinOperator(BuiltinOperatorModule::String) => Ok(Universal {
-            package: PackageId::Special(arcstr::literal!("core")),
+            package: PackageId::Builtin(BuiltinPackage::Core),
             directories: vec![],
             module: String::from("String"),
         }),
@@ -2208,17 +2264,17 @@ fn resolve_name_to_universal(
             }
         }
         Resolved::BuiltinOperator(BuiltinOperatorModule::Data) => Universal {
-            package: PackageId::Special(arcstr::literal!("core")),
+            package: PackageId::Builtin(BuiltinPackage::Core),
             directories: vec![],
             module: String::from("Data"),
         },
         Resolved::BuiltinOperator(BuiltinOperatorModule::Number) => Universal {
-            package: PackageId::Special(arcstr::literal!("core")),
+            package: PackageId::Builtin(BuiltinPackage::Core),
             directories: vec![],
             module: String::from("Number"),
         },
         Resolved::BuiltinOperator(BuiltinOperatorModule::String) => Universal {
-            package: PackageId::Special(arcstr::literal!("core")),
+            package: PackageId::Builtin(BuiltinPackage::Core),
             directories: vec![],
             module: String::from("String"),
         },

--- a/crates/par-doc/Cargo.toml
+++ b/crates/par-doc/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 askama = "0.14.0"
 miette = { version = "7.6.0", features = ["fancy"] }
+par-runtime = { path = "../par-runtime" }
 par-builtin = { path = "../par-builtin" }
 par-core = { path = "../par-core" }
 pathdiff = "0.2.3"

--- a/crates/par-doc/src/load.rs
+++ b/crates/par-doc/src/load.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
-use par_builtin::builtin_packages;
+use par_builtin::{builtin_packages, inject_builtin_packages};
 use par_core::frontend::TypeError;
 use par_core::frontend::language::{PackageId, Universal};
 use par_core::workspace::{
@@ -63,7 +63,7 @@ fn load_workspace_site(graph: PackageGraph, only_exported: bool) -> Result<Loade
         .clone()
         .into_workspace_packages(None)
         .map_err(DocError::Discovery)?;
-    inject_builtin_packages(&mut workspace_packages)?;
+    inject_builtin_packages(&mut workspace_packages).map_err(DocError::Discovery)?;
 
     let package_meta = build_workspace_meta(
         &graph,
@@ -83,7 +83,7 @@ fn load_workspace_site(graph: PackageGraph, only_exported: bool) -> Result<Loade
 fn load_builtin_site(start: &Path, only_exported: bool) -> Result<LoadedSite, DocError> {
     let workspace_packages = WorkspacePackages {
         root_package: PackageId::Special("__par_doc__".into()),
-        packages: builtin_packages(),
+        packages: builtin_packages().collect(),
     };
     let package_meta = build_builtin_meta(&workspace_packages);
     let workspace = assemble_workspace(workspace_packages).map_err(DocError::Workspace)?;
@@ -363,7 +363,7 @@ fn package_kind(
 ) -> PackageKind {
     if root_package == Some(id) {
         PackageKind::Root
-    } else if matches!(id, PackageId::Special(_)) {
+    } else if matches!(id, PackageId::Special(_) | PackageId::Builtin(_)) {
         PackageKind::BuiltIn
     } else if direct_dependencies.contains(id) {
         PackageKind::DirectDependency
@@ -395,6 +395,7 @@ fn is_module_exported(module: &ParsedModule) -> bool {
 
 fn builtin_package_name(id: &PackageId) -> String {
     match id {
+        PackageId::Builtin(name) => name.to_string(),
         PackageId::Special(name) => name.to_string(),
         PackageId::Local(name) | PackageId::Remote(name) => name.to_string(),
     }
@@ -402,7 +403,7 @@ fn builtin_package_name(id: &PackageId) -> String {
 
 fn package_identity(id: &PackageId) -> String {
     match id {
-        PackageId::Special(_) => String::from("built-in package"),
+        PackageId::Builtin(_) | PackageId::Special(_) => String::from("built-in package"),
         PackageId::Local(path) | PackageId::Remote(path) => path.to_string(),
     }
 }
@@ -413,40 +414,4 @@ fn fallback_out_dir(start: &Path) -> PathBuf {
     } else {
         start.parent().unwrap_or_else(|| Path::new(".")).join("doc")
     }
-}
-
-fn inject_builtin_packages(workspace_packages: &mut WorkspacePackages) -> Result<(), DocError> {
-    let builtin_packages = builtin_packages();
-    let builtin_aliases = builtin_packages
-        .iter()
-        .map(|package| match &package.id {
-            PackageId::Special(name) => Ok((name.to_string(), package.id.clone())),
-            PackageId::Local(_) | PackageId::Remote(_) => {
-                Err(WorkspaceDiscoveryError::DependencyAliasCollision {
-                    package: package.id.clone(),
-                    alias: String::from("<builtin>"),
-                })
-            }
-        })
-        .collect::<Result<Vec<_>, _>>()
-        .map_err(DocError::Discovery)?;
-
-    for package in &mut workspace_packages.packages {
-        for (alias, builtin_id) in &builtin_aliases {
-            if package.dependencies.contains_key(alias) {
-                return Err(DocError::Discovery(
-                    WorkspaceDiscoveryError::DependencyAliasCollision {
-                        package: package.id.clone(),
-                        alias: alias.clone(),
-                    },
-                ));
-            }
-            package
-                .dependencies
-                .insert(alias.clone(), builtin_id.clone());
-        }
-    }
-
-    workspace_packages.packages.extend(builtin_packages);
-    Ok(())
 }

--- a/crates/par-doc/src/load.rs
+++ b/crates/par-doc/src/load.rs
@@ -4,11 +4,12 @@ use std::sync::Arc;
 
 use par_builtin::{builtin_packages, inject_builtin_packages};
 use par_core::frontend::TypeError;
-use par_core::frontend::language::{PackageId, Universal};
+use par_core::frontend::language::Universal;
 use par_core::workspace::{
     PackageGraph, ParsedModule, Workspace, WorkspaceDiscoveryError, WorkspacePackage,
     WorkspacePackages, assemble_workspace,
 };
+use par_runtime::pkgid::PackageId;
 
 use crate::error::DocError;
 use crate::model::{
@@ -147,16 +148,11 @@ fn build_workspace_meta(
         .iter()
         .map(|package| {
             let kind = package_kind(&package.id, root_package, direct_dependencies);
-            let (name, identity) = match discovered.get(&package.id) {
-                Some(discovered) => (
-                    discovered.manifest.name.clone(),
-                    package_identity(&package.id),
-                ),
-                None => (
-                    builtin_package_name(&package.id),
-                    String::from("built-in package"),
-                ),
-            };
+            let name = discovered
+                .get(&package.id)
+                .map(|discovered| discovered.manifest.name.clone())
+                .unwrap_or_else(|| package.id.name().to_owned());
+            let identity = package_identity(&package.id).to_owned();
             (
                 package.id.clone(),
                 PackageMeta {
@@ -179,7 +175,7 @@ fn build_builtin_meta(workspace_packages: &WorkspacePackages) -> BTreeMap<Packag
             (
                 package.id.clone(),
                 PackageMeta {
-                    name: builtin_package_name(&package.id),
+                    name: package.id.name().into(),
                     identity: String::from("built-in package"),
                     kind: PackageKind::BuiltIn,
                     is_root: false,
@@ -363,7 +359,7 @@ fn package_kind(
 ) -> PackageKind {
     if root_package == Some(id) {
         PackageKind::Root
-    } else if matches!(id, PackageId::Special(_) | PackageId::Builtin(_)) {
+    } else if root_package.is_none_or(|root| root.is_regular()) && !id.is_regular() {
         PackageKind::BuiltIn
     } else if direct_dependencies.contains(id) {
         PackageKind::DirectDependency
@@ -393,18 +389,11 @@ fn is_module_exported(module: &ParsedModule) -> bool {
     })
 }
 
-fn builtin_package_name(id: &PackageId) -> String {
-    match id {
-        PackageId::Builtin(name) => name.to_string(),
-        PackageId::Special(name) => name.to_string(),
-        PackageId::Local(name) | PackageId::Remote(name) => name.to_string(),
-    }
-}
-
-fn package_identity(id: &PackageId) -> String {
-    match id {
-        PackageId::Builtin(_) | PackageId::Special(_) => String::from("built-in package"),
-        PackageId::Local(path) | PackageId::Remote(path) => path.to_string(),
+fn package_identity(id: &PackageId) -> &str {
+    if id.is_regular() {
+        id.name()
+    } else {
+        "built-in package"
     }
 }
 

--- a/crates/par-doc/src/model.rs
+++ b/crates/par-doc/src/model.rs
@@ -2,8 +2,9 @@ use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use par_core::frontend::Type;
-use par_core::frontend::language::{GlobalName, PackageId, Universal};
+use par_core::frontend::language::{GlobalName, Universal};
 use par_core::workspace::ModulePath;
+use par_runtime::pkgid::PackageId;
 
 #[derive(Debug, Clone)]
 pub struct LoadedSite {

--- a/crates/par-doc/src/paths.rs
+++ b/crates/par-doc/src/paths.rs
@@ -1,7 +1,7 @@
 use std::collections::BTreeMap;
 use std::path::{Path, PathBuf};
 
-use par_core::frontend::language::PackageId;
+use par_runtime::pkgid::PackageId;
 use pathdiff::diff_paths;
 use percent_encoding::{AsciiSet, CONTROLS, utf8_percent_encode};
 
@@ -90,7 +90,7 @@ pub fn relative_href_with_anchor(from_page: &Path, to_page: &Path, anchor: &str)
 fn package_page_path(id: &PackageId, kind: PackageKind) -> PathBuf {
     let mut path = PathBuf::from("packages").join(kind_dir(kind));
     if kind != PackageKind::Root {
-        path = path.join(package_identity_segment(id));
+        path = path.join(encode_segment(id.name()));
     }
     path.join("index.html")
 }
@@ -110,15 +110,6 @@ fn kind_dir(kind: PackageKind) -> &'static str {
         PackageKind::BuiltIn => "builtin",
         PackageKind::DirectDependency => "dependency",
         PackageKind::IndirectDependency => "indirect",
-    }
-}
-
-fn package_identity_segment(id: &PackageId) -> String {
-    match id {
-        PackageId::Builtin(name) => encode_segment(name.as_str()),
-        PackageId::Special(name) | PackageId::Local(name) | PackageId::Remote(name) => {
-            encode_segment(name.as_str())
-        }
     }
 }
 

--- a/crates/par-doc/src/paths.rs
+++ b/crates/par-doc/src/paths.rs
@@ -115,6 +115,7 @@ fn kind_dir(kind: PackageKind) -> &'static str {
 
 fn package_identity_segment(id: &PackageId) -> String {
     match id {
+        PackageId::Builtin(name) => encode_segment(name.as_str()),
         PackageId::Special(name) | PackageId::Local(name) | PackageId::Remote(name) => {
             encode_segment(name.as_str())
         }

--- a/crates/par-doc/src/render.rs
+++ b/crates/par-doc/src/render.rs
@@ -3,7 +3,8 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 use askama::Template;
-use par_core::frontend::language::{GlobalName, PackageId, Universal};
+use par_core::frontend::language::{GlobalName, Universal};
+use par_runtime::pkgid::PackageId;
 
 use crate::error::DocError;
 use crate::html::{self, TypeLinkTarget};
@@ -121,7 +122,6 @@ impl<'a> Renderer<'a> {
                 name: package.name.clone(),
                 identity: display_package_identity(package),
                 identity_href: package_identity_href(&package.id),
-                has_identity_link: matches!(package.id, PackageId::Remote(_)),
             },
             modules: &modules,
             has_modules: !modules.is_empty(),
@@ -335,10 +335,10 @@ fn module_path_parts(path: &par_core::workspace::ModulePath) -> (String, bool, S
     }
 }
 
-fn package_identity_href(id: &PackageId) -> String {
+fn package_identity_href(id: &PackageId) -> Option<String> {
     match id {
-        PackageId::Remote(path) => format!("https://{path}"),
-        PackageId::Builtin(_) | PackageId::Special(_) | PackageId::Local(_) => String::new(),
+        PackageId::Remote(path) => Some(format!("https://{path}")),
+        _ => None,
     }
 }
 
@@ -418,8 +418,7 @@ struct PackageCardView {
 struct PackageHeaderView {
     name: String,
     identity: String,
-    identity_href: String,
-    has_identity_link: bool,
+    identity_href: Option<String>,
 }
 
 #[derive(Debug, Clone)]

--- a/crates/par-doc/src/render.rs
+++ b/crates/par-doc/src/render.rs
@@ -338,7 +338,7 @@ fn module_path_parts(path: &par_core::workspace::ModulePath) -> (String, bool, S
 fn package_identity_href(id: &PackageId) -> String {
     match id {
         PackageId::Remote(path) => format!("https://{path}"),
-        PackageId::Special(_) | PackageId::Local(_) => String::new(),
+        PackageId::Builtin(_) | PackageId::Special(_) | PackageId::Local(_) => String::new(),
     }
 }
 

--- a/crates/par-doc/templates/package.html
+++ b/crates/par-doc/templates/package.html
@@ -7,8 +7,8 @@
       <span class="page-title-name">{{ package.name }}</span>
     </h1>
     <p class="page-subtitle">
-      {% if package.has_identity_link %}
-        <a class="page-subtitle-link" href="{{ package.identity_href }}" target="_blank" rel="noreferrer noopener">{{ package.identity }}</a>
+      {% if let Some(href) = package.identity_href %}
+        <a class="page-subtitle-link" href="{{ href }}" target="_blank" rel="noreferrer noopener">{{ package.identity }}</a>
       {% else %}
         {{ package.identity }}
       {% endif %}

--- a/crates/par-runtime/Cargo.toml
+++ b/crates/par-runtime/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2024"
 playground=[]
 
 [dependencies]
-arcstr = "1.2.0"
+arcstr = { version = "1.2.0", features = ["serde"] }
 futures = { version = "0.3.31", features = ["executor", "thread-pool"] }
 num-bigint = { version = "0.4.6", features = ["serde"] }
 bytes = { version = "1.6.1", features = ["serde"] }

--- a/crates/par-runtime/src/lib.rs
+++ b/crates/par-runtime/src/lib.rs
@@ -3,6 +3,7 @@ mod executor;
 pub mod fan_behavior;
 pub mod flat;
 pub mod linker;
+pub mod pkgid;
 pub mod poll;
 pub mod primitive;
 pub mod readback;

--- a/crates/par-runtime/src/linker.rs
+++ b/crates/par-runtime/src/linker.rs
@@ -2,7 +2,7 @@ use crate::flat::arena::{Arena, Index};
 use crate::flat::runtime::{
     ExternalFn, Global, GlobalCont, GlobalValue, Package, PackageBody, PackagePtr,
 };
-use crate::registry::{DefinitionRef, PackageRef, get_external_fn};
+use crate::registry::{BuiltinPackage, DefinitionRef, PackageRef, get_external_fn};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt::{self, Display};
@@ -13,6 +13,7 @@ pub type Linked = ExternalFn;
 
 #[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
 pub enum PackageID {
+    Builtin(BuiltinPackage),
     Special(String),
     Local(String),
     Remote(String),
@@ -34,6 +35,7 @@ pub struct LinkError {
 impl<'a> From<PackageRef<'a>> for PackageID {
     fn from(package: PackageRef) -> Self {
         match package {
+            PackageRef::Builtin(name) => PackageID::Builtin(name),
             PackageRef::Special(name) => PackageID::Special(name.to_string()),
             PackageRef::Local(name) => PackageID::Local(name.to_string()),
             PackageRef::Remote(name) => PackageID::Remote(name.to_string()),
@@ -55,6 +57,7 @@ impl<'a> From<DefinitionRef<'a>> for Unlinked {
 impl Display for PackageID {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            Self::Builtin(name) => write!(f, "@{name}"),
             Self::Special(name) | Self::Local(name) | Self::Remote(name) => write!(f, "@{name}"),
         }
     }
@@ -63,6 +66,9 @@ impl Display for PackageID {
 impl Display for Unlinked {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let package_prefix = match &self.package {
+            PackageID::Builtin(name) => {
+                format!("@{name}/")
+            }
             PackageID::Special(name) | PackageID::Local(name) | PackageID::Remote(name) => {
                 format!("@{name}/")
             }

--- a/crates/par-runtime/src/linker.rs
+++ b/crates/par-runtime/src/linker.rs
@@ -2,7 +2,8 @@ use crate::flat::arena::{Arena, Index};
 use crate::flat::runtime::{
     ExternalFn, Global, GlobalCont, GlobalValue, Package, PackageBody, PackagePtr,
 };
-use crate::registry::{BuiltinPackage, DefinitionRef, PackageRef, get_external_fn};
+use crate::pkgid::PackageId;
+use crate::registry::{DefinitionRef, PackageRef, get_external_fn};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::fmt::{self, Display};
@@ -11,17 +12,9 @@ use std::sync::{Arc, OnceLock};
 
 pub type Linked = ExternalFn;
 
-#[derive(Clone, Debug, Hash, PartialEq, Eq, Serialize, Deserialize)]
-pub enum PackageID {
-    Builtin(BuiltinPackage),
-    Special(String),
-    Local(String),
-    Remote(String),
-}
-
 #[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Unlinked {
-    pub package: PackageID,
+    pub package: PackageId,
     pub path: Vec<String>,
     pub module: String,
     pub name: String,
@@ -32,13 +25,13 @@ pub struct LinkError {
     pub missing: Unlinked,
 }
 
-impl<'a> From<PackageRef<'a>> for PackageID {
+impl<'a> From<PackageRef<'a>> for PackageId {
     fn from(package: PackageRef) -> Self {
         match package {
-            PackageRef::Builtin(name) => PackageID::Builtin(name),
-            PackageRef::Special(name) => PackageID::Special(name.to_string()),
-            PackageRef::Local(name) => PackageID::Local(name.to_string()),
-            PackageRef::Remote(name) => PackageID::Remote(name.to_string()),
+            PackageRef::Builtin(name) => PackageId::Builtin(name),
+            PackageRef::Special(name) => PackageId::Special(name.into()),
+            PackageRef::Local(name) => PackageId::Local(name.into()),
+            PackageRef::Remote(name) => PackageId::Remote(name.into()),
         }
     }
 }
@@ -54,25 +47,8 @@ impl<'a> From<DefinitionRef<'a>> for Unlinked {
     }
 }
 
-impl Display for PackageID {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self {
-            Self::Builtin(name) => write!(f, "@{name}"),
-            Self::Special(name) | Self::Local(name) | Self::Remote(name) => write!(f, "@{name}"),
-        }
-    }
-}
-
 impl Display for Unlinked {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let package_prefix = match &self.package {
-            PackageID::Builtin(name) => {
-                format!("@{name}/")
-            }
-            PackageID::Special(name) | PackageID::Local(name) | PackageID::Remote(name) => {
-                format!("@{name}/")
-            }
-        };
         let path_prefix = if self.path.is_empty() {
             String::new()
         } else {
@@ -80,8 +56,8 @@ impl Display for Unlinked {
         };
         write!(
             f,
-            "{}{}{}.{}",
-            package_prefix, path_prefix, self.module, self.name
+            "{}/{}{}.{}",
+            self.package, path_prefix, self.module, self.name
         )
     }
 }

--- a/crates/par-runtime/src/pkgid.rs
+++ b/crates/par-runtime/src/pkgid.rs
@@ -1,0 +1,78 @@
+use std::fmt;
+
+use arcstr::ArcStr;
+use serde::{Deserialize, Serialize};
+
+#[derive(Clone, Debug, Hash, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+pub enum PackageId {
+    Builtin(BuiltinPackage),
+    Special(ArcStr),
+    Local(ArcStr),
+    Remote(ArcStr),
+}
+
+impl PackageId {
+    pub fn name(&self) -> &str {
+        match self {
+            PackageId::Builtin(name) => name.as_str(),
+            PackageId::Special(name) | PackageId::Local(name) | PackageId::Remote(name) => {
+                name.as_str()
+            }
+        }
+    }
+
+    pub fn is_regular(&self) -> bool {
+        matches!(self, Self::Local(_) | Self::Remote(_))
+    }
+
+    pub fn local_path(&self) -> Option<&str> {
+        match self {
+            PackageId::Local(name) => Some(name),
+            _ => None,
+        }
+    }
+
+    pub fn remote_path(&self) -> Option<&str> {
+        match self {
+            PackageId::Remote(name) => Some(name),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for PackageId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "@{}", self.name())
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+pub enum BuiltinPackage {
+    Core,
+    Basic,
+}
+
+impl BuiltinPackage {
+    pub const ALL: &[Self] = &[Self::Core, Self::Basic];
+
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "core" => Some(BuiltinPackage::Core),
+            "basic" => Some(BuiltinPackage::Basic),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            BuiltinPackage::Core => "core",
+            BuiltinPackage::Basic => "basic",
+        }
+    }
+}
+
+impl fmt::Display for BuiltinPackage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}

--- a/crates/par-runtime/src/poll.rs
+++ b/crates/par-runtime/src/poll.rs
@@ -3,7 +3,7 @@ use crate::registry::{DefinitionRef, ExternalDef};
 use arcstr::ArcStr;
 use std::pin::Pin;
 
-pub static POLL_TOKEN: DefinitionRef = DefinitionRef {
+pub const POLL_TOKEN: DefinitionRef = DefinitionRef {
     package: Special("#internal"),
     path: &[],
     module: "",
@@ -83,11 +83,6 @@ async fn poll_token_server(mut handle: crate::readback::Handle) {
 }
 
 inventory::submit!(ExternalDef {
-    path: DefinitionRef {
-        package: Special("#internal"),
-        path: &[],
-        module: "",
-        name: "#poll_token",
-    },
+    path: POLL_TOKEN,
     f: poll_token,
 });

--- a/crates/par-runtime/src/registry.rs
+++ b/crates/par-runtime/src/registry.rs
@@ -1,7 +1,7 @@
 use crate::flat::runtime::ExternalFn;
 use crate::linker::{Linked, Unlinked};
+use crate::pkgid::BuiltinPackage;
 use std::collections::HashMap;
-use std::fmt;
 use std::sync::LazyLock;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -15,39 +15,6 @@ pub enum PackageRef<'a> {
 impl PackageRef<'_> {
     pub const CORE: Self = Self::Builtin(BuiltinPackage::Core);
     pub const BASIC: Self = Self::Builtin(BuiltinPackage::Basic);
-}
-
-#[derive(
-    Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
-)]
-pub enum BuiltinPackage {
-    Core,
-    Basic,
-}
-
-impl BuiltinPackage {
-    pub const ALL: &[Self] = &[Self::Core, Self::Basic];
-
-    pub fn from_str(s: &str) -> Option<Self> {
-        match s {
-            "core" => Some(BuiltinPackage::Core),
-            "basic" => Some(BuiltinPackage::Basic),
-            _ => None,
-        }
-    }
-
-    pub fn as_str(self) -> &'static str {
-        match self {
-            BuiltinPackage::Core => "core",
-            BuiltinPackage::Basic => "basic",
-        }
-    }
-}
-
-impl fmt::Display for BuiltinPackage {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.as_str())
-    }
 }
 
 #[derive(Hash, Eq, PartialEq, Clone, Copy, Debug)]

--- a/crates/par-runtime/src/registry.rs
+++ b/crates/par-runtime/src/registry.rs
@@ -1,21 +1,64 @@
 use crate::flat::runtime::ExternalFn;
-use crate::linker::{Linked, PackageID, Unlinked};
+use crate::linker::{Linked, Unlinked};
 use std::collections::HashMap;
+use std::fmt;
 use std::sync::LazyLock;
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum PackageRef<'a> {
+    Builtin(BuiltinPackage),
     Special(&'a str),
     Local(&'a str),
     Remote(&'a str),
 }
-#[derive(Hash, Eq, PartialEq, Clone, Debug)]
+
+impl PackageRef<'_> {
+    pub const CORE: Self = Self::Builtin(BuiltinPackage::Core);
+    pub const BASIC: Self = Self::Builtin(BuiltinPackage::Basic);
+}
+
+#[derive(
+    Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
+)]
+pub enum BuiltinPackage {
+    Core,
+    Basic,
+}
+
+impl BuiltinPackage {
+    pub const ALL: &[Self] = &[Self::Core, Self::Basic];
+
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "core" => Some(BuiltinPackage::Core),
+            "basic" => Some(BuiltinPackage::Basic),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            BuiltinPackage::Core => "core",
+            BuiltinPackage::Basic => "basic",
+        }
+    }
+}
+
+impl fmt::Display for BuiltinPackage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+#[derive(Hash, Eq, PartialEq, Clone, Copy, Debug)]
 pub struct DefinitionRef<'a> {
     pub package: PackageRef<'a>,
     pub path: &'a [&'a str],
     pub module: &'a str,
     pub name: &'a str,
 }
+
+#[derive(Clone, Copy)]
 pub struct ExternalDef {
     pub path: DefinitionRef<'static>,
     pub f: ExternalFn,
@@ -23,24 +66,15 @@ pub struct ExternalDef {
 
 inventory::collect!(ExternalDef);
 
-static REGISTRY: LazyLock<HashMap<PackageID, HashMap<Unlinked, Linked>>> = LazyLock::new(|| {
-    let mut map: HashMap<PackageID, HashMap<Unlinked, Linked>> = HashMap::new();
-    for def in inventory::iter::<ExternalDef> {
-        let package = def.path.package.clone().into();
-        if !map.contains_key(&package) {
-            map.insert(package.clone(), HashMap::new());
-        }
-        map.get_mut(&package)
-            .unwrap()
-            .insert(def.path.clone().into(), def.f);
-    }
-    map
+type Registry = HashMap<Unlinked, Linked>;
+
+static REGISTRY: LazyLock<Registry> = LazyLock::new(|| {
+    inventory::iter::<ExternalDef>
+        .into_iter()
+        .map(|&ExternalDef { path, f }| (path.into(), f))
+        .collect()
 });
 
 pub fn get_external_fn(path: &Unlinked) -> Option<ExternalFn> {
-    if let Some(map) = REGISTRY.get(&path.package) {
-        map.get(path).copied()
-    } else {
-        None
-    }
+    REGISTRY.get(path).copied()
 }

--- a/src/package_utils.rs
+++ b/src/package_utils.rs
@@ -2,9 +2,10 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use par_core::frontend::TypeError;
-use par_core::frontend::language::{PackageId, Universal};
+use par_core::frontend::language::Universal;
 use par_core::source::FileName;
 use par_core::workspace::ModulePath;
+use par_runtime::pkgid::PackageId;
 
 pub type SourceLookup = HashMap<FileName, Arc<str>>;
 

--- a/src/playground/build.rs
+++ b/src/playground/build.rs
@@ -10,11 +10,7 @@ use crate::workspace_support::{
     CheckedWorkspaceBuild, ScopedTypeError, WorkspaceBuildError,
     checked_workspace_from_loaded_package,
 };
-use par_core::frontend::{
-    Definition, DefinitionBody,
-    language::{PackageId, Universal},
-    process::Expression,
-};
+use par_core::frontend::{Definition, DefinitionBody, language::Universal, process::Expression};
 use par_core::source::FileName;
 #[cfg(not(target_family = "wasm"))]
 use par_core::workspace::SourceOverrides;
@@ -23,6 +19,7 @@ use par_core::{
     workspace::{CheckedWorkspace, LoadedPackageFile, WorkspaceDiscoveryError, WorkspaceError},
 };
 use par_runtime::linker::Linked;
+use par_runtime::pkgid::PackageId;
 
 type LoweredDefinition = Definition<Arc<Expression<(), Universal>>, Universal>;
 

--- a/src/playground/run_menu.rs
+++ b/src/playground/run_menu.rs
@@ -8,13 +8,14 @@ use futures::task::{Spawn, SpawnExt};
 use par_core::{
     frontend::{
         Type, Visibility,
-        language::{GlobalName, PackageId, Universal},
+        language::{GlobalName, Universal},
     },
     runtime::{Compiled, TypedHandle, type_supports_readback},
     source::FileName,
     workspace::{CheckedWorkspace, FileImportScope, ModulePath},
 };
 use par_runtime::linker::Linked;
+use par_runtime::pkgid::PackageId;
 use tokio_util::sync::CancellationToken;
 
 use super::readback::Element;
@@ -317,16 +318,9 @@ fn show_package_modules(
 
 fn package_label(root_package: &PackageId, package: &PackageId) -> String {
     if package == root_package {
-        return String::from("This package");
-    }
-
-    match package {
-        PackageId::Builtin(name) => {
-            format!("@{name}")
-        }
-        PackageId::Special(name) | PackageId::Local(name) | PackageId::Remote(name) => {
-            format!("@{name}")
-        }
+        String::from("This package")
+    } else {
+        package.to_string()
     }
 }
 

--- a/src/playground/run_menu.rs
+++ b/src/playground/run_menu.rs
@@ -321,6 +321,9 @@ fn package_label(root_package: &PackageId, package: &PackageId) -> String {
     }
 
     match package {
+        PackageId::Builtin(name) => {
+            format!("@{name}")
+        }
         PackageId::Special(name) | PackageId::Local(name) | PackageId::Remote(name) => {
             format!("@{name}")
         }

--- a/src/playground/sources.rs
+++ b/src/playground/sources.rs
@@ -7,11 +7,13 @@ use std::{
 };
 
 use arcstr::literal;
+use par_core::source::FileName;
+use par_core::workspace::LoadedPackageFile;
 #[cfg(not(target_family = "wasm"))]
 use par_core::workspace::{
     PackageLayout, SourceOverrides, WorkspaceDiscoveryError, load_package_source_files,
 };
-use par_core::{frontend::language::PackageId, source::FileName, workspace::LoadedPackageFile};
+use par_runtime::pkgid::PackageId;
 
 use super::examples::PLAYGROUND_EXAMPLES;
 

--- a/src/workspace_support.rs
+++ b/src/workspace_support.rs
@@ -3,10 +3,7 @@ use std::path::{Path, PathBuf};
 use crate::package_utils::{SourceLookup, source_for_type_error};
 use arcstr::literal;
 use par_builtin::inject_builtin_packages;
-use par_core::frontend::{
-    TypeError,
-    language::{PackageId, Universal},
-};
+use par_core::frontend::{TypeError, language::Universal};
 use par_core::runtime::{Compiled, RuntimeCompilerError};
 use par_core::source::FileName;
 use par_core::workspace::{
@@ -15,6 +12,7 @@ use par_core::workspace::{
     discover_workspace_packages_from_path, parse_loaded_files,
 };
 use par_runtime::linker::{Linked, Unlinked};
+use par_runtime::pkgid::PackageId;
 
 #[derive(Debug, Clone)]
 pub(crate) enum WorkspaceBuildError {

--- a/src/workspace_support.rs
+++ b/src/workspace_support.rs
@@ -2,7 +2,7 @@ use std::path::{Path, PathBuf};
 
 use crate::package_utils::{SourceLookup, source_for_type_error};
 use arcstr::literal;
-use par_builtin::builtin_packages;
+use par_builtin::inject_builtin_packages;
 use par_core::frontend::{
     TypeError,
     language::{PackageId, Universal},
@@ -106,19 +106,22 @@ pub fn default_workspace_packages_from_path(
     start: impl AsRef<Path>,
     overrides: Option<&SourceOverrides>,
 ) -> Result<WorkspacePackages, WorkspaceDiscoveryError> {
-    let discovered = discover_workspace_packages_from_path(start, overrides)?;
-    inject_builtin_packages(discovered)
+    let mut discovered = discover_workspace_packages_from_path(start, overrides)?;
+    inject_builtin_packages(&mut discovered)?;
+    Ok(discovered)
 }
 
 pub fn default_workspace_packages_from_parsed(
     root_package: PackageId,
     local: ParsedPackage,
 ) -> WorkspacePackages {
-    inject_builtin_packages(WorkspacePackages {
+    let mut packages = WorkspacePackages {
         root_package: root_package.clone(),
         packages: vec![WorkspacePackage::new(root_package, local)],
-    })
-    .expect("synthetic workspace should not conflict with builtin aliases")
+    };
+    inject_builtin_packages(&mut packages)
+        .expect("synthetic workspace should not conflict with builtin aliases");
+    packages
 }
 
 pub fn assemble_default_workspace(
@@ -173,39 +176,4 @@ pub(crate) fn checked_workspace_from_single_file(
         }],
         PackageId::Special(literal!("__synthetic__")),
     )
-}
-
-fn inject_builtin_packages(
-    mut workspace_packages: WorkspacePackages,
-) -> Result<WorkspacePackages, WorkspaceDiscoveryError> {
-    let builtin_packages = builtin_packages();
-    let builtin_aliases = builtin_packages
-        .iter()
-        .map(|package| match &package.id {
-            PackageId::Special(name) => Ok((name.to_string(), package.id.clone())),
-            PackageId::Local(_) | PackageId::Remote(_) => {
-                Err(WorkspaceDiscoveryError::DependencyAliasCollision {
-                    package: package.id.clone(),
-                    alias: String::from("<builtin>"),
-                })
-            }
-        })
-        .collect::<Result<Vec<_>, _>>()?;
-
-    for package in &mut workspace_packages.packages {
-        for (alias, builtin_id) in &builtin_aliases {
-            if package.dependencies.contains_key(alias) {
-                return Err(WorkspaceDiscoveryError::DependencyAliasCollision {
-                    package: package.id.clone(),
-                    alias: alias.clone(),
-                });
-            }
-            package
-                .dependencies
-                .insert(alias.clone(), builtin_id.clone());
-        }
-    }
-
-    workspace_packages.packages.extend(builtin_packages);
-    Ok(workspace_packages)
 }


### PR DESCRIPTION
`par check --package ./crates/par-builtin/packages/{core,basic}` now properly recognizes that these are dev versions of the builtin packages, and can successfully compile them. In the second commit, I remove the duplication of `PackageId` and `PackageID`. If it's desired that I split this out into a separate PR, I could do that.