### PR TITLE
[lsp] Allow go-to-definition for builtin modules

### DIFF
--- a/crates/par-builtin/src/builtin.rs
+++ b/crates/par-builtin/src/builtin.rs
@@ -184,6 +184,20 @@ const BASIC_SOURCE_FILES: &[BuiltinSourceFile] = &[
     },
 ];
 
+pub fn get_builtin_source(filename: &str) -> Option<&'static str> {
+    let (package, path) = filename.split_once('/')?;
+    let files = match package {
+        "core" => CORE_SOURCE_FILES,
+        "basic" => BASIC_SOURCE_FILES,
+        _ => return None,
+    };
+    files
+        .iter()
+        .find_map(|file| (file.relative_path_from_src == path).then_some(file.source))
+}
+
+pub const PAR_BUILTIN_URI_SCHEME: &str = "par-builtin";
+
 fn parse_builtin_sources(
     package_name: &str,
     source_files: &[BuiltinSourceFile],
@@ -191,9 +205,10 @@ fn parse_builtin_sources(
     let files = source_files
         .iter()
         .map(|file| LoadedPackageFile {
-            name: FileName::from(
-                format!("par:{}/{}", package_name, file.relative_path_from_src).as_str(),
-            ),
+            name: FileName::from(format!(
+                "{PAR_BUILTIN_URI_SCHEME}:{}/{}",
+                package_name, file.relative_path_from_src
+            )),
             relative_path_from_src: PathBuf::from(file.relative_path_from_src),
             source: file.source.to_owned(),
         })

--- a/crates/par-builtin/src/lib.rs
+++ b/crates/par-builtin/src/lib.rs
@@ -2,4 +2,6 @@
 
 mod builtin;
 
-pub use builtin::{builtin_packages, inject_builtin_packages};
+pub use builtin::{
+    PAR_BUILTIN_URI_SCHEME, builtin_packages, get_builtin_source, inject_builtin_packages,
+};

--- a/crates/par-core/src/location.rs
+++ b/crates/par-core/src/location.rs
@@ -148,11 +148,6 @@ impl Point {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct FileName(pub ArcStr);
 
-impl FileName {
-    pub const BUILTIN: Self = FileName(arcstr::literal!("par:Builtin"));
-    pub const NATIVE_BUILTIN: Self = FileName(arcstr::literal!("par:NativeBuiltin"));
-}
-
 impl Display for FileName {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         f.write_str(self.0.as_str())

--- a/src/language_server.rs
+++ b/src/language_server.rs
@@ -1,4 +1,5 @@
 mod data;
+mod ext;
 mod feedback;
 mod instance;
 mod io;

--- a/src/language_server/ext.rs
+++ b/src/language_server/ext.rs
@@ -1,0 +1,15 @@
+use lsp_types::request::Request;
+use serde::{Deserialize, Serialize};
+
+pub enum GetBuiltinFileContent {}
+
+impl Request for GetBuiltinFileContent {
+    type Params = GetBuiltinFileContentParams;
+    type Result = String;
+    const METHOD: &'static str = "par-lang/getBuiltinFileContent";
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct GetBuiltinFileContentParams {
+    pub builtin_path: String,
+}

--- a/src/language_server/feedback.rs
+++ b/src/language_server/feedback.rs
@@ -165,9 +165,6 @@ fn uri_for_span(span: &Span) -> Option<Uri> {
 }
 
 fn file_name_to_uri(file: &FileName) -> Option<Uri> {
-    if *file == FileName::BUILTIN {
-        return None;
-    }
     let path = Path::new(file.0.as_str());
     if path.is_absolute() {
         return path_to_uri(path);

--- a/src/language_server/instance.rs
+++ b/src/language_server/instance.rs
@@ -252,9 +252,6 @@ impl Instance {
         let decl_span = name_info.decl_span();
         let (start, end) = decl_span.points()?;
         let path = decl_span.file()?;
-        if path == FileName::BUILTIN {
-            return None;
-        }
 
         Some(lsp::GotoDefinitionResponse::Scalar(lsp::Location {
             uri: file_name_to_uri(&path)?,
@@ -283,9 +280,6 @@ impl Instance {
         let def_span = name_info.def_span();
         let (start, end) = def_span.points()?;
         let path = def_span.file()?;
-        if path == FileName::BUILTIN {
-            return None;
-        }
 
         Some(lsp::GotoDefinitionResponse::Scalar(lsp::Location {
             uri: file_name_to_uri(&path)?,

--- a/src/language_server/server.rs
+++ b/src/language_server/server.rs
@@ -1,10 +1,12 @@
 use super::io::IO;
+use crate::language_server::ext::{GetBuiltinFileContent, GetBuiltinFileContentParams};
 use crate::language_server::feedback::{FeedbackBookKeeper, diagnostic_for_error};
 use crate::language_server::instance::Instance;
-use lsp_server::Connection;
+use lsp_server::{Connection, ErrorCode};
 use lsp_types::notification::DidSaveTextDocument;
 use lsp_types::request::{DocumentSymbolRequest, ExecuteCommand, GotoDeclaration, GotoDefinition};
 use lsp_types::{self as lsp, InitializeParams, Uri};
+use par_builtin::get_builtin_source;
 use std::collections::HashMap;
 use std::str::FromStr;
 
@@ -106,6 +108,20 @@ impl<'c> LanguageServer<'c> {
                         tracing::warn!("Unhandled command: {:?}", params);
                         return;
                     }
+                }
+            }
+            GetBuiltinFileContent::METHOD => {
+                let GetBuiltinFileContentParams { builtin_path } =
+                    extract_request::<GetBuiltinFileContent>(request);
+
+                if let Some(content) = get_builtin_source(&builtin_path) {
+                    lsp_server::Response::new_ok(request_id, content)
+                } else {
+                    lsp_server::Response::new_err(
+                        request_id,
+                        ErrorCode::InvalidRequest as i32,
+                        format!("unknown builtin {builtin_path}"),
+                    )
                 }
             }
             _ => {


### PR DESCRIPTION
Now go-to-definition can work for items from core.