### PR TITLE
Add codelens support to run top level definition & test

### DIFF
--- a/src/language_server/instance.rs
+++ b/src/language_server/instance.rs
@@ -1,13 +1,13 @@
 use super::io::IO;
 use crate::language_server::data::ToLspPosition;
-use crate::package_utils::SourceLookup;
+use crate::package_utils::{SourceLookup, root_module_slash_path};
 use crate::workspace_support::{
     ScopedTypeError, WorkspaceBuildError, checked_workspace_from_path,
     checked_workspace_from_single_file,
 };
 use indexmap::IndexMap;
 use lsp_types::{self as lsp, Uri};
-use par_core::frontend::language::GlobalName;
+use par_core::frontend::{Type, language::GlobalName};
 use par_core::source::{FileName, Span};
 use par_core::workspace::{
     CheckedWorkspace, SourceOverrides, WorkspaceDiscoveryError, WorkspaceError,
@@ -231,6 +231,50 @@ impl Instance {
             symbols.into_values().collect(),
         ))
     }
+
+    pub fn provide_code_lenses(&self, params: &lsp::CodeLensParams) -> Option<Vec<lsp::CodeLens>> {
+        tracing::debug!("Handling code lens request with params: {:?}", params);
+
+        let Some(checked) = self.checked.as_ref() else {
+            return None;
+        };
+
+        Some(
+            checked
+                .checked_module()
+                .definitions
+                .iter()
+                .filter_map(|(name, (definition, typ))| {
+                    if definition.span.file() != Some(self.file.clone()) || !matches!(typ, Type::Break(_)) {
+                        return None;
+                    }
+
+                    let module_path =
+                        root_module_slash_path(checked.workspace().root_package(), &name.module)?;
+                    let (start, _) = definition.span.points()?;
+                    Some(lsp::CodeLens {
+                        range: lsp::Range {
+                            start: start.to_lsp_position(),
+                            end: start.to_lsp_position(),
+                        },
+                        command: Some(lsp::Command {
+                            title: "Run".to_string(),
+                            command: "par.runDefinitionCli".to_string(),
+                            arguments: Some(vec![
+                                serde_json::Value::String(self.uri.to_string()),
+                                serde_json::Value::String(format!(
+                                    "{module_path}.{}",
+                                    name.primary
+                                )),
+                            ]),
+                        }),
+                        data: None,
+                    })
+                })
+                .collect(),
+        )
+    }
+
     pub fn handle_goto_declaration(
         &self,
         params: &lsp::GotoDefinitionParams,

--- a/src/language_server/instance.rs
+++ b/src/language_server/instance.rs
@@ -245,12 +245,20 @@ impl Instance {
                 .definitions
                 .iter()
                 .filter_map(|(name, (definition, typ))| {
-                    if definition.span.file() != Some(self.file.clone()) || !matches!(typ, Type::Break(_)) {
+                    if definition.span.file() != Some(self.file.clone()) {
                         return None;
                     }
 
                     let module_path =
                         root_module_slash_path(checked.workspace().root_package(), &name.module)?;
+                    let (title, command) =
+                        if name.primary.starts_with("Test") && name.primary != "Test" {
+                            ("Run Test", "par.runTestCli")
+                        } else if matches!(typ, Type::Break(_)) {
+                            ("Run", "par.runDefinitionCli")
+                        } else {
+                            return None;
+                        };
                     let (start, _) = definition.span.points()?;
                     Some(lsp::CodeLens {
                         range: lsp::Range {
@@ -258,8 +266,8 @@ impl Instance {
                             end: start.to_lsp_position(),
                         },
                         command: Some(lsp::Command {
-                            title: "Run".to_string(),
-                            command: "par.runDefinitionCli".to_string(),
+                            title: title.to_string(),
+                            command: command.to_string(),
                             arguments: Some(vec![
                                 serde_json::Value::String(self.uri.to_string()),
                                 serde_json::Value::String(format!(

--- a/src/language_server/server.rs
+++ b/src/language_server/server.rs
@@ -4,7 +4,9 @@ use crate::language_server::feedback::{FeedbackBookKeeper, diagnostic_for_error}
 use crate::language_server::instance::Instance;
 use lsp_server::{Connection, ErrorCode};
 use lsp_types::notification::DidSaveTextDocument;
-use lsp_types::request::{DocumentSymbolRequest, ExecuteCommand, GotoDeclaration, GotoDefinition};
+use lsp_types::request::{
+    CodeLensRequest, DocumentSymbolRequest, ExecuteCommand, GotoDeclaration, GotoDefinition,
+};
 use lsp_types::{self as lsp, InitializeParams, Uri};
 use par_builtin::get_builtin_source;
 use std::collections::HashMap;
@@ -68,6 +70,12 @@ impl<'c> LanguageServer<'c> {
                 let params = extract_request::<DocumentSymbolRequest>(request);
                 self.handle_request_instance(request_id, &params.text_document.uri, |instance| {
                     instance.provide_document_symbols(&params)
+                })
+            }
+            CodeLensRequest::METHOD => {
+                let params = extract_request::<CodeLensRequest>(request);
+                self.handle_request_instance(request_id, &params.text_document.uri, |instance| {
+                    instance.provide_code_lenses(&params)
                 })
             }
             GotoDeclaration::METHOD => {
@@ -256,6 +264,9 @@ fn initialize_lsp(connection: &Connection) -> InitializeParams {
         )),
         hover_provider: Some(lsp::HoverProviderCapability::Simple(true)),
         document_symbol_provider: Some(lsp::OneOf::Left(true)),
+        code_lens_provider: Some(lsp::CodeLensOptions {
+            resolve_provider: Some(false),
+        }),
         declaration_provider: Some(lsp::DeclarationCapability::Simple(true)),
         definition_provider: Some(lsp::OneOf::Left(true)),
         execute_command_provider: Some(lsp::ExecuteCommandOptions {


### PR DESCRIPTION
Now a codelens action will appear at the top of topp level definition to run the program : 
<img width="218" height="96" alt="image" src="https://github.com/user-attachments/assets/2daa2f8c-9254-42d6-ad1d-e359eae2d284" />

Companion with : https://github.com/s15n/par-vscode/pull/6
