### PR TITLE
Miscellaneous docs improvements

### DIFF
--- a/crates/par-builtin/src/builtin.rs
+++ b/crates/par-builtin/src/builtin.rs
@@ -223,24 +223,12 @@ fn load_external_type_defs(name: BuiltinPackage) -> BTreeMap<ModulePath, Externa
             directories: type_def.path.path.iter().map(|s| s.to_string()).collect(),
             module: type_def.path.module.into(),
         };
-        match externals.entry(module_path) {
-            Entry::Vacant(vacant) => {
-                let mut module = ExternalModule::default();
-                module.type_defs.push(TypeDef::external(
-                    type_def.path.name,
-                    &[],
-                    type_def.typ.clone(),
-                ));
-                vacant.insert(module);
-            }
-            Entry::Occupied(mut occupied) => {
-                occupied.get_mut().type_defs.push(TypeDef::external(
-                    type_def.path.name,
-                    &[],
-                    type_def.typ.clone(),
-                ));
-            }
-        }
+        let module = externals.entry(module_path).or_default();
+        module.type_defs.push(TypeDef::external(
+            type_def.path.name,
+            type_def.doc,
+            type_def.typ.clone(),
+        ));
     }
     externals
 }

--- a/crates/par-builtin/src/builtin/byte.rs
+++ b/crates/par-builtin/src/builtin/byte.rs
@@ -15,6 +15,7 @@ inventory::submit!(ExternalTypeDef {
         module: "Byte",
         name: "Byte"
     },
+    doc: r"A primitive type representing a single byte.",
     typ: Type::Primitive(Span::None, PrimitiveType::Byte)
 });
 

--- a/crates/par-builtin/src/builtin/bytes.rs
+++ b/crates/par-builtin/src/builtin/bytes.rs
@@ -29,6 +29,7 @@ inventory::submit!(ExternalTypeDef {
         module: "Bytes",
         name: "Bytes"
     },
+    doc: r"A primitive type representing a sequence of bytes.",
     typ: Type::Primitive(Span::None, PrimitiveType::Bytes)
 });
 

--- a/crates/par-builtin/src/builtin/char_.rs
+++ b/crates/par-builtin/src/builtin/char_.rs
@@ -14,6 +14,7 @@ inventory::submit!(ExternalTypeDef {
         module: "Char",
         name: "Char"
     },
+    doc: r"A primitive type representing a [Unicode scalar value](https://www.unicode.org/glossary/#unicode_scalar_value).",
     typ: Type::Primitive(Span::None, PrimitiveType::Char)
 });
 

--- a/crates/par-builtin/src/builtin/float.rs
+++ b/crates/par-builtin/src/builtin/float.rs
@@ -17,6 +17,7 @@ inventory::submit!(ExternalTypeDef {
         module: "Float",
         name: "Float"
     },
+    doc: r"A primitive type representing a 64-bit floating point number.",
     typ: Type::Primitive(Span::None, PrimitiveType::Float)
 });
 

--- a/crates/par-builtin/src/builtin/int.rs
+++ b/crates/par-builtin/src/builtin/int.rs
@@ -14,7 +14,7 @@ inventory::submit!(ExternalTypeDef {
         module: "Int",
         name: "Int"
     },
-    doc: r"A primitive type representing an unlimited-precision integer.",
+    doc: r"A primitive type representing an arbitrary-precision integer.",
     typ: Type::Primitive(Span::None, PrimitiveType::Int)
 });
 

--- a/crates/par-builtin/src/builtin/int.rs
+++ b/crates/par-builtin/src/builtin/int.rs
@@ -14,6 +14,7 @@ inventory::submit!(ExternalTypeDef {
         module: "Int",
         name: "Int"
     },
+    doc: r"A primitive type representing an unlimited-precision integer.",
     typ: Type::Primitive(Span::None, PrimitiveType::Int)
 });
 

--- a/crates/par-builtin/src/builtin/nat.rs
+++ b/crates/par-builtin/src/builtin/nat.rs
@@ -16,7 +16,7 @@ inventory::submit!(ExternalTypeDef {
         module: "Nat",
         name: "Nat"
     },
-    doc: r"A primitive type representing an unlimited-precision natural number.",
+    doc: r"A primitive type representing an arbitrary-precision natural number.",
     typ: Type::Primitive(Span::None, PrimitiveType::Nat)
 });
 

--- a/crates/par-builtin/src/builtin/nat.rs
+++ b/crates/par-builtin/src/builtin/nat.rs
@@ -16,6 +16,7 @@ inventory::submit!(ExternalTypeDef {
         module: "Nat",
         name: "Nat"
     },
+    doc: r"A primitive type representing an unlimited-precision natural number.",
     typ: Type::Primitive(Span::None, PrimitiveType::Nat)
 });
 

--- a/crates/par-builtin/src/builtin/string.rs
+++ b/crates/par-builtin/src/builtin/string.rs
@@ -21,6 +21,7 @@ inventory::submit!(ExternalTypeDef {
         module: "String",
         name: "String"
     },
+    doc: r"A primitive type representing a UTF-8 encoded string.",
     typ: Type::Primitive(Span::None, PrimitiveType::String)
 });
 

--- a/crates/par-core/src/frontend_impl/language.rs
+++ b/crates/par-core/src/frontend_impl/language.rs
@@ -178,6 +178,12 @@ impl GlobalName<Unresolved> {
     }
 }
 
+impl GlobalName<Universal> {
+    pub fn is_primary_export(&self) -> bool {
+        self.primary == self.module.module
+    }
+}
+
 impl<S> GlobalName<S> {
     pub fn new(span: Span, module: S, primary: String) -> Self {
         Self {

--- a/crates/par-core/src/frontend_impl/program.rs
+++ b/crates/par-core/src/frontend_impl/program.rs
@@ -6,7 +6,7 @@ use indexmap::IndexMap;
 use crate::location::{FileName, Point, Span, Spanning};
 
 use super::{
-    language::{CompileError, GlobalName, LocalName, TypeParameter, Unresolved},
+    language::{CompileError, GlobalName, TypeParameter, Unresolved},
     parse::SyntaxError,
     process::{self, HoverInfo},
     types::{Context, Type, TypeDefs, TypeError},
@@ -126,21 +126,16 @@ pub struct Definition<Expr, S> {
 }
 
 impl TypeDef<Unresolved> {
-    pub fn external(name: &'static str, params: &[&'static str], typ: Type<Unresolved>) -> Self {
+    pub fn external(name: &'static str, doc: &'static str, typ: Type<Unresolved>) -> Self {
         Self {
             span: Default::default(),
             exported: true,
-            doc: None,
+            doc: Some(DocComment {
+                span: Span::None,
+                markdown: ArcStr::from(doc),
+            }),
             name: GlobalName::<Unresolved>::external(None, name),
-            params: params
-                .into_iter()
-                .map(|&var| {
-                    TypeParameter::any(LocalName {
-                        span: Default::default(),
-                        string: ArcStr::from(var),
-                    })
-                })
-                .collect(),
+            params: Vec::new(),
             typ,
         }
     }

--- a/crates/par-core/src/frontend_impl/types/display.rs
+++ b/crates/par-core/src/frontend_impl/types/display.rs
@@ -49,6 +49,16 @@ impl TypeRenderOptions {
             ..self
         }
     }
+
+    fn write_indentation(self, f: &mut impl Write) -> fmt::Result {
+        if !self.compact {
+            write!(f, "\n")?;
+            for _ in 0..self.indent {
+                write!(f, "  ")?;
+            }
+        }
+        Ok(())
+    }
 }
 
 impl<S: Clone> Type<S> {
@@ -406,30 +416,32 @@ fn write_braced_branches<S: Clone, N: GlobalNameWriter<S>>(
 
     write!(f, "{prefix} {{")?;
 
-    if options.compact {
-        for (branch, branch_type) in branches {
-            if choice {
-                write!(f, ".{branch} => ")?;
+    for (branch, branch_type) in branches {
+        let options = options.next_indent();
+        options.write_indentation(f)?;
+        write!(f, ".{branch}")?;
+        if choice {
+            if matches!(branch_type, Type::Function(.., vars) if vars.is_empty())
+                || matches!(branch_type, Type::Forall(..))
+            {
+                write_pair_like(f, names, "(", ") =>", branch_type, true, options)?;
             } else {
-                write!(f, ".{branch} ")?;
+                write!(f, " => ")?;
+                write_type_with_options(f, names, branch_type, options)?;
+            }
+        } else {
+            if matches!(branch_type, Type::Break(_) | Type::Exists(..))
+                || matches!(branch_type, Type::Pair(.., vars) if vars.is_empty())
+            {
+                // no space between `.foo` and `!`/`(`
+            } else {
+                write!(f, " ")?;
             }
             write_type_with_options(f, names, branch_type, options)?;
-            write!(f, ",")?;
         }
-        return write!(f, "}}");
-    }
-
-    for (branch, branch_type) in branches {
-        indentation(f, options.indent + 1)?;
-        if choice {
-            write!(f, ".{branch} => ")?;
-        } else {
-            write!(f, ".{branch} ")?;
-        }
-        write_type_with_options(f, names, branch_type, options.next_indent())?;
         write!(f, ",")?;
     }
-    indentation(f, options.indent)?;
+    options.write_indentation(f)?;
     write!(f, "}}")
 }
 
@@ -460,12 +472,4 @@ fn dual_keyword_hover_span<S>(full_span: &Span, name: &GlobalName<S>) -> Span {
         }
         _ => Span::None,
     }
-}
-
-fn indentation(f: &mut impl Write, indent: usize) -> fmt::Result {
-    write!(f, "\n")?;
-    for _ in 0..indent {
-        write!(f, "  ")?;
-    }
-    Ok(())
 }

--- a/crates/par-core/src/frontend_impl/types/registry.rs
+++ b/crates/par-core/src/frontend_impl/types/registry.rs
@@ -8,6 +8,7 @@ use std::sync::LazyLock;
 pub struct ExternalTypeDef {
     pub path: DefinitionRef<'static>,
     pub typ: Type<Unresolved>,
+    pub doc: &'static str,
 }
 
 inventory::collect!(ExternalTypeDef);

--- a/crates/par-core/src/workspace.rs
+++ b/crates/par-core/src/workspace.rs
@@ -2445,10 +2445,8 @@ fn write_global_name_in_file(
         }
 
         for (alias, module) in &scope.aliases {
-            if module == &name.module {
-                if name.primary == module.module {
-                    return write!(f, "{alias}");
-                }
+            if module == &name.module && name.is_primary_export() {
+                return write!(f, "{alias}");
             }
         }
     }

--- a/crates/par-doc/src/html.rs
+++ b/crates/par-doc/src/html.rs
@@ -106,7 +106,7 @@ fn render_item_name_link(name: &GlobalName<Universal>, href: &str) -> String {
     let href = escape_html(href);
     let title = escape_html(&full_global_name(name));
 
-    if name.primary == *module_name {
+    if name.is_primary_export() {
         return format!(
             r#"<a class="item-link" href="{href}" title="{title}"><span class="item-name">{primary}</span></a>"#
         );
@@ -119,7 +119,7 @@ fn render_item_name_link(name: &GlobalName<Universal>, href: &str) -> String {
 }
 
 fn short_global_name(name: &GlobalName<Universal>) -> String {
-    if name.primary == name.module.module {
+    if name.is_primary_export() {
         name.primary.clone()
     } else {
         format!("{}.{}", name.module.module, name.primary)

--- a/crates/par-doc/src/load.rs
+++ b/crates/par-doc/src/load.rs
@@ -340,13 +340,15 @@ fn sort_modules(modules: &mut [ModuleModel]) {
 
 fn sort_items(items: &mut [ItemModel]) {
     items.sort_by(|left, right| {
-        left.kind
-            .cmp(&right.kind)
+        (left.kind.cmp(&right.kind))
             .then_with(|| {
-                left.name
-                    .primary
-                    .to_lowercase()
-                    .cmp(&right.name.primary.to_lowercase())
+                // reverse-sort the bool: we want primary export first and true > false
+                (left.name.is_primary_export())
+                    .cmp(&right.name.is_primary_export())
+                    .reverse()
+            })
+            .then_with(|| {
+                (left.name.primary.to_lowercase()).cmp(&right.name.primary.to_lowercase())
             })
             .then_with(|| left.name.primary.cmp(&right.name.primary))
     });


### PR DESCRIPTION
* Render choices and eithers more like they'd typically be written (`.none!`, `.add(String) => self` rather than `.none !`, `.add => [String] self`)
* Order primary exports (String.String, Map.Map) first in their module pages
* Add docs for primitive types