### PR TITLE
Fix outdated Par Book contents

### DIFF
--- a/docs/src/quality_of_life/pipes.md
+++ b/docs/src/quality_of_life/pipes.md
@@ -22,7 +22,7 @@ def Square = [n: Nat] n * n
 Without pipes you call them inside one another:
 
 ```par
-let result = Square(Add(3, Double(4)))  // = 196
+let result = Square(Add(3, Double(4)))  // = 121
 ```
 
 With pipes you can say the same thing in the order you want to read it:

--- a/docs/src/structure/definitions_and_declarations.md
+++ b/docs/src/structure/definitions_and_declarations.md
@@ -80,7 +80,7 @@ module Main
 def MyNumber = 7
 ```
 
-In this case, Par is able to infer the type of `MyNumber` as [`Nat`](./primitive_types.md#nat)
+In this case, Par is able to infer the type of `MyNumber` as [`Nat`](./primitive_types.md)
 (a natural number), so no type annotation is needed. Often, a type annotation is needed, or wanted.
 In those cases, we can add it using a colon after the name:
 


### PR DESCRIPTION
There are two minor mistakes in the Par Book, which this PR fixes:

* Updates in [Primitive Types](https://par.run/book/structure/primitive_types) section has rendered the link ``[`Nat`](./primitive_types.md#nat)`` in [Definitions & Declarations](https://par.run/book/structure/definitions_and_declarations) outdated (not quite "broken", but still points to a nonexistent subsection)
* In [Pipes](https://par.run/book/quality_of_life/pipes), the expression `Square(Add(3, Double(4)))` should evaluate to 121, not 196