### PR TITLE
 typechecking: infer .begin.case result type in chan blocks

### DIFF
--- a/crates/par-core/src/frontend_impl/types/checking.rs
+++ b/crates/par-core/src/frontend_impl/types/checking.rs
@@ -1611,7 +1611,12 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
         mode: &ProcessAnalyzerMode,
         emit: &mut impl FnMut(TypeError<S>),
     ) -> (Command<Type<S>, S>, Option<Type<S>>) {
-        if let Some(inference_subject) = inference_subject {
+        // when inferring another subject, .begin is only problematic if this
+        // object's type is still unknown. known recursive types
+        // can be checked normally.
+        if let Some(inference_subject) = inference_subject
+            && !matches!(typ, Type::Recursive { .. })
+        {
             emit(TypeError::TypeMustBeKnownAtThisPoint(
                 span.clone(),
                 inference_subject.clone(),
@@ -1693,7 +1698,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
         if let Err(e) = self.put(span, object.clone(), expanded) {
             emit(e);
         }
-        let (process, _inferred_type) = self.analyze_process(process, mode, emit);
+        let (process, inferred_type) = self.analyze_process(process, mode, emit);
         (
             Command::Begin {
                 unfounded,
@@ -1701,7 +1706,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
                 captures: captures.clone(),
                 body: process,
             },
-            None,
+            inferred_type,
         )
     }
 

--- a/tests/src/BeginInference.par
+++ b/tests/src/BeginInference.par
@@ -1,0 +1,89 @@
+// ref: https://github.com/par-team/par-lang/issues/218
+module BeginInference
+
+import {
+  @core/Bool
+  @core/List
+  @core/Nat
+  @core/Option
+  @core/Test
+  @core/Try
+}
+
+dec Head : <a: box> [List<a>] Option<a>
+def Head = <a: box> [items] chan return {
+  let res = items.begin.case {
+    .end! => .none!,
+    .item(x) _ => .some x,
+  }
+  return <> res
+}
+
+dec HeadAnnotated : <a: box> [List<a>] Option<a>
+def HeadAnnotated = <a: box> [items] chan return {
+  let res: Option<a> = items.begin.case {
+    .end! => .none!,
+    .item(x) _ => .some x,
+  }
+  return <> res
+}
+
+dec IsEmpty : <a: box> [List<a>] Bool
+def IsEmpty = <a: box> [items] chan return {
+  return <> items.begin.case {
+    .end! => .true!,
+    .item(_) _ => .false!,
+  }
+}
+
+dec FirstOk : [List<Nat>] Try<!, Nat>
+def FirstOk = [items] chan return {
+  catch e => { return <> .err e }
+  let try head = items.begin.case {
+    .end! => .err !,
+    .item(x) _ => .ok x,
+  }
+  return <> .ok head
+}
+
+def TestBeginInference : [Test] ! = [test] do {
+  let emptyList: List<Nat> = *()
+  let emptyIsNone = Head(emptyList).case {
+    .some _ => .false!,
+    .none! => .true!,
+  }
+  test.assert("Head of empty list is none", emptyIsNone)
+
+  let firstIsSeven = Head(*(7, 8, 9)).case {
+    .some x => x == 7,
+    .none! => .false!,
+  }
+  test.assert("Head of *(7, 8, 9) is some 7", firstIsSeven)
+
+  let annotatedIsOne = HeadAnnotated(*(1, 2)).case {
+    .some x => x == 1,
+    .none! => .false!,
+  }
+  test.assert("HeadAnnotated of *(1, 2) is some 1", annotatedIsOne)
+
+  let anotherEmpty: List<Nat> = *()
+  test.assert("IsEmpty of empty list is true", IsEmpty(anotherEmpty))
+
+  let single: List<Nat> = *(1)
+  test.assert("IsEmpty of *(1) is false", IsEmpty(single).case {
+    .true! => .false!,
+    .false! => .true!,
+  })
+
+  let firstOk = FirstOk(*(5, 6)).case {
+    .ok x => x == 5,
+    .err! => .false!,
+  }
+  test.assert("FirstOk of *(5, 6) is ok 5", firstOk)
+
+  let firstErr = FirstOk(*()).case {
+    .ok _ => .false!,
+    .err! => .true!,
+  }
+  test.assert("FirstOk of empty list is err", firstErr)
+} in !


### PR DESCRIPTION
## Description

Closes #218 

Fixed `begin.case` so it can infer the result type without an annotation when the recursive subject's type is already known