### PR TITLE
refactor: update Arena struct to use Vec<ArcStr> for strings

### DIFF
--- a/crates/par-core/src/backend/flat/transpiler.rs
+++ b/crates/par-core/src/backend/flat/transpiler.rs
@@ -80,7 +80,7 @@ impl Transpiled<Unlinked> {
                 match ty {
                     Type::Either(_, variants) | Type::Choice(_, variants) => {
                         for k in variants.keys() {
-                            arena.intern(k.string.as_str());
+                            arena.intern(&k.string);
                         }
                     }
                     _ => {}
@@ -273,7 +273,7 @@ impl ProgramTranspiler {
                 Global::Fanout(self.dest.alloc_clone(&s))
             }
             Tree::Signal(arc_str, tree) => Global::Value(GlobalValue::Either(
-                self.dest.intern(arc_str.as_str()),
+                self.dest.intern(&arc_str),
                 self.transpile_tree_and_alloc(*tree),
             )),
             Tree::Choice(captures, hash_map, els) => {
@@ -283,7 +283,7 @@ impl ProgramTranspiler {
                     .map(|(k, v)| (k.clone(), v.clone()))
                     .chain(els.map(|id| (ArcStr::from(""), id)))
                     .map(|(signal, id)| {
-                        let signal = self.dest.intern(signal.as_str());
+                        let signal = self.dest.intern(&signal);
                         let package = self.id_to_package.get(&id).unwrap().clone();
                         let (package, length) = self.transpile_casebranch_package(package);
                         maximum_casebranch_length = maximum_casebranch_length.max(length);

--- a/crates/par-runtime/src/flat/arena.rs
+++ b/crates/par-runtime/src/flat/arena.rs
@@ -14,7 +14,7 @@ use std::sync::OnceLock;
 #[derive(Serialize, Deserialize)]
 pub struct Arena<Ext: Clone> {
     pub(crate) nodes: Vec<Global<Ext>>,
-    pub(crate) strings: String,
+    pub(crate) strings: Vec<String>,
     pub(crate) string_to_location: BTreeMap<String, Index<Ext, str>>,
     pub(crate) case_branches: Vec<(Index<Ext, str>, PackageBody<Ext>)>,
     #[serde(
@@ -59,7 +59,7 @@ impl<Ext: Clone> Default for Arena<Ext> {
     fn default() -> Self {
         Self {
             nodes: vec![],
-            strings: String::new(),
+            strings: vec![],
             string_to_location: BTreeMap::new(),
             case_branches: vec![],
             packages: vec![],
@@ -87,7 +87,7 @@ impl<Ext: Clone> Arena<Ext> {
             + self.case_branches.len() * size_of::<(Index<Ext, str>, PackageBody<Ext>)>()
     }
     pub fn empty_string(&self) -> Index<Ext, str> {
-        Index((0, 0))
+        Index(0)
     }
     pub fn intern(&mut self, s: &str) -> Index<Ext, str> {
         if s.is_empty() {
@@ -209,14 +209,14 @@ sized_indexable!(packages, OnceLock<Package<Ext>>);
 sized_indexable!(nodes, Global<Ext>);
 
 impl<Ext: Clone> Indexable<Ext> for str {
-    type Store = (usize, usize);
+    type Store = usize;
     fn get<'s>(store: &'s Arena<Ext>, index: Index<Ext, Self>) -> &'s Self {
-        &store.strings[index.0.0..index.0.0 + index.0.1]
+        &store.strings[index.0]
     }
     fn alloc_clone<'s>(store: &'s mut Arena<Ext>, data: &Self) -> Index<Ext, Self> {
-        let start = store.strings.len();
-        store.strings.push_str(data);
-        Index((start, data.len()))
+        let index = store.strings.len();
+        store.strings.push(data.into());
+        Index(index)
     }
 }
 

--- a/crates/par-runtime/src/flat/arena.rs
+++ b/crates/par-runtime/src/flat/arena.rs
@@ -3,6 +3,7 @@ use crate::flat::{
     runtime::PackageBody,
     show::{Showable, Shower},
 };
+use arcstr::ArcStr;
 use serde::{Deserialize, Deserializer, Serialize};
 use std::collections::BTreeMap;
 use std::fmt::Debug;
@@ -14,7 +15,7 @@ use std::sync::OnceLock;
 #[derive(Serialize, Deserialize)]
 pub struct Arena<Ext: Clone> {
     pub(crate) nodes: Vec<Global<Ext>>,
-    pub(crate) strings: Vec<String>,
+    pub(crate) strings: Vec<ArcStr>,
     pub(crate) string_to_location: BTreeMap<String, Index<Ext, str>>,
     pub(crate) case_branches: Vec<(Index<Ext, str>, PackageBody<Ext>)>,
     #[serde(
@@ -89,23 +90,27 @@ impl<Ext: Clone> Arena<Ext> {
     pub fn empty_string(&self) -> Index<Ext, str> {
         Index(0)
     }
-    pub fn intern(&mut self, s: &str) -> Index<Ext, str> {
+    pub fn intern(&mut self, s: &ArcStr) -> Index<Ext, str> {
         if s.is_empty() {
             self.empty_string()
-        } else if let Some(s) = self.string_to_location.get(s) {
+        } else if let Some(s) = self.string_to_location.get(s.as_str()) {
             s.clone()
         } else {
-            let i = self.alloc_clone(s);
+            let i = Index(self.strings.len());
+            self.strings.push(s.clone());
             self.string_to_location.insert(s.to_string(), i.clone());
             i
         }
     }
-    pub fn interned(&self, s: &str) -> Option<Index<Ext, str>> {
+    pub fn interned(&self, s: &ArcStr) -> Option<Index<Ext, str>> {
         if s.is_empty() {
             Some(self.empty_string())
         } else {
-            self.string_to_location.get(s).cloned()
+            self.string_to_location.get(s.as_str()).cloned()
         }
+    }
+    pub fn get_arcstr<'s>(&'s self, index: Index<Ext, str>) -> &'s ArcStr {
+        &self.strings[index.0]
     }
 }
 

--- a/crates/par-runtime/src/flat/readback.rs
+++ b/crates/par-runtime/src/flat/readback.rs
@@ -211,23 +211,19 @@ impl Handle {
 
     pub fn signal(&mut self, chosen: ArcStr) {
         let (payload, payload_h) = linked_pair();
-        let chosen = self
-            .linker
-            .arena
-            .interned(&chosen)
-            .unwrap_or_else(|| {
-                // This happens when we send a signal that the program doesn't have
-                // and that also isn't present in the types
-                // It might still be handled by an "else" branch then
-                eprintln!(
-                    "Attempted to signal a non-interned string: `{}`
+        let chosen = self.linker.arena.interned(&chosen).unwrap_or_else(|| {
+            // This happens when we send a signal that the program doesn't have
+            // and that also isn't present in the types
+            // It might still be handled by an "else" branch then
+            eprintln!(
+                "Attempted to signal a non-interned string: `{}`
                 This is most likely type error with built in definitions.
                 Sending an empty signal instead, which will always trigger an `else` branch.
                 ",
-                    chosen
-                );
-                self.linker.arena.empty_string()
-            });
+                chosen
+            );
+            self.linker.arena.empty_string()
+        });
         let either = Node::Linear(Linear::Value(Box::new(Value::Either(chosen, payload))));
         let choice = core::mem::replace(&mut self.node, payload_h);
         self.linker.link(choice, either);
@@ -327,19 +323,16 @@ impl Handle {
     }
 
     fn intern_signal(&self, chosen: &ArcStr) -> Index<Linked, str> {
-        self.linker
-            .arena
-            .interned(&chosen)
-            .unwrap_or_else(|| {
-                eprintln!(
-                    "Attempted to provide non-interned signal data: `{}`
+        self.linker.arena.interned(&chosen).unwrap_or_else(|| {
+            eprintln!(
+                "Attempted to provide non-interned signal data: `{}`
                 This is most likely a type error with built in definitions.
                 Providing an empty signal instead, which will always trigger an `else` branch.
                 ",
-                    chosen
-                );
-                self.linker.arena.empty_string()
-            })
+                chosen
+            );
+            self.linker.arena.empty_string()
+        })
     }
 
     async fn data_from_value(&self, value: Value<Node<Linked>, Linked>) -> Result<Data> {

--- a/crates/par-runtime/src/flat/readback.rs
+++ b/crates/par-runtime/src/flat/readback.rs
@@ -214,7 +214,7 @@ impl Handle {
         let chosen = self
             .linker
             .arena
-            .interned(chosen.as_str())
+            .interned(&chosen)
             .unwrap_or_else(|| {
                 // This happens when we send a signal that the program doesn't have
                 // and that also isn't present in the types
@@ -243,7 +243,7 @@ impl Handle {
             linker,
             node: payload,
         };
-        self.linker.arena.get(name).into()
+        self.linker.arena.get_arcstr(name).clone()
     }
 
     pub fn break_(mut self) {
@@ -329,7 +329,7 @@ impl Handle {
     fn intern_signal(&self, chosen: &ArcStr) -> Index<Linked, str> {
         self.linker
             .arena
-            .interned(chosen.as_str())
+            .interned(&chosen)
             .unwrap_or_else(|| {
                 eprintln!(
                     "Attempted to provide non-interned signal data: `{}`


### PR DESCRIPTION
Now String indexes are a single `usize`.