### PR TITLE
refactor(builtin): replace all `…_…_external!` macros with a single macro

### DIFF
--- a/crates/par-builtin/src/builtin/bench.rs
+++ b/crates/par-builtin/src/builtin/bench.rs
@@ -1,21 +1,9 @@
+use par_runtime::external_def;
 use par_runtime::readback::Handle;
-use par_runtime::registry::{DefinitionRef, ExternalDef, PackageRef};
 
-macro_rules! core_bench_external {
-    ($name:literal, $f:path $(, $arg:expr)*) => {
-        inventory::submit!(ExternalDef {
-            path: DefinitionRef {
-                package: PackageRef::CORE,
-                path: &[],
-                module: "Bench",
-                name: $name,
-            },
-            f: |handle| Box::pin($f(handle $(, $arg)*)),
-        });
-    };
+external_def! {
+    @core/Bench.BlackBox => bench_black_box
 }
-
-core_bench_external!("BlackBox", bench_black_box);
 
 async fn bench_black_box(mut handle: Handle) {
     let x = handle.receive();

--- a/crates/par-builtin/src/builtin/boxmap.rs
+++ b/crates/par-builtin/src/builtin/boxmap.rs
@@ -1,30 +1,20 @@
 //package: core
 use std::sync::Arc;
 
+use par_runtime::external_def;
 use tokio::sync::Mutex;
 
 use crate::builtin::list::readback_list;
 use arcstr::literal;
 use im::OrdMap;
 use par_runtime::readback::{Data, Handle};
-use par_runtime::registry::{DefinitionRef, ExternalDef, PackageRef};
 
-macro_rules! core_boxmap_external {
-    ($name:literal, $f:path $(, $arg:expr)*) => {
-        inventory::submit!(ExternalDef {
-            path: DefinitionRef {
-                package: PackageRef::CORE,
-                path: &[],
-                module: "BoxMap",
-                name: $name,
-            },
-            f: |handle| Box::pin($f(handle $(, $arg)*)),
-        });
-    };
+external_def! {
+    @core/BoxMap.{
+        New => boxmap_new,
+        FromList => boxmap_from_list,
+    }
 }
-
-core_boxmap_external!("New", boxmap_new);
-core_boxmap_external!("FromList", boxmap_from_list);
 
 async fn boxmap_new(handle: Handle) {
     provide_boxmap(handle, OrdMap::new());

--- a/crates/par-builtin/src/builtin/byte.rs
+++ b/crates/par-builtin/src/builtin/byte.rs
@@ -5,8 +5,9 @@ use num_traits::ToPrimitive;
 use par_core::frontend::ExternalTypeDef;
 use par_core::frontend::{PrimitiveType, Type};
 use par_core::source::Span;
+use par_runtime::external_def;
 use par_runtime::readback::Handle;
-use par_runtime::registry::{DefinitionRef, ExternalDef, PackageRef};
+use par_runtime::registry::{DefinitionRef, PackageRef};
 
 inventory::submit!(ExternalTypeDef {
     path: DefinitionRef {
@@ -19,23 +20,13 @@ inventory::submit!(ExternalTypeDef {
     typ: Type::Primitive(Span::None, PrimitiveType::Byte)
 });
 
-macro_rules! core_byte_external {
-    ($name:literal, $f:path $(, $arg:expr)*) => {
-        inventory::submit!(ExternalDef {
-            path: DefinitionRef {
-                package: PackageRef::CORE,
-                path: &[],
-                module: "Byte",
-                name: $name,
-            },
-            f: |handle| Box::pin($f(handle $(, $arg)*)),
-        });
-    };
+external_def! {
+    @core/Byte.{
+        Code => byte_code,
+        FromCode => byte_from_code,
+        Is => byte_is,
+    }
 }
-
-core_byte_external!("Code", byte_code);
-core_byte_external!("FromCode", byte_from_code);
-core_byte_external!("Is", byte_is);
 
 async fn byte_code(mut handle: Handle) {
     let c = handle.receive().byte().await;

--- a/crates/par-builtin/src/builtin/bytes.rs
+++ b/crates/par-builtin/src/builtin/bytes.rs
@@ -19,8 +19,8 @@ use crate::builtin::{
 };
 use par_core::frontend::{ExternalTypeDef, PrimitiveType, Type};
 use par_core::source::Span;
-use par_runtime::readback::Handle;
-use par_runtime::registry::{DefinitionRef, ExternalDef, PackageRef};
+use par_runtime::registry::{DefinitionRef, PackageRef};
+use par_runtime::{external_def, readback::Handle};
 
 inventory::submit!(ExternalTypeDef {
     path: DefinitionRef {
@@ -33,27 +33,17 @@ inventory::submit!(ExternalTypeDef {
     typ: Type::Primitive(Span::None, PrimitiveType::Bytes)
 });
 
-macro_rules! core_bytes_external {
-    ($name:literal, $f:path $(, $arg:expr)*) => {
-        inventory::submit!(ExternalDef {
-            path: DefinitionRef {
-                package: PackageRef::CORE,
-                path: &[],
-                module: "Bytes",
-                name: $name,
-            },
-            f: |handle| Box::pin($f(handle $(, $arg)*)),
-        });
-    };
+external_def! {
+    @core/Bytes.{
+        Builder => bytes_builder,
+        Parse => bytes_parser,
+        ParseReader => bytes_parser_from_reader,
+        Reader => bytes_reader,
+        EmptyReader => bytes_empty_reader,
+        PipeReader => bytes_pipe_reader,
+        Length => bytes_length,
+    }
 }
-
-core_bytes_external!("Builder", bytes_builder);
-core_bytes_external!("Parse", bytes_parser);
-core_bytes_external!("ParseReader", bytes_parser_from_reader);
-core_bytes_external!("Reader", bytes_reader);
-core_bytes_external!("EmptyReader", bytes_empty_reader);
-core_bytes_external!("PipeReader", bytes_pipe_reader);
-core_bytes_external!("Length", bytes_length);
 
 async fn bytes_builder(mut handle: Handle) {
     let mut buf = Vec::<u8>::new();

--- a/crates/par-builtin/src/builtin/char_.rs
+++ b/crates/par-builtin/src/builtin/char_.rs
@@ -4,8 +4,9 @@ use num_traits::ToPrimitive;
 
 use par_core::frontend::{ExternalTypeDef, PrimitiveType, Type};
 use par_core::source::Span;
+use par_runtime::external_def;
 use par_runtime::readback::Handle;
-use par_runtime::registry::{DefinitionRef, ExternalDef, PackageRef};
+use par_runtime::registry::{DefinitionRef, PackageRef};
 
 inventory::submit!(ExternalTypeDef {
     path: DefinitionRef {
@@ -18,25 +19,15 @@ inventory::submit!(ExternalTypeDef {
     typ: Type::Primitive(Span::None, PrimitiveType::Char)
 });
 
-macro_rules! core_char_external {
-    ($name:literal, $f:path $(, $arg:expr)*) => {
-        inventory::submit!(ExternalDef {
-            path: DefinitionRef {
-                package: PackageRef::CORE,
-                path: &[],
-                module: "Char",
-                name: $name,
-            },
-            f: |handle| Box::pin($f(handle $(, $arg)*)),
-        });
-    };
+external_def! {
+    @core/Char.{
+        Code => char_code,
+        FromCode => char_from_code,
+        Is => char_is,
+        ToLower => char_to_lower,
+        ToUpper => char_to_upper,
+    }
 }
-
-core_char_external!("Code", char_code);
-core_char_external!("FromCode", char_from_code);
-core_char_external!("Is", char_is);
-core_char_external!("ToLower", char_to_lower);
-core_char_external!("ToUpper", char_to_upper);
 
 async fn char_code(mut handle: Handle) {
     let c = handle.receive().char().await;

--- a/crates/par-builtin/src/builtin/console.rs
+++ b/crates/par-builtin/src/builtin/console.rs
@@ -2,8 +2,8 @@
 use std::io::{Write, stdin, stdout};
 
 use arcstr::literal;
+use par_runtime::external_def;
 use par_runtime::readback::Handle;
-use par_runtime::registry::{DefinitionRef, ExternalDef, PackageRef};
 
 use par_core::frontend::ParString;
 
@@ -46,18 +46,6 @@ async fn console_open(mut handle: Handle) {
     }
 }
 
-macro_rules! basic_console_external {
-    ($name:literal, $f:path $(, $arg:expr)*) => {
-        inventory::submit!(ExternalDef {
-            path: DefinitionRef {
-                package: PackageRef::BASIC,
-                path: &[],
-                module: "Console",
-                name: $name,
-            },
-            f: |handle| Box::pin($f(handle $(, $arg)*)),
-        });
-    };
+external_def! {
+    @basic/Console.Open => console_open
 }
-
-basic_console_external!("Open", console_open);

--- a/crates/par-builtin/src/builtin/data.rs
+++ b/crates/par-builtin/src/builtin/data.rs
@@ -1,24 +1,14 @@
 //package: core
 use arcstr::literal;
+use par_runtime::external_def;
 use par_runtime::readback::Handle;
-use par_runtime::registry::{DefinitionRef, ExternalDef, PackageRef};
 
-macro_rules! core_data_external {
-    ($name:literal, $f:path $(, $arg:expr)*) => {
-        inventory::submit!(ExternalDef {
-            path: DefinitionRef {
-                package: PackageRef::CORE,
-                path: &[],
-                module: "Data",
-                name: $name,
-            },
-            f: |handle| Box::pin($f(handle $(, $arg)*)),
-        });
-    };
+external_def! {
+    @core/Data.{
+        ToString => data_to_string,
+        Compare => data_compare,
+    }
 }
-
-core_data_external!("ToString", data_to_string);
-core_data_external!("Compare", data_compare);
 
 async fn data_to_string(mut handle: Handle) {
     let value = handle.receive().data().await;

--- a/crates/par-builtin/src/builtin/debug.rs
+++ b/crates/par-builtin/src/builtin/debug.rs
@@ -1,5 +1,5 @@
+use par_runtime::external_def;
 use par_runtime::readback::Handle;
-use par_runtime::registry::{DefinitionRef, ExternalDef, PackageRef};
 
 async fn debug_log(mut handle: Handle) {
     let string = handle.receive().string().await;
@@ -7,18 +7,6 @@ async fn debug_log(mut handle: Handle) {
     handle.break_();
 }
 
-macro_rules! core_debug_external {
-    ($name:literal, $f:path $(, $arg:expr)*) => {
-        inventory::submit!(ExternalDef {
-            path: DefinitionRef {
-                package: PackageRef::CORE,
-                path: &[],
-                module: "Debug",
-                name: $name,
-            },
-            f: |handle| Box::pin($f(handle $(, $arg)*)),
-        });
-    };
+external_def! {
+    @core/Debug.Log => debug_log
 }
-
-core_debug_external!("Log", debug_log);

--- a/crates/par-builtin/src/builtin/float.rs
+++ b/crates/par-builtin/src/builtin/float.rs
@@ -6,9 +6,10 @@ use num_bigint::{BigInt, Sign};
 use num_traits::{FromPrimitive, ToPrimitive};
 use par_core::frontend::{ExternalTypeDef, PrimitiveType, Type};
 use par_core::source::Span;
+use par_runtime::external_def;
 use par_runtime::primitive::parse_float_text;
 use par_runtime::readback::Handle;
-use par_runtime::registry::{DefinitionRef, ExternalDef, PackageRef};
+use par_runtime::registry::{DefinitionRef, PackageRef};
 
 inventory::submit!(ExternalTypeDef {
     path: DefinitionRef {
@@ -21,48 +22,38 @@ inventory::submit!(ExternalTypeDef {
     typ: Type::Primitive(Span::None, PrimitiveType::Float)
 });
 
-macro_rules! core_float_external {
-    ($name:literal, $f:path $(, $arg:expr)*) => {
-        inventory::submit!(ExternalDef {
-            path: DefinitionRef {
-                package: PackageRef::CORE,
-                path: &[],
-                module: "Float",
-                name: $name,
-            },
-            f: |handle| Box::pin($f(handle $(, $arg)*)),
-        });
-    };
+external_def! {
+    @core/Float.{
+        NaN_ => float_nan,
+        Inf_ => float_inf,
+        NegInf_ => float_neg_inf,
+        Pi_ => float_pi,
+        E_ => float_e,
+        IsNaN => float_is_nan,
+        IsFinite => float_is_finite,
+        IsInfinite => float_is_infinite,
+        FromInt => float_from_int,
+        ToInt => float_to_int,
+        FromString => float_from_string,
+        Neg => float_neg,
+        Abs => float_abs,
+        Floor => float_floor,
+        Ceil => float_ceil,
+        Round => float_round,
+        Pow => float_pow,
+        Min => float_min,
+        Max => float_max,
+        Clamp => float_clamp,
+        Equals => float_equals,
+        Sqrt => float_sqrt,
+        Exp => float_exp,
+        Ln => float_ln,
+        Sin => float_sin,
+        Cos => float_cos,
+        Tan => float_tan,
+        Atan2 => float_atan2,
+    }
 }
-
-core_float_external!("NaN_", float_nan);
-core_float_external!("Inf_", float_inf);
-core_float_external!("NegInf_", float_neg_inf);
-core_float_external!("Pi_", float_pi);
-core_float_external!("E_", float_e);
-core_float_external!("IsNaN", float_is_nan);
-core_float_external!("IsFinite", float_is_finite);
-core_float_external!("IsInfinite", float_is_infinite);
-core_float_external!("FromInt", float_from_int);
-core_float_external!("ToInt", float_to_int);
-core_float_external!("FromString", float_from_string);
-core_float_external!("Neg", float_neg);
-core_float_external!("Abs", float_abs);
-core_float_external!("Floor", float_floor);
-core_float_external!("Ceil", float_ceil);
-core_float_external!("Round", float_round);
-core_float_external!("Pow", float_pow);
-core_float_external!("Min", float_min);
-core_float_external!("Max", float_max);
-core_float_external!("Clamp", float_clamp);
-core_float_external!("Equals", float_equals);
-core_float_external!("Sqrt", float_sqrt);
-core_float_external!("Exp", float_exp);
-core_float_external!("Ln", float_ln);
-core_float_external!("Sin", float_sin);
-core_float_external!("Cos", float_cos);
-core_float_external!("Tan", float_tan);
-core_float_external!("Atan2", float_atan2);
 
 fn signal_bool(mut handle: Handle, value: bool) {
     if value {

--- a/crates/par-builtin/src/builtin/http.rs
+++ b/crates/par-builtin/src/builtin/http.rs
@@ -30,26 +30,15 @@ use tokio::{net::TcpListener, signal, sync::Notify};
 use url::Url as ParsedUrl;
 
 use crate::builtin::{list::readback_list, url::provide_url_value};
-use par_runtime::primitive::ParString;
 use par_runtime::readback::Handle;
-use par_runtime::registry::{DefinitionRef, ExternalDef, PackageRef};
+use par_runtime::{external_def, primitive::ParString};
 
-macro_rules! basic_http_external {
-    ($name:literal, $f:path $(, $arg:expr)*) => {
-        inventory::submit!(ExternalDef {
-            path: DefinitionRef {
-                package: PackageRef::BASIC,
-                path: &[],
-                module: "Http",
-                name: $name,
-            },
-            f: |handle| Box::pin($f(handle $(, $arg)*)),
-        });
-    };
+external_def! {
+    @basic/Http.{
+        Fetch => http_fetch,
+        Listen => http_listen,
+    }
 }
-
-basic_http_external!("Fetch", http_fetch);
-basic_http_external!("Listen", http_listen);
 
 // ----------
 

--- a/crates/par-builtin/src/builtin/int.rs
+++ b/crates/par-builtin/src/builtin/int.rs
@@ -4,8 +4,9 @@ use num_bigint::{BigInt, BigUint};
 use num_traits::Zero;
 use par_core::frontend::{ExternalTypeDef, PrimitiveType, Type};
 use par_core::source::Span;
+use par_runtime::external_def;
 use par_runtime::readback::Handle;
-use par_runtime::registry::{DefinitionRef, ExternalDef, PackageRef};
+use par_runtime::registry::{DefinitionRef, PackageRef};
 
 inventory::submit!(ExternalTypeDef {
     path: DefinitionRef {
@@ -18,27 +19,17 @@ inventory::submit!(ExternalTypeDef {
     typ: Type::Primitive(Span::None, PrimitiveType::Int)
 });
 
-macro_rules! core_int_external {
-    ($name:literal, $f:path $(, $arg:expr)*) => {
-        inventory::submit!(ExternalDef {
-            path: DefinitionRef {
-                package: PackageRef::CORE,
-                path: &[],
-                module: "Int",
-                name: $name,
-            },
-            f: |handle| Box::pin($f(handle $(, $arg)*)),
-        });
-    };
+external_def! {
+    @core/Int.{
+        Mod => int_mod,
+        Min => int_min,
+        Max => int_max,
+        Abs => int_abs,
+        Clamp => int_clamp,
+        Range => int_range,
+        FromString => int_from_string,
+    }
 }
-
-core_int_external!("Mod", int_mod);
-core_int_external!("Min", int_min);
-core_int_external!("Max", int_max);
-core_int_external!("Abs", int_abs);
-core_int_external!("Clamp", int_clamp);
-core_int_external!("Range", int_range);
-core_int_external!("FromString", int_from_string);
 
 async fn int_mod(mut handle: Handle) {
     let x = handle.receive().int().await;

--- a/crates/par-builtin/src/builtin/json.rs
+++ b/crates/par-builtin/src/builtin/json.rs
@@ -3,27 +3,17 @@ use std::{collections::BTreeMap, sync::Arc};
 
 use crate::builtin::list::readback_list;
 use arcstr::literal;
+use par_runtime::external_def;
 use par_runtime::primitive::ParString;
 use par_runtime::readback::Handle;
-use par_runtime::registry::{DefinitionRef, ExternalDef, PackageRef};
 use serde_json::{Map, Number, Value};
 
-macro_rules! core_json_external {
-    ($name:literal, $f:path $(, $arg:expr)*) => {
-        inventory::submit!(ExternalDef {
-            path: DefinitionRef {
-                package: PackageRef::CORE,
-                path: &[],
-                module: "Json",
-                name: $name,
-            },
-            f: |handle| Box::pin($f(handle $(, $arg)*)),
-        });
-    };
+external_def! {
+    @core/Json.{
+        Encode => json_encode,
+        Decode => json_decode,
+    }
 }
-
-core_json_external!("Encode", json_encode);
-core_json_external!("Decode", json_decode);
 
 #[derive(Clone, Debug)]
 enum JsonValue {

--- a/crates/par-builtin/src/builtin/list.rs
+++ b/crates/par-builtin/src/builtin/list.rs
@@ -1,29 +1,19 @@
 //package: core
 use arcstr::literal;
+use par_runtime::external_def;
 use par_runtime::readback::{Data, Handle};
-use par_runtime::registry::{DefinitionRef, ExternalDef, PackageRef};
 use std::future::Future;
 
-macro_rules! core_list_external {
-    ($name:literal, $f:path $(, $arg:expr)*) => {
-        inventory::submit!(ExternalDef {
-            path: DefinitionRef {
-                package: PackageRef::CORE,
-                path: &[],
-                module: "List",
-                name: $name,
-            },
-            f: |handle| Box::pin($f(handle $(, $arg)*)),
-        });
-    };
+external_def! {
+    @core/List.{
+        Sort => list_sort(false),
+        SortDesc => list_sort(true),
+        SortBy => list_sort_by(false),
+        SortDescBy => list_sort_by(true),
+        SortLinearBy => list_sort_linear_by(false),
+        SortLinearDescBy => list_sort_linear_by(true),
+    }
 }
-
-core_list_external!("Sort", list_sort, false);
-core_list_external!("SortDesc", list_sort, true);
-core_list_external!("SortBy", list_sort_by, false);
-core_list_external!("SortDescBy", list_sort_by, true);
-core_list_external!("SortLinearBy", list_sort_linear_by, false);
-core_list_external!("SortLinearDescBy", list_sort_linear_by, true);
 
 pub(super) async fn readback_list<T, F>(
     mut handle: Handle,

--- a/crates/par-builtin/src/builtin/map.rs
+++ b/crates/par-builtin/src/builtin/map.rs
@@ -3,25 +3,15 @@ use std::collections::BTreeMap;
 
 use crate::builtin::list::readback_list;
 use arcstr::literal;
+use par_runtime::external_def;
 use par_runtime::readback::{Data, Handle};
-use par_runtime::registry::{DefinitionRef, ExternalDef, PackageRef};
 
-macro_rules! core_map_external {
-    ($name:literal, $f:path $(, $arg:expr)*) => {
-        inventory::submit!(ExternalDef {
-            path: DefinitionRef {
-                package: PackageRef::CORE,
-                path: &[],
-                module: "Map",
-                name: $name,
-            },
-            f: |handle| Box::pin($f(handle $(, $arg)*)),
-        });
-    };
+external_def! {
+    @core/Map.{
+        New => map_new,
+        FromList => map_from_list,
+    }
 }
-
-core_map_external!("New", map_new);
-core_map_external!("FromList", map_from_list);
 
 async fn map_new(handle: Handle) {
     provide_map(handle, BTreeMap::new()).await;

--- a/crates/par-builtin/src/builtin/nat.rs
+++ b/crates/par-builtin/src/builtin/nat.rs
@@ -6,8 +6,9 @@ use num_integer::Integer;
 use num_traits::Zero;
 use par_core::frontend::{ExternalTypeDef, PrimitiveType, Type};
 use par_core::source::Span;
+use par_runtime::external_def;
 use par_runtime::readback::Handle;
-use par_runtime::registry::{DefinitionRef, ExternalDef, PackageRef};
+use par_runtime::registry::{DefinitionRef, PackageRef};
 
 inventory::submit!(ExternalTypeDef {
     path: DefinitionRef {
@@ -20,28 +21,18 @@ inventory::submit!(ExternalTypeDef {
     typ: Type::Primitive(Span::None, PrimitiveType::Nat)
 });
 
-macro_rules! core_nat_external {
-    ($name:literal, $f:path $(, $arg:expr)*) => {
-        inventory::submit!(ExternalDef {
-            path: DefinitionRef {
-                package: PackageRef::CORE,
-                path: &[],
-                module: "Nat",
-                name: $name,
-            },
-            f: |handle| Box::pin($f(handle $(, $arg)*)),
-        });
-    };
+external_def! {
+    @core/Nat.{
+        Mod => nat_mod,
+        Min => nat_min,
+        Max => nat_max,
+        Clamp => nat_clamp,
+        Repeat => nat_repeat,
+        RepeatLazy => nat_repeat_lazy,
+        Range => nat_range,
+        FromString => nat_from_string,
+    }
 }
-
-core_nat_external!("Mod", nat_mod);
-core_nat_external!("Min", nat_min);
-core_nat_external!("Max", nat_max);
-core_nat_external!("Clamp", nat_clamp);
-core_nat_external!("Repeat", nat_repeat);
-core_nat_external!("RepeatLazy", nat_repeat_lazy);
-core_nat_external!("Range", nat_range);
-core_nat_external!("FromString", nat_from_string);
 
 async fn nat_mod(mut handle: Handle) {
     let x = handle.receive().nat().await;

--- a/crates/par-builtin/src/builtin/number.rs
+++ b/crates/par-builtin/src/builtin/number.rs
@@ -1,29 +1,19 @@
 //package: core
 use num_bigint::BigInt;
+use par_runtime::external_def;
 use par_runtime::primitive::Number;
 use par_runtime::readback::Handle;
-use par_runtime::registry::{DefinitionRef, ExternalDef, PackageRef};
 
-macro_rules! core_number_external {
-    ($name:literal, $f:path $(, $arg:expr)*) => {
-        inventory::submit!(ExternalDef {
-            path: DefinitionRef {
-                package: PackageRef::CORE,
-                path: &[],
-                module: "Number",
-                name: $name,
-            },
-            f: |handle| Box::pin($f(handle $(, $arg)*)),
-        });
-    };
+external_def! {
+    @core/Number.{
+        Zero_ => number_zero,
+        Add => number_add,
+        Sub => number_sub,
+        Mul => number_mul,
+        Div => number_div,
+        Neg => number_neg,
+    }
 }
-
-core_number_external!("Zero_", number_zero);
-core_number_external!("Add", number_add);
-core_number_external!("Sub", number_sub);
-core_number_external!("Mul", number_mul);
-core_number_external!("Div", number_div);
-core_number_external!("Neg", number_neg);
 
 async fn number_zero(mut handle: Handle) {
     handle.receive().continue_();

--- a/crates/par-builtin/src/builtin/os.rs
+++ b/crates/par-builtin/src/builtin/os.rs
@@ -8,45 +8,34 @@ use arcstr::literal;
 use bytes::Bytes;
 use futures::future::BoxFuture;
 use num_bigint::BigUint;
-use par_runtime::primitive::ParString;
 use par_runtime::readback::Handle;
-use par_runtime::registry::{DefinitionRef, ExternalDef, PackageRef};
+use par_runtime::{external_def, primitive::ParString};
 use tokio::{
     fs::{self, DirEntry, File, OpenOptions, ReadDir},
     io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
 };
 
-macro_rules! basic_os_external {
-    ($name:literal, $f:path $(, $arg:expr)*) => {
-        inventory::submit!(ExternalDef {
-            path: DefinitionRef {
-                package: PackageRef::BASIC,
-                path: &[],
-                module: "Os",
-                name: $name,
-            },
-            f: |handle| Box::pin($f(handle $(, $arg)*)),
-        });
-    };
+external_def! {
+    @basic/Os.{
+        Path => path_from_bytes,
+        Stdin => os_stdin,
+        Stdout => os_stdout,
+        Stderr => os_stderr,
+        OpenFile => os_open_file,
+        CreateOrReplaceFile => os_create_or_replace_file,
+        CreateNewFile => os_create_new_file,
+        AppendToFile => os_append_to_file,
+        CreateOrAppendToFile => os_create_or_append_to_file,
+        CreateDir => os_create_dir,
+        RemoveFile => os_remove_file,
+        RemoveDir => os_remove_dir,
+        MoveFile => os_move_file,
+        MoveDir => os_move_dir,
+        ListDir => os_list_dir,
+        TraverseDir => os_traverse_dir,
+        Env => envmap_new,
+    }
 }
-
-basic_os_external!("Path", path_from_bytes);
-basic_os_external!("Stdin", os_stdin);
-basic_os_external!("Stdout", os_stdout);
-basic_os_external!("Stderr", os_stderr);
-basic_os_external!("OpenFile", os_open_file);
-basic_os_external!("CreateOrReplaceFile", os_create_or_replace_file);
-basic_os_external!("CreateNewFile", os_create_new_file);
-basic_os_external!("AppendToFile", os_append_to_file);
-basic_os_external!("CreateOrAppendToFile", os_create_or_append_to_file);
-basic_os_external!("CreateDir", os_create_dir);
-basic_os_external!("RemoveFile", os_remove_file);
-basic_os_external!("RemoveDir", os_remove_dir);
-basic_os_external!("MoveFile", os_move_file);
-basic_os_external!("MoveDir", os_move_dir);
-basic_os_external!("ListDir", os_list_dir);
-basic_os_external!("TraverseDir", os_traverse_dir);
-basic_os_external!("Env", envmap_new);
 
 async fn path_from_bytes(mut handle: Handle) {
     let b = handle.receive().bytes().await;

--- a/crates/par-builtin/src/builtin/sql.rs
+++ b/crates/par-builtin/src/builtin/sql.rs
@@ -27,6 +27,7 @@ use futures::StreamExt;
 use futures::future::BoxFuture;
 use num_bigint::{BigInt, BigUint};
 use num_traits::ToPrimitive;
+use par_runtime::external_def;
 use tokio::time::timeout;
 
 use sqlx::any::{AnyArguments, AnyPoolOptions, AnyRow};
@@ -34,25 +35,12 @@ use sqlx::{Any, AnyPool, Column, Row as _, Transaction, TypeInfo, ValueRef};
 
 use par_runtime::primitive::{Number, ParString, Primitive};
 use par_runtime::readback::{Data, Handle};
-use par_runtime::registry::{DefinitionRef, ExternalDef, PackageRef};
 
 use crate::builtin::list::readback_list;
 
-macro_rules! basic_sql_external {
-    ($name:literal, $f:path $(, $arg:expr)*) => {
-        inventory::submit!(ExternalDef {
-            path: DefinitionRef {
-                package: PackageRef::BASIC,
-                path: &[],
-                module: "Sql",
-                name: $name,
-            },
-            f: |handle| Box::pin($f(handle $(, $arg)*)),
-        });
-    };
+external_def! {
+    @basic/Sql.Open => sql_open
 }
-
-basic_sql_external!("Open", sql_open);
 
 // All external waits are bounded by these defaults. A future `OpenWith(config)`
 // could expose them without changing the resource model.

--- a/crates/par-builtin/src/builtin/string.rs
+++ b/crates/par-builtin/src/builtin/string.rs
@@ -10,9 +10,9 @@ use crate::builtin::{
 };
 use par_core::frontend::{ExternalTypeDef, PrimitiveType, Type};
 use par_core::source::Span;
-use par_runtime::primitive::ParString;
 use par_runtime::readback::Handle;
-use par_runtime::registry::{DefinitionRef, ExternalDef, PackageRef};
+use par_runtime::registry::{DefinitionRef, PackageRef};
+use par_runtime::{external_def, primitive::ParString};
 
 inventory::submit!(ExternalTypeDef {
     path: DefinitionRef {
@@ -25,27 +25,17 @@ inventory::submit!(ExternalTypeDef {
     typ: Type::Primitive(Span::None, PrimitiveType::String)
 });
 
-macro_rules! core_string_external {
-    ($name:literal, $f:path $(, $arg:expr)*) => {
-        inventory::submit!(ExternalDef {
-            path: DefinitionRef {
-                package: PackageRef::CORE,
-                path: &[],
-                module: "String",
-                name: $name,
-            },
-            f: |handle| Box::pin($f(handle $(, $arg)*)),
-        });
-    };
+external_def! {
+    @core/String.{
+        Builder => string_builder,
+        Parse => string_parser,
+        ParseReader => string_parser_from_reader,
+        Quote => string_quote,
+        FromBytes => string_from_bytes,
+        ToLower => string_to_lower,
+        ToUpper => string_to_upper,
+    }
 }
-
-core_string_external!("Builder", string_builder);
-core_string_external!("Parse", string_parser);
-core_string_external!("ParseReader", string_parser_from_reader);
-core_string_external!("Quote", string_quote);
-core_string_external!("FromBytes", string_from_bytes);
-core_string_external!("ToLower", string_to_lower);
-core_string_external!("ToUpper", string_to_upper);
 
 async fn string_builder(mut handle: Handle) {
     let mut buf = String::new();

--- a/crates/par-builtin/src/builtin/time.rs
+++ b/crates/par-builtin/src/builtin/time.rs
@@ -6,36 +6,26 @@ use jiff::civil::{DateTime, Weekday};
 use jiff::tz::{Offset, TimeZone};
 use jiff::{SignedDuration, Span, Timestamp, Zoned};
 
+use par_runtime::external_def;
 use par_runtime::primitive::ParString;
 use par_runtime::readback::Handle;
-use par_runtime::registry::{DefinitionRef, ExternalDef, PackageRef};
 
-macro_rules! core_time_external {
-    ($name:literal, $f:path $(, $arg:expr)*) => {
-        inventory::submit!(ExternalDef {
-            path: DefinitionRef {
-                package: PackageRef::CORE,
-                path: &[],
-                module: "Time",
-                name: $name,
-            },
-            f: |handle| Box::pin($f(handle $(, $arg)*)),
-        });
-    };
+external_def! {
+    @core/Time.{
+        Now_ => time_now,
+        FromUnixNanos_ => time_from_unix_nanos,
+        Show => time_show,
+        FromRFC3339 => time_from_rfc3339,
+        ToRFC3339 => time_to_rfc3339,
+        UTC => time_utc,
+        Local => time_local,
+        Offset => time_offset,
+        Zone => time_zone,
+        InZone => time_in_zone,
+        At => time_at,
+        Parse => time_parse,
+    }
 }
-
-core_time_external!("Now_", time_now);
-core_time_external!("FromUnixNanos_", time_from_unix_nanos);
-core_time_external!("Show", time_show);
-core_time_external!("FromRFC3339", time_from_rfc3339);
-core_time_external!("ToRFC3339", time_to_rfc3339);
-core_time_external!("UTC", time_utc);
-core_time_external!("Local", time_local);
-core_time_external!("Offset", time_offset);
-core_time_external!("Zone", time_zone);
-core_time_external!("InZone", time_in_zone);
-core_time_external!("At", time_at);
-core_time_external!("Parse", time_parse);
 
 const NANOS_PER_SEC: i128 = 1_000_000_000;
 

--- a/crates/par-builtin/src/builtin/url.rs
+++ b/crates/par-builtin/src/builtin/url.rs
@@ -1,26 +1,14 @@
 use arcstr::literal;
+use par_runtime::external_def;
 use percent_encoding::percent_decode_str;
 use url::Url as ParsedUrl;
 
 use par_runtime::primitive::ParString;
 use par_runtime::readback::Handle;
-use par_runtime::registry::{DefinitionRef, ExternalDef, PackageRef};
 
-macro_rules! core_url_external {
-    ($name:literal, $f:path $(, $arg:expr)*) => {
-        inventory::submit!(ExternalDef {
-            path: DefinitionRef {
-                package: PackageRef::CORE,
-                path: &[],
-                module: "Url",
-                name: $name,
-            },
-            f: |handle| Box::pin($f(handle $(, $arg)*)),
-        });
-    };
+external_def! {
+    @core/Url.FromString => url_from_string
 }
-
-core_url_external!("FromString", url_from_string);
 
 async fn url_from_string(mut handle: Handle) {
     let input = handle.receive().string().await;

--- a/crates/par-runtime/src/registry.rs
+++ b/crates/par-runtime/src/registry.rs
@@ -45,3 +45,74 @@ static REGISTRY: LazyLock<Registry> = LazyLock::new(|| {
 pub fn get_external_fn(path: &Unlinked) -> Option<ExternalFn> {
     REGISTRY.get(path).copied()
 }
+
+#[expect(non_upper_case_globals)]
+#[doc(hidden)]
+pub mod __package_ref {
+    use super::PackageRef;
+    pub const basic: PackageRef = PackageRef::BASIC;
+    pub const core: PackageRef = PackageRef::CORE;
+}
+
+/// Provides implementation for an `external` definition.
+/// # Syntax
+/// ```ignore
+/// external_def! {
+///     @package/path/to/Module.Name => handler
+/// }
+/// external_def! {
+///     @package/path/to/Module.Name => handler(arg1, arg2)
+/// }
+/// external_def! {
+///     @package/path/to/Module.{
+///         Name1 => handler1,
+///         Name2 => handler2(arg1, arg2),
+///     }
+/// }
+/// ```
+/// Here, `package` is either `core` or `basic`, and `handler` must be the name of an async function
+/// that takes a [`Handle`](crate::readback::Handle) as the first argument,
+/// while all `arg`s would be passed as subsequent arguments.
+/// See `par-builtin/src/builtin/` for usages.
+///
+/// The `%`-branches shown in the definition are an implementation detail and shouldn't be used.
+#[macro_export]
+macro_rules! external_def {
+    (@$pkg:ident/$($path:ident)/+.$name:ident => $f:ident($($arg:expr),*)) => {
+        ::inventory::submit!($crate::registry::ExternalDef {
+            f: |handle| ::std::boxed::Box::pin($f(handle, $($arg),*)),
+            path: {
+                let [ref path @ .., module] = [$(::core::stringify!($path)),+];
+                $crate::registry::DefinitionRef {
+                    name: ::core::stringify!($name),
+                    package: $crate::registry::__package_ref::$pkg,
+                    module,
+                    path,
+                }
+            }
+        });
+    };
+
+    (@$($path:ident)/+.$name:ident => $f:ident) => {
+        $crate::external_def! { @$($path)/+.$name => $f() }
+    };
+    (@$($path:ident)/+.$name:ident => $f:ident($(arg:expr),+ ,)) => {
+        $crate::external_def! { @$($path)/+.$name => $f($($arg),+) }
+    };
+
+    (@$($path:ident)/+.{$($name:ident => $f:ident$(($($param:tt)*))?),*}) => {
+        $crate::external_def! { %exp[$($path)+]; $($name => $f($($($param)*)?)),* }
+    };
+    (@$($path:ident)/+.{$($name:ident => $f:ident$(($($param:tt)*))?),+ ,}) => {
+        $crate::external_def! { @$($path)/+.{$($name => $f$(($($param)*))?),+ } }
+    };
+
+    (%exp1[$($path:ident)+]; $name:ident => $f:ident$params:tt) => {
+        $crate::external_def! { @$($path)/+.$name => $f$params }
+    };
+    (%exp$path:tt; $($name:ident => $f:ident$params:tt),*) => {
+        $(
+            $crate::external_def! {%exp1 $path; $name => $f$params }
+        )*
+    };
+}


### PR DESCRIPTION
The macro is available at `par_runtime::external_def!`. Usage syntax:
```rust
external_def! {
    @package/path/to/Module.Name => handler
}
external_def! {
    @package/path/to/Module.Name => handler(arg1, arg2)
}
external_def! {
    @package/path/to/Module.{
        Name1 => handler1,
        Name2 => handler2(arg1, arg2),
    }
}
```