### PR TITLE
Use bytes_utils::Str for ParString

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -761,6 +761,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bytes-utils"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dafe3a8757b027e2be6e4e5601ed563c55989fcf1546e933c66c8eb3a058d35"
+dependencies = [
+ "bytes",
+ "either",
+ "serde",
+]
+
+[[package]]
 name = "calloop"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1218,6 +1229,12 @@ dependencies = [
  "web-sys",
  "winit",
 ]
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "emath"
@@ -2260,7 +2277,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3147,6 +3164,7 @@ dependencies = [
  "arcstr",
  "atomicbox",
  "bytes",
+ "bytes-utils",
  "futures",
  "inventory",
  "num-bigint",

--- a/crates/par-builtin/src/builtin/console.rs
+++ b/crates/par-builtin/src/builtin/console.rs
@@ -29,9 +29,8 @@ async fn console_open(mut handle: Handle) {
                 handle.send().concurrently(|mut handle| async move {
                     match result {
                         Ok(n) if n > 0 => {
-                            let string = ParString::copy_from_slice(
-                                buf.trim_end_matches(&['\n', '\r']).as_bytes(),
-                            );
+                            let string =
+                                ParString::copy_from_slice(buf.trim_end_matches(&['\n', '\r']));
                             handle.signal(literal!("ok"));
                             handle.provide_string(string);
                         }

--- a/crates/par-builtin/src/builtin/http.rs
+++ b/crates/par-builtin/src/builtin/http.rs
@@ -172,7 +172,7 @@ fn provide_headers_list(mut handle: Handle, headers: &reqwest::header::HeaderMap
     for (name, value) in headers {
         handle.signal(literal!("item"));
         let (name, value) = (
-            ParString::copy_from_slice(name.as_str().as_bytes()),
+            ParString::copy_from_slice(name.as_str()),
             Bytes::copy_from_slice(value.as_bytes()),
         );
         handle.send().concurrently(|mut handle| async {
@@ -629,7 +629,7 @@ async fn build_response(mut handle: Handle) -> Result<Response<ResponseBody>, Pa
     let mut response = Response::builder()
         .status(status)
         .body(BodyExt::boxed(reader_to_body(handle)))
-        .map_err(|err| Bytes::from(err.to_string()))?;
+        .map_err(|err| err.to_string())?;
 
     for (name, value) in headers {
         let Ok(header_name) = HeaderName::from_str(name.as_str()) else {

--- a/crates/par-builtin/src/builtin/parser.rs
+++ b/crates/par-builtin/src/builtin/parser.rs
@@ -245,8 +245,7 @@ impl CharsRemainder for ReaderRemainder {
 
     fn pop_chars(&mut self, n: usize) -> ParString {
         let popped = self.buffer.drain(..n).collect::<Vec<u8>>();
-        let popped = String::from_utf8_lossy(&popped[..]);
-        ParString::copy_from_slice(&popped)
+        ParString::from_utf8_lossy(popped.into())
     }
 
     async fn remaining_chars(&mut self) -> Result<ParString, Self::Err> {

--- a/crates/par-builtin/src/builtin/parser.rs
+++ b/crates/par-builtin/src/builtin/parser.rs
@@ -246,7 +246,7 @@ impl CharsRemainder for ReaderRemainder {
     fn pop_chars(&mut self, n: usize) -> ParString {
         let popped = self.buffer.drain(..n).collect::<Vec<u8>>();
         let popped = String::from_utf8_lossy(&popped[..]);
-        ParString::copy_from_slice(popped.as_bytes())
+        ParString::copy_from_slice(&popped)
     }
 
     async fn remaining_chars(&mut self) -> Result<ParString, Self::Err> {

--- a/crates/par-builtin/src/builtin/string.rs
+++ b/crates/par-builtin/src/builtin/string.rs
@@ -107,9 +107,7 @@ async fn string_parser_from_reader(mut handle: Handle) {
 
 async fn string_from_bytes(mut handle: Handle) {
     let bytes = handle.receive().bytes().await;
-    handle.provide_string(ParString::copy_from_slice(
-        String::from_utf8_lossy(&bytes).as_bytes(),
-    ));
+    handle.provide_string(ParString::copy_from_slice(&String::from_utf8_lossy(&bytes)));
 }
 
 #[derive(Debug, Clone)]

--- a/crates/par-builtin/src/builtin/string.rs
+++ b/crates/par-builtin/src/builtin/string.rs
@@ -107,7 +107,7 @@ async fn string_parser_from_reader(mut handle: Handle) {
 
 async fn string_from_bytes(mut handle: Handle) {
     let bytes = handle.receive().bytes().await;
-    handle.provide_string(ParString::copy_from_slice(&String::from_utf8_lossy(&bytes)));
+    handle.provide_string(ParString::from_utf8_lossy(bytes))
 }
 
 #[derive(Debug, Clone)]

--- a/crates/par-builtin/src/builtin/url.rs
+++ b/crates/par-builtin/src/builtin/url.rs
@@ -37,11 +37,11 @@ pub(super) fn provide_url_value(handle: Handle, url: ParsedUrl) {
             loop {
                 match handle.case().await.as_str() {
                     "full" => {
-                        handle.provide_string(ParString::copy_from_slice(url.as_str().as_bytes()));
+                        handle.provide_string(ParString::copy_from_slice(url.as_str()));
                         return;
                     }
                     "protocol" => {
-                        handle.provide_string(ParString::copy_from_slice(url.scheme().as_bytes()));
+                        handle.provide_string(ParString::copy_from_slice(url.scheme()));
                         return;
                     }
                     "host" => {
@@ -54,7 +54,7 @@ pub(super) fn provide_url_value(handle: Handle, url: ParsedUrl) {
                     }
                     "path" => {
                         let decoded = percent_decode_str(url.path()).decode_utf8_lossy();
-                        handle.provide_string(ParString::copy_from_slice(decoded.as_bytes()));
+                        handle.provide_string(ParString::copy_from_slice(&decoded));
                         return;
                     }
                     "query" => {

--- a/crates/par-builtin/src/builtin/url.rs
+++ b/crates/par-builtin/src/builtin/url.rs
@@ -54,7 +54,7 @@ pub(super) fn provide_url_value(handle: Handle, url: ParsedUrl) {
                     }
                     "path" => {
                         let decoded = percent_decode_str(url.path()).decode_utf8_lossy();
-                        handle.provide_string(ParString::copy_from_slice(&decoded));
+                        handle.provide_string(decoded.into_owned().into());
                         return;
                     }
                     "query" => {

--- a/crates/par-core/src/frontend_impl/language.rs
+++ b/crates/par-core/src/frontend_impl/language.rs
@@ -1102,7 +1102,7 @@ impl Context {
                 TemplatePart::Literal(value) => {
                     items.push(Expression::Primitive(
                         Span::None,
-                        Primitive::String(ParString::copy_from_slice(value)),
+                        Primitive::String(ParString::from_owner(value.clone())),
                     ));
                 }
                 TemplatePart::StringExpr(expr) => {

--- a/crates/par-core/src/frontend_impl/language.rs
+++ b/crates/par-core/src/frontend_impl/language.rs
@@ -1102,7 +1102,7 @@ impl Context {
                 TemplatePart::Literal(value) => {
                     items.push(Expression::Primitive(
                         Span::None,
-                        Primitive::String(ParString::copy_from_slice(value.as_bytes())),
+                        Primitive::String(ParString::copy_from_slice(value)),
                     ));
                 }
                 TemplatePart::StringExpr(expr) => {
@@ -1121,10 +1121,7 @@ impl Context {
         }
 
         match items.as_slice() {
-            [] => Expression::Primitive(
-                Span::None,
-                Primitive::String(ParString::copy_from_slice(b"")),
-            ),
+            [] => Expression::Primitive(Span::None, Primitive::String(ParString::default())),
             [only] if !has_interpolation => only.clone(),
             _ => Self::apply_expression(
                 &Span::None,

--- a/crates/par-runtime/Cargo.toml
+++ b/crates/par-runtime/Cargo.toml
@@ -11,6 +11,7 @@ arcstr = "1.2.0"
 futures = { version = "0.3.31", features = ["executor", "thread-pool"] }
 num-bigint = { version = "0.4.6", features = ["serde"] }
 bytes = { version = "1.6.1", features = ["serde"] }
+bytes-utils = { version = "0.1.4", features = ["serde"] }
 inventory = "0.3.22"
 serde = { version = "1.0.228", features = ["derive", "rc"] }
 atomicbox = "0.4.0"

--- a/crates/par-runtime/src/primitive.rs
+++ b/crates/par-runtime/src/primitive.rs
@@ -167,38 +167,38 @@ fn number_kind_rank(number: &Number) -> u8 {
     }
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
-pub struct ParString {
-    bytes: Bytes,
-}
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, Default)]
+#[serde(transparent)]
+pub struct ParString(bytes_utils::Str);
 
 impl ParString {
-    pub fn copy_from_slice(slice: &[u8]) -> ParString {
-        let _ = std::str::from_utf8(slice).expect("ParString should be UTF8");
-        Self {
-            bytes: Bytes::copy_from_slice(slice),
-        }
+    pub fn copy_from_slice(slice: &str) -> ParString {
+        Self(slice.to_string().into())
     }
 
     pub fn as_str(&self) -> &str {
-        std::str::from_utf8(&self.bytes).expect("ParString should be UTF8")
+        &self.0
     }
 
     pub fn as_bytes(&self) -> Bytes {
-        self.bytes.clone()
+        self.0.inner().clone()
     }
 
     pub fn substr(&self, range: impl RangeBounds<usize>) -> Self {
-        let bytes = self.bytes.slice(range);
-        let _ = std::str::from_utf8(&bytes).expect("ParString should be UTF8");
-        Self { bytes }
+        let start = range.start_bound().cloned();
+        let end = range.end_bound().cloned();
+        Self(self.0.slice((start, end)))
     }
 }
 
-impl<T: Into<Bytes>> From<T> for ParString {
-    fn from(value: T) -> Self {
-        Self {
-            bytes: value.into(),
-        }
+impl From<&'static str> for ParString {
+    fn from(s: &'static str) -> Self {
+        Self(bytes_utils::Str::from_static(s))
+    }
+}
+
+impl From<String> for ParString {
+    fn from(s: String) -> Self {
+        Self(s.into())
     }
 }

--- a/crates/par-runtime/src/primitive.rs
+++ b/crates/par-runtime/src/primitive.rs
@@ -176,6 +176,28 @@ impl ParString {
         Self(slice.to_string().into())
     }
 
+    pub fn from_utf8_lossy(v: Bytes) -> ParString {
+        let s = bytes_utils::Str::from_inner(v)
+            .unwrap_or_else(|e| String::from_utf8_lossy(&e.into_inner()).into_owned().into());
+        Self(s)
+    }
+
+    pub fn from_owner<T>(owner: T) -> ParString
+    where
+        T: AsRef<str> + Send + 'static,
+    {
+        struct Wrapper<T>(T);
+        impl<T: AsRef<str>> AsRef<[u8]> for Wrapper<T> {
+            fn as_ref(&self) -> &[u8] {
+                self.0.as_ref().as_bytes()
+            }
+        }
+        let bytes = Bytes::from_owner(Wrapper(owner));
+        // SAFETY: the bytes content of `bytes` is derived from a `str`,
+        //         and thus must be valid UTF-8.
+        Self(unsafe { bytes_utils::Str::from_inner_unchecked(bytes) })
+    }
+
     pub fn as_str(&self) -> &str {
         &self.0
     }
@@ -200,5 +222,11 @@ impl From<&'static str> for ParString {
 impl From<String> for ParString {
     fn from(s: String) -> Self {
         Self(s.into())
+    }
+}
+
+impl From<char> for ParString {
+    fn from(c: char) -> Self {
+        ParString::copy_from_slice(c.encode_utf8(&mut [0u8; 4]))
     }
 }

--- a/crates/par-runtime/src/readback.rs
+++ b/crates/par-runtime/src/readback.rs
@@ -85,7 +85,7 @@ impl Handle {
     pub fn provide_char(self, value: char) {
         self.handle
             .provide_primitive(Primitive::String(ParString::copy_from_slice(
-                value.encode_utf8(&mut [0u8; 4]).as_bytes(),
+                value.encode_utf8(&mut [0u8; 4]),
             )))
     }
 

--- a/crates/par-runtime/src/readback.rs
+++ b/crates/par-runtime/src/readback.rs
@@ -84,9 +84,7 @@ impl Handle {
 
     pub fn provide_char(self, value: char) {
         self.handle
-            .provide_primitive(Primitive::String(ParString::copy_from_slice(
-                value.encode_utf8(&mut [0u8; 4]),
-            )))
+            .provide_primitive(Primitive::String(value.into()))
     }
 
     pub fn provide_byte(self, value: u8) {


### PR DESCRIPTION
This eliminates the redundant utf-8 checks for ParString, since `bytes_utils::Str` handles the validity invariant for us.