### PR TITLE
fix: make brace grouping transparent in conditions so `not { x is .ok y }` binds in else

### DIFF
--- a/crates/par-core/src/frontend_impl/language.rs
+++ b/crates/par-core/src/frontend_impl/language.rs
@@ -899,6 +899,8 @@ impl Context {
     fn expression_to_condition(expr: Expression<Unresolved>) -> Condition<Unresolved> {
         match expr {
             Expression::Condition(_, condition) => *condition,
+            // Brace grouping is transparent for conditions (issue #203).
+            Expression::Grouped(_, inner) => Self::expression_to_condition(*inner),
             other => {
                 let span = other.span();
                 Condition::Bool(span, Box::new(other))

--- a/crates/par-core/src/frontend_impl/parse.rs
+++ b/crates/par-core/src/frontend_impl/parse.rs
@@ -1456,6 +1456,9 @@ fn pattern_payload_receive(input: &mut Input) -> Result<Pattern<Unresolved>> {
 fn expression_to_condition(expr: Expression<Unresolved>) -> Condition<Unresolved> {
     match expr {
         Expression::Condition(_, cond) => *cond,
+        // Brace grouping is transparent for conditions: `not { x is .ok y }`
+        // must export the same bindings as `not x is .ok y` (issue #203).
+        Expression::Grouped(_, inner) => expression_to_condition(*inner),
         other => Condition::Bool(other.span(), Box::new(other)),
     }
 }
@@ -4051,6 +4054,52 @@ def Value = {a < b} < c
                         if matches!(*inner, Expression::ComparisonChain { .. })
                 ));
             }
+            other => panic!("unexpected AST: {other:#?}"),
+        }
+    }
+
+    #[test]
+    fn test_parse_grouped_not_condition_is_transparent() {
+        // Issue #203: `not { r is .ok x }` must desugar to the same
+        // condition as `not r is .ok x`, so `x` binds in the else branch.
+        let expr = parse_single_definition_expression(
+            "\
+module Main
+
+def Value = not {r is .ok x}
+",
+        );
+        match expr {
+            Expression::Condition(_, cond) => match *cond {
+                Condition::Not(_, inner) => {
+                    assert!(
+                        matches!(*inner, Condition::Is { .. }),
+                        "grouped condition should unwrap to Is, got: {inner:#?}"
+                    );
+                }
+                other => panic!("expected Not condition, got: {other:#?}"),
+            },
+            other => panic!("unexpected AST: {other:#?}"),
+        }
+
+        // Nested grouping unwraps recursively.
+        let expr = parse_single_definition_expression(
+            "\
+module Main
+
+def Value = not {{r is .ok x}}
+",
+        );
+        match expr {
+            Expression::Condition(_, cond) => match *cond {
+                Condition::Not(_, inner) => {
+                    assert!(
+                        matches!(*inner, Condition::Is { .. }),
+                        "nested grouped condition should unwrap to Is, got: {inner:#?}"
+                    );
+                }
+                other => panic!("expected Not condition, got: {other:#?}"),
+            },
             other => panic!("unexpected AST: {other:#?}"),
         }
     }


### PR DESCRIPTION
## Summary
`not { r is .ok x }` now binds `x` in the `else` branch exactly like the brace-less `not r is .ok x`. Brace grouping around a condition was opaque to the condition desugar, so the grouped form lost the pattern bindings the negated branch should receive and failed with "Variable `x` does not exist."

## Why this matters
#203 reduced this to two otherwise-identical definitions from the [Conditions & If docs](https://par.run/book/quality_of_life/if) differing only by `{ }`, and faiface confirmed the bug ("Good find, thank you!"). The root cause: `{ ... }` parses to `Expression::Grouped`, and `expression_to_condition` only unwrapped `Expression::Condition` - anything else, including a grouped condition, collapsed to an opaque `Condition::Bool`, which exports no pattern bindings to the complementary branch.

The fix unwraps `Expression::Grouped` recursively in both copies of `expression_to_condition` (`parse.rs` for the `not`/`and`/`or` infix parsers, `language.rs` for the comparison-chain desugar), so `not { COND }`, `{ COND } and { COND }`, and nested `not {{ COND }}` all produce the same `Condition` AST as their ungrouped equivalents - the binding behavior follows by construction.

## Testing
- New parser regression test `test_parse_grouped_not_condition_is_transparent` asserts `not {r is .ok x}` and nested `not {{r is .ok x}}` desugar to `Condition::Not(Condition::Is ...)` rather than `Not(Bool(Grouped(...)))`
- `cargo test -p par-core`: all parse tests pass (26); the only failures on this machine (`*_keeps_named_fixpoint_aliases_after_expansion`, 2 tests) fail identically on clean `main` and are unrelated to this change

Fixes #203
