### PR TITLE
Flatten low and high-level ASTs, improving stack usage

### DIFF
--- a/crates/par-core/src/backend/tree/compiler.rs
+++ b/crates/par-core/src/backend/tree/compiler.rs
@@ -9,7 +9,9 @@ use crate::frontend_impl::program::DefinitionBody;
 use crate::frontend_impl::types::core::get_primitive_type;
 use crate::frontend_impl::{
     language::{GlobalName, LocalName, TypeParameter, Universal},
-    process::{Captures, Command, Expression, PollKind, Process},
+    process::{
+        Captures, Command, Expression, PollKind, Process, Step, TerminalCommand, Terminator,
+    },
     types::Type,
 };
 use crate::runtime_impl::tree::net::{Net, Tree};
@@ -627,20 +629,40 @@ impl Compiler {
     }
 
     fn compile_process(&mut self, proc: &Process<Type<Universal>, Universal>) -> Result<()> {
-        match proc {
-            Process::Let {
-                name, value, then, ..
-            } => self.compile_process_let(name, value, then),
+        let mut received_parameters = Vec::new();
+        for step in &proc.steps {
+            match step {
+                Step::Let { name, value, .. } => {
+                    let value = self.compile_expression(value)?;
+                    self.bind_variable(name.clone(), value)?;
+                }
+                Step::Do {
+                    span,
+                    name,
+                    usage,
+                    typ,
+                    command,
+                } => self.compile_command(
+                    span,
+                    name.clone(),
+                    usage,
+                    typ.clone(),
+                    command,
+                    &mut received_parameters,
+                )?,
+            }
+        }
 
-            Process::Do {
+        match &proc.terminator {
+            Terminator::Do {
                 span,
                 name,
                 usage,
                 typ,
                 command,
-            } => self.compile_process_do(span, name, usage, typ, command),
+            } => self.compile_terminal_command(span, name, usage, typ, command)?,
 
-            Process::Poll {
+            Terminator::Poll {
                 span: _span,
                 kind,
                 driver,
@@ -652,97 +674,104 @@ impl Compiler {
                 then,
                 else_,
             } => self.compile_process_poll(
-                proc, kind, driver, point, clients, name, captures, then, else_,
-            ),
+                proc.span(),
+                kind,
+                driver,
+                point,
+                clients,
+                name,
+                captures,
+                then,
+                else_,
+            )?,
 
-            Process::Submit {
+            Terminator::Submit {
                 span: _span,
                 driver,
                 point,
                 values,
                 captures,
-            } => self.compile_process_submit(driver, point, values, captures),
+            } => self.compile_process_submit(driver, point, values, captures)?,
 
-            Process::Block(_, index, body, process) => {
-                self.compile_process_block(*index, body, process)
+            Terminator::Block(_, index, body, process) => {
+                self.compile_process_block(*index, body, process)?
             }
 
-            Process::Goto(_, index, _) => self.compile_process_goto(*index),
+            Terminator::Goto(_, index, _) => self.compile_process_goto(*index)?,
 
-            Process::Unreachable(_) => self.compile_process_unreachable(),
+            Terminator::Unreachable(_) => self.compile_process_unreachable()?,
         }
+
+        for (parameter, was_empty_before) in received_parameters.into_iter().rev() {
+            if was_empty_before {
+                self.type_defs.vars.shift_remove(&parameter);
+            }
+        }
+        Ok(())
     }
 
     fn compile_command(
         &mut self,
-        span: &Span,
+        _span: &Span,
         name: LocalName,
         usage: &VariableUsage,
         _ty: Type<Universal>,
         cmd: &Command<Type<Universal>, Universal>,
+        received_parameters: &mut Vec<(LocalName, bool)>,
     ) -> Result<()> {
         match cmd {
-            Command::Noop(process) => self.compile_process(process)?,
-            Command::Link(expr) => self.compile_command_link(&name, usage, expr)?,
+            Command::Noop => {}
             // types get erased.
-            Command::SendType(_argument, process) => {
-                self.compile_command_send_type(name, usage, process)?
+            Command::SendType(_argument) => self.compile_command_send_type(name, usage)?,
+            Command::ReceiveType(parameter) => {
+                let was_empty_before = self.compile_command_receive_type(name, usage, parameter)?;
+                received_parameters.push((parameter.name.clone(), was_empty_before));
             }
-            Command::ReceiveType(parameter, process) => {
-                self.compile_command_receive_type(name, usage, parameter, process)?
+            Command::Send(expr) => self.compile_command_send(name, usage, expr)?,
+            Command::Receive(target, _, _, _) => {
+                self.compile_command_receive(name, usage, target)?
             }
-            Command::Send(expr, process) => {
-                self.compile_command_send(name, usage, expr, process)?
-            }
-            Command::Receive(target, _, _, process, _) => {
-                self.compile_command_receive(name, usage, target, process)?
-            }
-            Command::Signal(chosen, process) => {
-                self.compile_command_signal(name, usage, chosen, process)?
-            }
-            Command::Case(names, processes, else_process) => {
-                self.compile_command_case(span, name, usage, names, processes, else_process)?
-            }
-            Command::Break => self.compile_command_break(&name, usage)?,
-            Command::Continue(process) => self.compile_command_continue(&name, usage, process)?,
-            Command::Begin {
+            Command::Signal(chosen) => self.compile_command_signal(name, usage, chosen)?,
+            Command::Continue => self.compile_command_continue(&name, usage)?,
+        };
+        Ok(())
+    }
+
+    fn compile_terminal_command(
+        &mut self,
+        span: &Span,
+        name: &LocalName,
+        usage: &VariableUsage,
+        _ty: &Type<Universal>,
+        cmd: &TerminalCommand<Type<Universal>, Universal>,
+    ) -> Result<()> {
+        match cmd {
+            TerminalCommand::Link(expr) => self.compile_command_link(name, usage, expr)?,
+            TerminalCommand::Case(names, processes, else_process) => self.compile_command_case(
+                span,
+                name.clone(),
+                usage,
+                names,
+                processes,
+                else_process,
+            )?,
+            TerminalCommand::Break => self.compile_command_break(name, usage)?,
+            TerminalCommand::Begin {
                 label,
                 captures,
                 body,
                 ..
-            } => self.compile_command_begin(span, &name, label, captures, body)?,
-            Command::Loop(label, driver, captures) => {
-                self.compile_command_loop(span, &name, usage, label, driver, captures)?
+            } => self.compile_command_begin(span, name, label, captures, body)?,
+            TerminalCommand::Loop(label, driver, captures) => {
+                self.compile_command_loop(span, name, usage, label, driver, captures)?
             }
         };
         Ok(())
     }
 
-    fn compile_process_let(
-        &mut self,
-        name: &LocalName,
-        value: &Expression<Type<Universal>, Universal>,
-        then: &Arc<Process<Type<Universal>, Universal>>,
-    ) -> Result<()> {
-        let value = self.compile_expression(value)?;
-        self.bind_variable(name.clone(), value)?;
-        self.compile_process(then)
-    }
-
-    fn compile_process_do(
-        &mut self,
-        span: &Span,
-        name: &LocalName,
-        usage: &VariableUsage,
-        typ: &Type<Universal>,
-        command: &Command<Type<Universal>, Universal>,
-    ) -> Result<()> {
-        self.compile_command(span, name.clone(), usage, typ.clone(), command)
-    }
-
     fn compile_process_poll(
         &mut self,
-        proc: &Process<Type<Universal>, Universal>,
+        span: Span,
         kind: &PollKind,
         driver: &LocalName,
         point: &LocalName,
@@ -794,9 +823,8 @@ impl Compiler {
             &mut self.net,
         );
 
-        let (poll_package_id, _) = self.in_package(
-            format!("poll body at {:?}", proc.span()),
-            |this, package_id| {
+        let (poll_package_id, _) =
+            self.in_package(format!("poll body at {span:?}"), |this, package_id| {
                 this.poll_packages.insert(
                     point.clone(),
                     PollInfo {
@@ -872,8 +900,7 @@ impl Compiler {
                     Tree::Era.with_type(Type::Break(Span::None)),
                     context_out.with_type(Type::Continue(Span::None)),
                 ))
-            },
-        )?;
+            })?;
 
         self.lazy_redexes.push((
             Tree::Package(poll_package_id, Box::new(context_in), FanBehavior::Expand),
@@ -969,15 +996,10 @@ impl Compiler {
         Ok(())
     }
 
-    fn compile_command_send_type(
-        &mut self,
-        name: LocalName,
-        usage: &VariableUsage,
-        process: &Arc<Process<Type<Universal>, Universal>>,
-    ) -> Result<()> {
+    fn compile_command_send_type(&mut self, name: LocalName, usage: &VariableUsage) -> Result<()> {
         let subject = self.use_variable(&name, usage, true)?;
         self.bind_variable(name, subject.tree.with_type(Type::Break(Span::None)))?;
-        self.compile_process(process)
+        Ok(())
     }
 
     fn compile_command_receive_type(
@@ -985,8 +1007,7 @@ impl Compiler {
         name: LocalName,
         usage: &VariableUsage,
         parameter: &TypeParameter,
-        process: &Arc<Process<Type<Universal>, Universal>>,
-    ) -> Result<()> {
+    ) -> Result<bool> {
         let subject = self.use_variable(&name, usage, true)?;
         let was_empty_before = self
             .type_defs
@@ -994,11 +1015,7 @@ impl Compiler {
             .insert(parameter.name.clone(), parameter.constraint)
             .is_none();
         self.bind_variable(name, subject.tree.with_type(Type::Break(Span::None)))?;
-        self.compile_process(process)?;
-        if was_empty_before {
-            self.type_defs.vars.shift_remove(&parameter.name);
-        }
-        Ok(())
+        Ok(was_empty_before)
     }
 
     fn compile_command_send(
@@ -1006,7 +1023,6 @@ impl Compiler {
         name: LocalName,
         usage: &VariableUsage,
         expr: &Expression<Type<Universal>, Universal>,
-        process: &Arc<Process<Type<Universal>, Universal>>,
     ) -> Result<()> {
         let subject = self.use_variable(&name, usage, true)?;
         let expr = self.compile_expression(expr)?;
@@ -1016,7 +1032,7 @@ impl Compiler {
             Tree::Times(Box::new(v1.tree), Box::new(expr.tree)),
             subject.tree,
         );
-        self.compile_process(process)
+        Ok(())
     }
 
     fn compile_command_receive(
@@ -1024,7 +1040,6 @@ impl Compiler {
         name: LocalName,
         usage: &VariableUsage,
         target: &LocalName,
-        process: &Arc<Process<Type<Universal>, Universal>>,
     ) -> Result<()> {
         let subject = self.use_variable(&name, usage, true)?;
         let (v0, v1) = self.create_typed_wire();
@@ -1035,7 +1050,7 @@ impl Compiler {
             Tree::Par(Box::new(w1.tree), Box::new(v1.tree)),
             subject.tree,
         );
-        self.compile_process(process)
+        Ok(())
     }
 
     fn compile_command_signal(
@@ -1043,14 +1058,13 @@ impl Compiler {
         name: LocalName,
         usage: &VariableUsage,
         chosen: &LocalName,
-        process: &Arc<Process<Type<Universal>, Universal>>,
     ) -> Result<()> {
         let subject = self.use_variable(&name, usage, true)?;
         let (v0, v1) = self.create_typed_wire();
         let choosing_tree = self.either_instance(ArcStr::from(&chosen.string), v1.tree);
         self.net.link(choosing_tree, subject.tree);
         self.bind_variable(name, v0)?;
-        self.compile_process(process)
+        Ok(())
     }
 
     fn compile_command_case(
@@ -1118,15 +1132,10 @@ impl Compiler {
         Ok(())
     }
 
-    fn compile_command_continue(
-        &mut self,
-        name: &LocalName,
-        usage: &VariableUsage,
-        process: &Arc<Process<Type<Universal>, Universal>>,
-    ) -> Result<()> {
+    fn compile_command_continue(&mut self, name: &LocalName, usage: &VariableUsage) -> Result<()> {
         let a = self.use_variable(name, usage, true)?.tree;
         self.net.link(a, Tree::Continue);
-        self.compile_process(process)
+        Ok(())
     }
 
     fn compile_command_begin(

--- a/crates/par-core/src/frontend_impl/captures.rs
+++ b/crates/par-core/src/frontend_impl/captures.rs
@@ -1,6 +1,6 @@
 use super::{
     language::{LocalName, Unresolved},
-    process::{Command, Expression, Process},
+    process::{Command, Expression, Process, Step, TerminalCommand, Terminator},
 };
 use crate::location::Span;
 use indexmap::IndexMap;
@@ -142,39 +142,72 @@ impl CaptureAnalysis {
         process: &Process<(), Unresolved>,
         env: &LoopEnv,
     ) -> (Arc<Process<(), Unresolved>>, Captures) {
-        match process {
-            Process::Let {
-                span,
-                name,
-                annotation,
-                typ,
-                value,
-                then,
-            } => {
-                let (then, mut caps) = self.fix_process(then, env);
-                caps.remove(name);
-                let (value, caps1) = self.fix_expression(value, env, &caps);
-                caps.extend(caps1);
-                (
-                    Arc::new(Process::Let {
+        let (terminator, mut caps) = self.fix_terminator(&process.terminator, env);
+        let mut steps = Vec::with_capacity(process.steps.len());
+
+        for step in process.steps.iter().rev() {
+            match step {
+                Step::Let {
+                    span,
+                    name,
+                    annotation,
+                    typ,
+                    value,
+                } => {
+                    caps.remove(name);
+                    let (value, value_caps) = self.fix_expression(value, env, &caps);
+                    caps.extend(value_caps);
+                    steps.push(Step::Let {
                         span: span.clone(),
                         name: name.clone(),
                         annotation: annotation.clone(),
-                        typ: typ.clone(),
+                        typ: *typ,
                         value,
-                        then,
-                    }),
-                    caps,
-                )
+                    });
+                }
+                Step::Do {
+                    span,
+                    name,
+                    typ,
+                    command,
+                    ..
+                } => {
+                    let (command, mut command_caps) = self.fix_command(command, env, caps);
+                    let usage = if command_caps.contains(name) {
+                        VariableUsage::Copy
+                    } else {
+                        VariableUsage::Move
+                    };
+                    command_caps.add(name.clone(), span.clone(), VariableUsage::Unknown);
+                    caps = command_caps;
+                    steps.push(Step::Do {
+                        span: span.clone(),
+                        name: name.clone(),
+                        usage,
+                        typ: *typ,
+                        command,
+                    });
+                }
             }
-            Process::Do {
+        }
+        steps.reverse();
+        (Arc::new(Process::new(steps, terminator)), caps)
+    }
+
+    fn fix_terminator(
+        &self,
+        terminator: &Terminator<(), Unresolved>,
+        env: &LoopEnv,
+    ) -> (Terminator<(), Unresolved>, Captures) {
+        match terminator {
+            Terminator::Do {
                 span,
                 name,
-                usage: _usage,
                 typ,
                 command,
+                ..
             } => {
-                let (command, mut caps) = self.fix_command(command, span, env);
+                let (command, mut caps) = self.fix_terminal_command(command, span, env);
                 let usage = if caps.contains(name) {
                     VariableUsage::Copy
                 } else {
@@ -182,17 +215,17 @@ impl CaptureAnalysis {
                 };
                 caps.add(name.clone(), span.clone(), VariableUsage::Unknown);
                 (
-                    Arc::new(Process::Do {
+                    Terminator::Do {
                         span: span.clone(),
                         name: name.clone(),
                         usage,
-                        typ: typ.clone(),
+                        typ: *typ,
                         command,
-                    }),
+                    },
                     caps,
                 )
             }
-            Process::Poll {
+            Terminator::Poll {
                 span,
                 kind,
                 driver,
@@ -225,7 +258,7 @@ impl CaptureAnalysis {
 
                 let poll_caps = self.poll_caps.get(point).cloned().unwrap_or_default();
                 (
-                    Arc::new(Process::Poll {
+                    Terminator::Poll {
                         span: span.clone(),
                         kind: kind.clone(),
                         driver: driver.clone(),
@@ -236,11 +269,11 @@ impl CaptureAnalysis {
                         captures: poll_caps,
                         then,
                         else_,
-                    }),
+                    },
                     caps,
                 )
             }
-            Process::Submit {
+            Terminator::Submit {
                 span,
                 driver,
                 point,
@@ -259,79 +292,71 @@ impl CaptureAnalysis {
                 }
 
                 (
-                    Arc::new(Process::Submit {
+                    Terminator::Submit {
                         span: span.clone(),
                         driver: driver.clone(),
                         point: point.clone(),
                         values: fixed_values,
                         captures: poll_caps,
-                    }),
+                    },
                     caps,
                 )
             }
-            Process::Block(span, index, body, process) => {
+            Terminator::Block(span, index, body, process) => {
                 let (process, caps) = self.fix_process(process, env);
                 let body_env = self.block_envs.get(index).cloned().unwrap_or_default();
                 let (body, _body_caps) = self.fix_process(body, &body_env);
-                (
-                    Arc::new(Process::Block(span.clone(), *index, body, process)),
-                    caps,
-                )
+                (Terminator::Block(span.clone(), *index, body, process), caps)
             }
-            Process::Goto(span, index, _) => {
+            Terminator::Goto(span, index, _) => {
                 let caps = self.block_caps.get(index).cloned().unwrap_or_default();
-                (
-                    Arc::new(Process::Goto(span.clone(), *index, caps.clone())),
-                    caps,
-                )
+                (Terminator::Goto(span.clone(), *index, caps.clone()), caps)
             }
-            Process::Unreachable(span) => (
-                Arc::new(Process::Unreachable(span.clone())),
-                Captures::new(),
-            ),
+            Terminator::Unreachable(span) => {
+                (Terminator::Unreachable(span.clone()), Captures::new())
+            }
         }
     }
 
     fn fix_command(
         &self,
         command: &Command<(), Unresolved>,
-        span: &Span,
         env: &LoopEnv,
+        mut caps: Captures,
     ) -> (Command<(), Unresolved>, Captures) {
         match command {
-            Command::Noop(process) => {
-                let (process, caps) = self.fix_process(process, env);
-                (Command::Noop(process), caps)
-            }
-            Command::Link(expression) => {
-                let (expression, caps) = self.fix_expression(expression, env, &Captures::new());
-                (Command::Link(expression), caps)
-            }
-            Command::Send(argument, process) => {
-                let (process, mut caps) = self.fix_process(process, env);
+            Command::Noop => (Command::Noop, caps),
+            Command::Send(argument) => {
                 let (argument, caps1) = self.fix_expression(argument, env, &caps);
                 caps.extend(caps1);
-                (Command::Send(argument, process), caps)
+                (Command::Send(argument), caps)
             }
-            Command::Receive(parameter, annotation, typ, process, vars) => {
-                let (process, mut caps) = self.fix_process(process, env);
+            Command::Receive(parameter, annotation, typ, vars) => {
                 caps.remove(parameter);
                 (
-                    Command::Receive(
-                        parameter.clone(),
-                        annotation.clone(),
-                        typ.clone(),
-                        process,
-                        vars.clone(),
-                    ),
+                    Command::Receive(parameter.clone(), annotation.clone(), *typ, vars.clone()),
                     caps,
                 )
             }
-            Command::Signal(chosen, process) => {
-                let (process, caps) = self.fix_process(process, env);
-                (Command::Signal(chosen.clone(), process), caps)
+            Command::Signal(chosen) => (Command::Signal(chosen.clone()), caps),
+            Command::Continue => (Command::Continue, caps),
+            Command::SendType(argument) => (Command::SendType(argument.clone()), caps),
+            Command::ReceiveType(parameter) => (Command::ReceiveType(parameter.clone()), caps),
+        }
+    }
+
+    fn fix_terminal_command(
+        &self,
+        command: &TerminalCommand<(), Unresolved>,
+        span: &Span,
+        env: &LoopEnv,
+    ) -> (TerminalCommand<(), Unresolved>, Captures) {
+        match command {
+            TerminalCommand::Link(expression) => {
+                let (expression, caps) = self.fix_expression(expression, env, &Captures::new());
+                (TerminalCommand::Link(expression), caps)
             }
-            Command::Case(branches, processes, else_process) => {
+            TerminalCommand::Case(branches, processes, else_process) => {
                 let mut fixed_processes = Vec::new();
                 let mut caps = Captures::new();
                 for process in processes {
@@ -345,7 +370,7 @@ impl CaptureAnalysis {
                     process
                 });
                 (
-                    Command::Case(
+                    TerminalCommand::Case(
                         branches.clone(),
                         fixed_processes.into_boxed_slice(),
                         fixed_else,
@@ -353,12 +378,8 @@ impl CaptureAnalysis {
                     caps,
                 )
             }
-            Command::Break => (Command::Break, Captures::new()),
-            Command::Continue(process) => {
-                let (process, caps) = self.fix_process(process, env);
-                (Command::Continue(process), caps)
-            }
-            Command::Begin {
+            TerminalCommand::Break => (TerminalCommand::Break, Captures::new()),
+            TerminalCommand::Begin {
                 unfounded,
                 label,
                 captures: _,
@@ -369,7 +390,7 @@ impl CaptureAnalysis {
                 let (process, caps) = self.fix_process(body, &env);
                 let loop_caps = self.begin_caps.get(&begin_id).cloned().unwrap_or_default();
                 (
-                    Command::Begin {
+                    TerminalCommand::Begin {
                         unfounded: *unfounded,
                         label: label.clone(),
                         captures: loop_caps,
@@ -378,7 +399,7 @@ impl CaptureAnalysis {
                     caps,
                 )
             }
-            Command::Loop(label, _, _) => match env.resolve(label) {
+            TerminalCommand::Loop(label, _, _) => match env.resolve(label) {
                 Some(begin_id) => {
                     let driver = self
                         .begin_drivers
@@ -387,23 +408,15 @@ impl CaptureAnalysis {
                         .unwrap_or_else(LocalName::invalid);
                     let loop_caps = self.begin_caps.get(&begin_id).cloned().unwrap_or_default();
                     (
-                        Command::Loop(label.clone(), driver, loop_caps.clone()),
+                        TerminalCommand::Loop(label.clone(), driver, loop_caps.clone()),
                         loop_caps,
                     )
                 }
                 _ => (
-                    Command::Loop(label.clone(), LocalName::invalid(), Captures::new()),
+                    TerminalCommand::Loop(label.clone(), LocalName::invalid(), Captures::new()),
                     Captures::new(),
                 ),
             },
-            Command::SendType(argument, process) => {
-                let (process, caps) = self.fix_process(process, env);
-                (Command::SendType(argument.clone(), process), caps)
-            }
-            Command::ReceiveType(parameter, process) => {
-                let (process, caps) = self.fix_process(process, env);
-                (Command::ReceiveType(parameter.clone(), process), caps)
-            }
         }
     }
 
@@ -553,20 +566,21 @@ impl BlockEnvAnalyzer {
     }
 
     fn visit_process(&mut self, process: &Process<(), Unresolved>, env: &LoopEnv) {
-        match process {
-            Process::Let { value, then, .. } => {
-                self.visit_expression(value, env);
-                self.visit_process(then, env);
+        for step in &process.steps {
+            match step {
+                Step::Let { value, .. } => self.visit_expression(value, env),
+                Step::Do { command, .. } => self.visit_command(command, env),
             }
-            Process::Do {
+        }
+
+        match &process.terminator {
+            Terminator::Do {
                 span,
                 name,
                 command,
                 ..
-            } => {
-                self.visit_command(command, span, name, env);
-            }
-            Process::Poll {
+            } => self.visit_terminal_command(command, span, name, env),
+            Terminator::Poll {
                 clients,
                 then,
                 else_,
@@ -578,47 +592,46 @@ impl BlockEnvAnalyzer {
                 self.visit_process(then, env);
                 self.visit_process(else_, env);
             }
-            Process::Submit { values, .. } => {
+            Terminator::Submit { values, .. } => {
                 for value in values {
                     self.visit_expression(value, env);
                 }
             }
-            Process::Block(_, index, body, process) => {
+            Terminator::Block(_, index, body, process) => {
                 self.blocks
                     .entry(*index)
                     .or_insert_with(|| Arc::clone(body));
                 self.visit_process(process, env);
             }
-            Process::Goto(_, index, _) => {
+            Terminator::Goto(_, index, _) => {
                 self.schedule_block(*index, env);
             }
-            Process::Unreachable(_) => {}
+            Terminator::Unreachable(_) => {}
         }
     }
 
-    fn visit_command(
+    fn visit_command(&mut self, command: &Command<(), Unresolved>, env: &LoopEnv) {
+        match command {
+            Command::Send(argument) => self.visit_expression(argument, env),
+            Command::Noop
+            | Command::Receive(..)
+            | Command::Signal(_)
+            | Command::Continue
+            | Command::SendType(_)
+            | Command::ReceiveType(_) => {}
+        }
+    }
+
+    fn visit_terminal_command(
         &mut self,
-        command: &Command<(), Unresolved>,
+        command: &TerminalCommand<(), Unresolved>,
         span: &Span,
         subject: &LocalName,
         env: &LoopEnv,
     ) {
         match command {
-            Command::Noop(process) => {
-                self.visit_process(process, env);
-            }
-            Command::Link(expression) => self.visit_expression(expression, env),
-            Command::Send(argument, process) => {
-                self.visit_expression(argument, env);
-                self.visit_process(process, env);
-            }
-            Command::Receive(_, _annotation, _typ, process, _vars) => {
-                self.visit_process(process, env);
-            }
-            Command::Signal(_, process) => {
-                self.visit_process(process, env);
-            }
-            Command::Case(_, processes, else_process) => {
+            TerminalCommand::Link(expression) => self.visit_expression(expression, env),
+            TerminalCommand::Case(_, processes, else_process) => {
                 for process in processes {
                     self.visit_process(process, env);
                 }
@@ -626,24 +639,14 @@ impl BlockEnvAnalyzer {
                     self.visit_process(process, env);
                 }
             }
-            Command::Break => {}
-            Command::Continue(process) => {
-                self.visit_process(process, env);
-            }
-            Command::Begin { label, body, .. } => {
+            TerminalCommand::Break | TerminalCommand::Loop(..) => {}
+            TerminalCommand::Begin { label, body, .. } => {
                 let begin_id = span.clone();
                 self.begin_drivers
                     .entry(begin_id.clone())
                     .or_insert_with(|| subject.clone());
                 let env = env.with_begin(label, begin_id);
                 self.visit_process(body, &env);
-            }
-            Command::Loop(_, _, _) => {}
-            Command::SendType(_, process) => {
-                self.visit_process(process, env);
-            }
-            Command::ReceiveType(_, process) => {
-                self.visit_process(process, env);
             }
         }
     }
@@ -771,27 +774,45 @@ impl<'a> CaptureCollector<'a> {
     }
 
     fn process_captures(&mut self, process: &Process<(), Unresolved>, env: &LoopEnv) -> Captures {
-        match process {
-            Process::Let {
-                name, value, then, ..
-            } => {
-                let mut caps = self.process_captures(then, env);
-                caps.remove(name);
-                let expr_caps = self.expression_captures(value, env);
-                caps.merge_missing(&expr_caps);
-                caps
+        let mut caps = self.terminator_captures(&process.terminator, env);
+        for step in process.steps.iter().rev() {
+            match step {
+                Step::Let { name, value, .. } => {
+                    caps.remove(name);
+                    let expr_caps = self.expression_captures(value, env);
+                    caps.merge_missing(&expr_caps);
+                }
+                Step::Do {
+                    span,
+                    name,
+                    command,
+                    ..
+                } => {
+                    caps = self.command_captures(command, env, caps);
+                    caps.add(name.clone(), span.clone(), VariableUsage::Unknown);
+                }
             }
-            Process::Do {
+        }
+        caps
+    }
+
+    fn terminator_captures(
+        &mut self,
+        terminator: &Terminator<(), Unresolved>,
+        env: &LoopEnv,
+    ) -> Captures {
+        match terminator {
+            Terminator::Do {
                 span,
                 name,
                 command,
                 ..
             } => {
-                let mut caps = self.command_captures(command, span, name, env);
+                let mut caps = self.terminal_command_captures(command, span, name, env);
                 caps.add(name.clone(), span.clone(), VariableUsage::Unknown);
                 caps
             }
-            Process::Poll {
+            Terminator::Poll {
                 driver,
                 point,
                 clients,
@@ -815,7 +836,7 @@ impl<'a> CaptureCollector<'a> {
 
                 poll_caps
             }
-            Process::Submit {
+            Terminator::Submit {
                 span,
                 driver,
                 point,
@@ -830,42 +851,53 @@ impl<'a> CaptureCollector<'a> {
                 }
                 caps
             }
-            Process::Block(_span, index, body, process) => {
+            Terminator::Block(_span, index, body, process) => {
                 let body_env = self.block_envs.get(index).cloned().unwrap_or_default();
                 let body_caps = self.process_captures(body, &body_env);
                 self.update_block_caps(*index, &body_caps);
                 self.process_captures(process, env)
             }
-            Process::Goto(_, index, _) => {
+            Terminator::Goto(_, index, _) => {
                 self.old_block_caps.get(index).cloned().unwrap_or_default()
             }
-            Process::Unreachable(_) => Captures::new(),
+            Terminator::Unreachable(_) => Captures::new(),
         }
     }
 
     fn command_captures(
         &mut self,
         command: &Command<(), Unresolved>,
+        env: &LoopEnv,
+        mut caps: Captures,
+    ) -> Captures {
+        match command {
+            Command::Noop
+            | Command::Signal(_)
+            | Command::Continue
+            | Command::SendType(_)
+            | Command::ReceiveType(_) => caps,
+            Command::Send(argument) => {
+                let arg_caps = self.expression_captures(argument, env);
+                caps.merge_missing(&arg_caps);
+                caps
+            }
+            Command::Receive(parameter, _annotation, _typ, _vars) => {
+                caps.remove(parameter);
+                caps
+            }
+        }
+    }
+
+    fn terminal_command_captures(
+        &mut self,
+        command: &TerminalCommand<(), Unresolved>,
         span: &Span,
         subject: &LocalName,
         env: &LoopEnv,
     ) -> Captures {
         match command {
-            Command::Noop(process) => self.process_captures(process, env),
-            Command::Link(expression) => self.expression_captures(expression, env),
-            Command::Send(argument, process) => {
-                let mut caps = self.process_captures(process, env);
-                let arg_caps = self.expression_captures(argument, env);
-                caps.merge_missing(&arg_caps);
-                caps
-            }
-            Command::Receive(parameter, _annotation, _typ, process, _vars) => {
-                let mut caps = self.process_captures(process, env);
-                caps.remove(parameter);
-                caps
-            }
-            Command::Signal(_, process) => self.process_captures(process, env),
-            Command::Case(_, processes, else_process) => {
+            TerminalCommand::Link(expression) => self.expression_captures(expression, env),
+            TerminalCommand::Case(_, processes, else_process) => {
                 let mut caps = Captures::new();
                 for process in processes {
                     let branch_caps = self.process_captures(process, env);
@@ -877,9 +909,8 @@ impl<'a> CaptureCollector<'a> {
                 }
                 caps
             }
-            Command::Break => Captures::new(),
-            Command::Continue(process) => self.process_captures(process, env),
-            Command::Begin { label, body, .. } => {
+            TerminalCommand::Break => Captures::new(),
+            TerminalCommand::Begin { label, body, .. } => {
                 let begin_id = span.clone();
                 let env = env.with_begin(label, begin_id.clone());
                 let body_caps = self.process_captures(body, &env);
@@ -888,12 +919,10 @@ impl<'a> CaptureCollector<'a> {
                 self.update_begin_caps(begin_id, &loop_caps);
                 body_caps
             }
-            Command::Loop(label, _, _) => env
+            TerminalCommand::Loop(label, _, _) => env
                 .resolve(label)
                 .and_then(|id| self.old_begin_caps.get(&id).cloned())
                 .unwrap_or_default(),
-            Command::SendType(_, process) => self.process_captures(process, env),
-            Command::ReceiveType(_, process) => self.process_captures(process, env),
         }
     }
 

--- a/crates/par-core/src/frontend_impl/language.rs
+++ b/crates/par-core/src/frontend_impl/language.rs
@@ -280,13 +280,23 @@ impl LocalName {
 }
 
 #[derive(Clone, Debug)]
-pub enum Pattern<S> {
+pub struct Pattern<S> {
+    pub steps: Vec<PatternStep<S>>,
+    pub terminal: PatternTerminal<S>,
+}
+
+#[derive(Clone, Debug)]
+pub enum PatternStep<S> {
+    Receive(Span, Box<Pattern<S>>, Vec<TypeParameter>),
+    ReceiveType(Span, TypeParameter),
+    Try(Span, Option<LocalName>),
+    Default(Span, Box<Expression<S>>),
+}
+
+#[derive(Clone, Debug)]
+pub enum PatternTerminal<S> {
     Name(Span, LocalName, Option<Type<S>>),
-    Receive(Span, Box<Self>, Box<Self>, Vec<TypeParameter>),
     Continue(Span),
-    ReceiveType(Span, TypeParameter, Box<Self>),
-    Try(Span, Option<LocalName>, Box<Self>),
-    Default(Span, Box<Expression<S>>, Box<Self>),
 }
 
 #[derive(Clone, Debug)]
@@ -437,79 +447,135 @@ pub enum Expression<S> {
 }
 
 #[derive(Clone, Debug)]
-pub enum Construct<S> {
-    /// wraps an expression
+pub struct Construct<S> {
+    pub steps: Vec<ConstructStep<S>>,
+    pub terminator: ConstructTerminator<S>,
+}
+
+#[derive(Clone, Debug)]
+pub enum ConstructStep<S> {
+    Send(Span, Box<Expression<S>>),
+    Receive(Span, Pattern<S>, Vec<TypeParameter>),
+    Signal(Span, LocalName),
+    SendType(Span, Type<S>),
+    ReceiveType(Span, TypeParameter),
+}
+
+#[derive(Clone, Debug)]
+pub enum ConstructTerminator<S> {
     Then(Box<Expression<S>>),
-    Send(Span, Box<Expression<S>>, Box<Self>),
-    Receive(Span, Pattern<S>, Box<Self>, Vec<TypeParameter>),
-    /// constructs an either type
-    Signal(Span, LocalName, Box<Self>),
-    /// constructs a choice type
     Case(Span, ConstructBranches<S>, Option<Box<ConstructBranch<S>>>),
-    /// ! (unit)
     Break(Span),
     Begin {
         span: Span,
         unfounded: bool,
         label: Option<LocalName>,
-        then: Box<Self>,
+        body: Box<Construct<S>>,
     },
     Loop(Span, Option<LocalName>),
-    SendType(Span, Type<S>, Box<Self>),
-    ReceiveType(Span, TypeParameter, Box<Self>),
 }
 
 #[derive(Clone, Debug)]
 pub struct ConstructBranches<S>(pub BTreeMap<LocalName, ConstructBranch<S>>);
 
 #[derive(Clone, Debug)]
-pub enum ConstructBranch<S> {
-    Then(Span, Expression<S>),
-    Receive(Span, Pattern<S>, Box<Self>, Vec<TypeParameter>),
-    ReceiveType(Span, TypeParameter, Box<Self>),
+pub struct ConstructBranch<S> {
+    pub steps: Vec<ConstructBranchStep<S>>,
+    pub terminator: ConstructBranchTerminator<S>,
 }
 
 #[derive(Clone, Debug)]
-pub enum Apply<S> {
+pub enum ConstructBranchStep<S> {
+    Receive(Span, Pattern<S>, Vec<TypeParameter>),
+    ReceiveType(Span, TypeParameter),
+}
+
+#[derive(Clone, Debug)]
+pub enum ConstructBranchTerminator<S> {
+    Then(Span, Expression<S>),
+}
+
+#[derive(Clone, Debug)]
+pub struct Apply<S> {
+    pub steps: Vec<ApplyStep<S>>,
+    pub terminator: ApplyTerminator<S>,
+}
+
+#[derive(Clone, Debug)]
+pub enum ApplyStep<S> {
+    Send(Span, Box<Expression<S>>),
+    Signal(Span, LocalName),
+    SendType(Span, Type<S>),
+    Try(Span, Option<LocalName>),
+    Default(Span, Box<Expression<S>>),
+    Pipe(Span, Box<Expression<S>>),
+}
+
+#[derive(Clone, Debug)]
+pub enum ApplyTerminator<S> {
     Noop(Span),
-    Send(Span, Box<Expression<S>>, Box<Self>),
-    Signal(Span, LocalName, Box<Self>),
     Case(Span, ApplyBranches<S>, Option<Box<ApplyBranch<S>>>),
     Begin {
         span: Span,
         unfounded: bool,
         label: Option<LocalName>,
-        then: Box<Self>,
+        body: Box<Apply<S>>,
     },
     Loop(Span, Option<LocalName>),
-    SendType(Span, Type<S>, Box<Self>),
-    Try(Span, Option<LocalName>, Box<Self>),
-    Default(Span, Box<Expression<S>>, Box<Self>),
-    Pipe(Span, Box<Expression<S>>, Box<Self>),
 }
 
 #[derive(Clone, Debug)]
 pub struct ApplyBranches<S>(pub BTreeMap<LocalName, ApplyBranch<S>>);
 
 #[derive(Clone, Debug)]
-pub enum ApplyBranch<S> {
-    Then(Span, LocalName, Expression<S>),
-    Receive(Span, Pattern<S>, Box<Self>, Vec<TypeParameter>),
-    Continue(Span, Expression<S>),
-    ReceiveType(Span, TypeParameter, Box<Self>),
-    Try(Span, Option<LocalName>, Box<Self>),
-    Default(Span, Box<Expression<S>>, Box<Self>),
+pub struct ApplyBranch<S> {
+    pub steps: Vec<ApplyBranchStep<S>>,
+    pub terminator: ApplyBranchTerminator<S>,
 }
 
-// span doesn't include the "then" process
 #[derive(Clone, Debug)]
-pub enum Process<S> {
+pub enum ApplyBranchStep<S> {
+    Receive(Span, Pattern<S>, Vec<TypeParameter>),
+    ReceiveType(Span, TypeParameter),
+    Try(Span, Option<LocalName>),
+    Default(Span, Box<Expression<S>>),
+}
+
+#[derive(Clone, Debug)]
+pub enum ApplyBranchTerminator<S> {
+    Then(Span, LocalName, Expression<S>),
+    Continue(Span, Expression<S>),
+}
+
+#[derive(Clone, Debug)]
+pub struct Process<S> {
+    pub steps: Vec<ProcessStep<S>>,
+    pub terminator: ProcessTerminator<S>,
+}
+
+#[derive(Clone, Debug)]
+pub enum ProcessStep<S> {
     Let {
         span: Span,
         pattern: Pattern<S>,
         value: Box<Expression<S>>,
-        then: Box<Self>,
     },
+    Catch {
+        span: Span,
+        label: Option<LocalName>,
+        pattern: Pattern<S>,
+        block: Box<Process<S>>,
+    },
+    If {
+        span: Span,
+        branches: Vec<(Condition<S>, Process<S>)>,
+        else_: Option<Box<Process<S>>>,
+    },
+    Command(ProcessCommand<S>),
+}
+
+#[derive(Clone, Debug)]
+pub enum ProcessTerminator<S> {
     Poll {
         span: Span,
         label: Option<LocalName>,
@@ -531,66 +597,86 @@ pub enum Process<S> {
         label: Option<LocalName>,
         values: Vec<Expression<S>>,
     },
-    Catch {
-        span: Span,
-        label: Option<LocalName>,
-        pattern: Pattern<S>,
-        block: Box<Self>,
-        then: Box<Self>,
-    },
     Throw(Span, Option<LocalName>, Box<Expression<S>>),
     If {
         span: Span,
         branches: Vec<(Condition<S>, Process<S>)>,
         else_: Option<Box<Process<S>>>,
-        then: Option<Box<Process<S>>>,
     },
-    GlobalCommand(Span, GlobalName<S>, Command<S>),
-    Command(Span, LocalName, Command<S>),
+    Command(ProcessCommand<S>),
     Fallthrough(Span),
 }
 
 #[derive(Clone, Debug)]
-pub enum Command<S> {
-    Then(Box<Process<S>>),
+pub struct ProcessCommand<S> {
+    pub span: Span,
+    pub target: CommandTarget<S>,
+    pub command: Command<S>,
+}
+
+#[derive(Clone, Debug)]
+pub enum CommandTarget<S> {
+    Global(GlobalName<S>),
+    Local(LocalName),
+}
+
+#[derive(Clone, Debug)]
+pub struct Command<S> {
+    pub steps: Vec<CommandStep<S>>,
+    pub terminator: CommandTerminator<S>,
+}
+
+#[derive(Clone, Debug)]
+pub enum CommandStep<S> {
+    Send(Span, Expression<S>),
+    Receive(Span, Pattern<S>, Vec<TypeParameter>),
+    Signal(Span, LocalName),
+    Continue(Span),
+    SendType(Span, Type<S>),
+    ReceiveType(Span, TypeParameter),
+    Try(Span, Option<LocalName>),
+    Default(Span, Box<Expression<S>>),
+    Pipe(Span, Box<Expression<S>>),
+}
+
+#[derive(Clone, Debug)]
+pub enum CommandTerminator<S> {
+    Then(Span),
     Link(Span, Box<Expression<S>>),
-    Send(Span, Expression<S>, Box<Self>),
-    Receive(Span, Pattern<S>, Box<Self>, Vec<TypeParameter>),
-    Signal(Span, LocalName, Box<Self>),
-    Case(
-        Span,
-        CommandBranches<S>,
-        Option<Box<CommandBranch<S>>>,
-        Option<Box<Process<S>>>,
-    ),
+    Case(Span, CommandBranches<S>, Option<Box<CommandBranch<S>>>),
     Break(Span),
-    Continue(Span, Box<Process<S>>),
     Begin {
         span: Span,
         unfounded: bool,
         label: Option<LocalName>,
-        then: Box<Self>,
+        body: Box<Command<S>>,
+        continuation: Option<Box<Process<S>>>,
     },
     Loop(Span, Option<LocalName>),
-    SendType(Span, Type<S>, Box<Self>),
-    ReceiveType(Span, TypeParameter, Box<Self>),
-    Try(Span, Option<LocalName>, Box<Self>),
-    Default(Span, Box<Expression<S>>, Box<Self>),
-    Pipe(Span, Box<Expression<S>>, Box<Self>),
 }
 
 #[derive(Clone, Debug)]
 pub struct CommandBranches<S>(pub BTreeMap<LocalName, CommandBranch<S>>);
 
 #[derive(Clone, Debug)]
-pub enum CommandBranch<S> {
+pub struct CommandBranch<S> {
+    pub steps: Vec<CommandBranchStep<S>>,
+    pub terminator: CommandBranchTerminator<S>,
+}
+
+#[derive(Clone, Debug)]
+pub enum CommandBranchStep<S> {
+    Receive(Span, Pattern<S>, Vec<TypeParameter>),
+    ReceiveType(Span, TypeParameter),
+    Try(Span, Option<LocalName>),
+    Default(Span, Box<Expression<S>>),
+}
+
+#[derive(Clone, Debug)]
+pub enum CommandBranchTerminator<S> {
     Then(Span, Process<S>),
     BindThen(Span, LocalName, Process<S>),
-    Receive(Span, Pattern<S>, Box<Self>, Vec<TypeParameter>),
     Continue(Span, Process<S>),
-    ReceiveType(Span, TypeParameter, Box<Self>),
-    Try(Span, Option<LocalName>, Box<Self>),
-    Default(Span, Box<Expression<S>>, Box<Self>),
 }
 
 impl Hash for LocalName {
@@ -854,6 +940,20 @@ enum CommandLoweringFrame {
     },
 }
 
+enum ProcessLoweringFrame {
+    Let {
+        span: Span,
+        pattern: Pattern<Unresolved>,
+        value: Arc<process::Expression<(), Unresolved>>,
+    },
+    Command {
+        target: CommandTarget<Unresolved>,
+        object_name: LocalName,
+        original_object_name: Option<LocalName>,
+        frames: Vec<CommandLoweringFrame>,
+    },
+}
+
 impl Context {
     pub(crate) fn new() -> Self {
         Self {
@@ -942,11 +1042,10 @@ impl Context {
         Expression::Application(
             span.clone(),
             Box::new(function),
-            Apply::Send(
-                span.clone(),
-                Box::new(argument),
-                Box::new(Apply::Noop(span.clone())),
-            ),
+            Apply {
+                steps: vec![ApplyStep::Send(span.clone(), Box::new(argument))],
+                terminator: ApplyTerminator::Noop(span.clone()),
+            },
         )
     }
 
@@ -957,11 +1056,10 @@ impl Context {
     ) -> Expression<Unresolved> {
         Expression::Construction(
             span.clone(),
-            Construct::Send(
-                span.clone(),
-                Box::new(left),
-                Box::new(Construct::Then(Box::new(right))),
-            ),
+            Construct {
+                steps: vec![ConstructStep::Send(span.clone(), Box::new(left))],
+                terminator: ConstructTerminator::Then(Box::new(right)),
+            },
         )
     }
 
@@ -1032,7 +1130,10 @@ impl Context {
             span: Span::None,
             value: compare,
             variant: Self::operator_local_name(&Span::None, variant),
-            pattern: Pattern::Continue(Span::None),
+            pattern: Pattern {
+                steps: Vec::new(),
+                terminal: PatternTerminal::Continue(Span::None),
+            },
         };
 
         if negate {
@@ -1093,7 +1194,10 @@ impl Context {
                     let binding_span = binding.span();
                     combined = Expression::Let {
                         span: binding_span.join(combined.span()),
-                        pattern: Pattern::Name(binding_span.clone(), name, None),
+                        pattern: Pattern {
+                            steps: Vec::new(),
+                            terminal: PatternTerminal::Name(binding_span.clone(), name, None),
+                        },
                         expression: Box::new(binding),
                         then: Box::new(combined),
                     };
@@ -1494,7 +1598,7 @@ impl Context {
         expression: Arc<process::Expression<(), Unresolved>>,
         process: Arc<process::Process<(), Unresolved>>,
     ) -> Result<Arc<process::Process<(), Unresolved>>, CompileError> {
-        if let Pattern::Name(_, name, annotation) = pattern {
+        if let Some((_, name, annotation)) = pattern.as_name() {
             return Ok(process::Process::let_step(
                 span.clone(),
                 name.clone(),
@@ -1521,7 +1625,7 @@ impl Context {
         span: &Span,
         process: Arc<process::Process<(), Unresolved>>,
     ) -> Result<Arc<process::Expression<(), Unresolved>>, CompileError> {
-        if let Pattern::Name(_, name, annotation) = pattern {
+        if let Some((_, name, annotation)) = pattern.as_name() {
             return Ok(Arc::new(process::Expression::Chan {
                 span: span.clone(),
                 captures: Captures::new(),
@@ -1549,7 +1653,7 @@ impl Context {
         span: &Span,
         block: Arc<process::Process<(), Unresolved>>,
     ) -> Result<Arc<process::Process<(), Unresolved>>, CompileError> {
-        if let Pattern::Name(_, name, annotation) = pattern {
+        if let Some((_, name, annotation)) = pattern.as_name() {
             return Ok(process::Process::let_step(
                 span.clone(),
                 name.clone(),
@@ -1589,7 +1693,7 @@ impl Context {
         process: Arc<process::Process<(), Unresolved>>,
         vars: Vec<TypeParameter>,
     ) -> Result<Arc<process::Process<(), Unresolved>>, CompileError> {
-        if let Pattern::Name(_, name, annotation) = pattern {
+        if let Some((_, name, annotation)) = pattern.as_name() {
             return Ok(process::Process::do_step(
                 span.clone(),
                 subject.clone(),
@@ -1616,8 +1720,8 @@ impl Context {
         level: usize,
         process: Arc<process::Process<(), Unresolved>>,
     ) -> Result<Arc<process::Process<(), Unresolved>>, CompileError> {
-        match pattern {
-            Pattern::Name(span, name, annotation) => Ok(process::Process::let_step(
+        let mut process = match &pattern.terminal {
+            PatternTerminal::Name(span, name, annotation) => process::Process::let_step(
                 span.clone(),
                 name.clone(),
                 annotation.clone(),
@@ -1629,70 +1733,62 @@ impl Context {
                     VariableUsage::Unknown,
                 )),
                 process,
-            )),
-
-            Pattern::Receive(span, first, rest, vars) => {
-                let then_process = self.compile_pattern_helper(rest, level, process)?;
-                self.compile_pattern_receive(
-                    first,
-                    level + 1,
-                    span,
-                    &LocalName::match_(level),
-                    then_process,
-                    vars.clone(),
-                )
-            }
-
-            Pattern::Continue(span) => Ok(process::Process::do_step(
+            ),
+            PatternTerminal::Continue(span) => process::Process::do_step(
                 span.clone(),
                 LocalName::match_(level),
                 VariableUsage::Unknown,
                 (),
                 process::Command::Continue,
                 process,
-            )),
-
-            Pattern::ReceiveType(span, parameter, rest) => {
-                let then = self.compile_pattern_helper(rest, level, process)?;
-                Ok(process::Process::do_step(
+            ),
+        };
+        for step in pattern.steps.iter().rev() {
+            process = match step {
+                PatternStep::Receive(span, first, vars) => self.compile_pattern_receive(
+                    first,
+                    level + 1,
+                    span,
+                    &LocalName::match_(level),
+                    process,
+                    vars.clone(),
+                )?,
+                PatternStep::ReceiveType(span, parameter) => process::Process::do_step(
                     span.clone(),
                     LocalName::match_(level),
                     VariableUsage::Unknown,
                     (),
                     process::Command::ReceiveType(parameter.clone()),
-                    then,
-                ))
-            }
-
-            Pattern::Try(span, label, rest) => {
-                let catch_block = self.use_catch(span, label)?;
-                let catch_block = if let Some(original) = &self.original_object_name {
-                    process::Process::let_step(
-                        original.span.clone(),
-                        original.clone(),
-                        None,
-                        (),
-                        Arc::new(process::Expression::Variable(
+                    process,
+                ),
+                PatternStep::Try(span, label) => {
+                    let catch_block = self.use_catch(span, label)?;
+                    let catch_block = if let Some(original) = &self.original_object_name {
+                        process::Process::let_step(
                             original.span.clone(),
-                            LocalName::subject(),
+                            original.clone(),
+                            None,
                             (),
-                            VariableUsage::Unknown,
-                        )),
-                        catch_block,
-                    )
-                } else {
-                    catch_block
-                };
-                let then_process = self.compile_pattern_helper(rest, level, process)?;
-                Ok(self.compile_try(span, LocalName::match_(level), catch_block, then_process))
-            }
-
-            Pattern::Default(span, expr, rest) => {
-                let default_expr = self.compile_expression(expr)?;
-                let ok_process = self.compile_pattern_helper(rest, level, process)?;
-                Ok(self.compile_default(span, LocalName::match_(level), default_expr, ok_process))
-            }
+                            Arc::new(process::Expression::Variable(
+                                original.span.clone(),
+                                LocalName::subject(),
+                                (),
+                                VariableUsage::Unknown,
+                            )),
+                            catch_block,
+                        )
+                    } else {
+                        catch_block
+                    };
+                    self.compile_try(span, LocalName::match_(level), catch_block, process)
+                }
+                PatternStep::Default(span, expr) => {
+                    let default_expr = self.compile_expression(expr)?;
+                    self.compile_default(span, LocalName::match_(level), default_expr, process)
+                }
+            };
         }
+        Ok(process)
     }
 
     pub(crate) fn compile_expression(
@@ -2125,7 +2221,14 @@ impl Context {
                 })
             }
 
-            Expression::Application(_, expr, Apply::Noop(_)) => self.compile_expression(expr)?,
+            Expression::Application(
+                _,
+                expr,
+                Apply {
+                    steps,
+                    terminator: ApplyTerminator::Noop(_),
+                },
+            ) if steps.is_empty() => self.compile_expression(expr)?,
 
             Expression::Application(span, expr, apply) => {
                 let expr = self.compile_expression(expr)?;
@@ -2160,8 +2263,8 @@ impl Context {
         &mut self,
         construct: &Construct<Unresolved>,
     ) -> Result<Arc<process::Process<(), Unresolved>>, CompileError> {
-        Ok(match construct {
-            Construct::Then(expression) => {
+        let mut process = match &construct.terminator {
+            ConstructTerminator::Then(expression) => {
                 let expression = self.compile_expression(expression)?;
                 process::Process::do_terminal(
                     Span::None,
@@ -2171,45 +2274,7 @@ impl Context {
                     process::TerminalCommand::Link(expression),
                 )
             }
-
-            Construct::Send(span, argument, construct) => {
-                let argument = self.compile_expression(argument)?;
-                let process = self.compile_construct(construct)?;
-                process::Process::do_step(
-                    span.clone(),
-                    LocalName::result(),
-                    VariableUsage::Unknown,
-                    (),
-                    process::Command::Send(argument),
-                    process,
-                )
-            }
-
-            Construct::Receive(span, pattern, construct, vars) => {
-                let process = self.compile_construct(construct)?;
-                self.compile_pattern_receive(
-                    pattern,
-                    0,
-                    span,
-                    &LocalName::result(),
-                    process,
-                    vars.clone(),
-                )?
-            }
-
-            Construct::Signal(span, chosen, construct) => {
-                let process = self.compile_construct(construct)?;
-                process::Process::do_step(
-                    span.clone(),
-                    LocalName::result(),
-                    VariableUsage::Unknown,
-                    (),
-                    process::Command::Signal(chosen.clone()),
-                    process,
-                )
-            }
-
-            Construct::Case(span, ConstructBranches(construct_branches), else_branch) => {
+            ConstructTerminator::Case(span, ConstructBranches(construct_branches), else_branch) => {
                 let mut branches = Vec::new();
                 let mut processes = Vec::new();
                 for (branch_name, construct_branch) in construct_branches {
@@ -2230,8 +2295,7 @@ impl Context {
                     process::TerminalCommand::Case(branches, processes, else_process),
                 )
             }
-
-            Construct::Break(span) => process::Process::do_terminal(
+            ConstructTerminator::Break(span) => process::Process::do_terminal(
                 span.clone(),
                 LocalName::result(),
                 VariableUsage::Unknown,
@@ -2239,11 +2303,11 @@ impl Context {
                 process::TerminalCommand::Break,
             ),
 
-            Construct::Begin {
+            ConstructTerminator::Begin {
                 span,
                 unfounded,
                 label,
-                then: construct,
+                body: construct,
             } => {
                 let process = self.compile_construct(construct)?;
                 process::Process::do_terminal(
@@ -2260,7 +2324,7 @@ impl Context {
                 )
             }
 
-            Construct::Loop(span, label) => process::Process::do_terminal(
+            ConstructTerminator::Loop(span, label) => process::Process::do_terminal(
                 span.clone(),
                 LocalName::result(),
                 VariableUsage::Unknown,
@@ -2271,39 +2335,60 @@ impl Context {
                     Captures::new(),
                 ),
             ),
-
-            Construct::SendType(span, argument, construct) => {
-                let process = self.compile_construct(construct)?;
-                process::Process::do_step(
+        };
+        for step in construct.steps.iter().rev() {
+            process = match step {
+                ConstructStep::Send(span, argument) => process::Process::do_step(
+                    span.clone(),
+                    LocalName::result(),
+                    VariableUsage::Unknown,
+                    (),
+                    process::Command::Send(self.compile_expression(argument)?),
+                    process,
+                ),
+                ConstructStep::Receive(span, pattern, vars) => self.compile_pattern_receive(
+                    pattern,
+                    0,
+                    span,
+                    &LocalName::result(),
+                    process,
+                    vars.clone(),
+                )?,
+                ConstructStep::Signal(span, chosen) => process::Process::do_step(
+                    span.clone(),
+                    LocalName::result(),
+                    VariableUsage::Unknown,
+                    (),
+                    process::Command::Signal(chosen.clone()),
+                    process,
+                ),
+                ConstructStep::SendType(span, argument) => process::Process::do_step(
                     span.clone(),
                     LocalName::result(),
                     VariableUsage::Unknown,
                     (),
                     process::Command::SendType(argument.clone()),
                     process,
-                )
-            }
-
-            Construct::ReceiveType(span, parameter, construct) => {
-                let process = self.compile_construct(construct)?;
-                process::Process::do_step(
+                ),
+                ConstructStep::ReceiveType(span, parameter) => process::Process::do_step(
                     span.clone(),
                     LocalName::result(),
                     VariableUsage::Unknown,
                     (),
                     process::Command::ReceiveType(parameter.clone()),
                     process,
-                )
-            }
-        })
+                ),
+            };
+        }
+        Ok(process)
     }
 
     pub(crate) fn compile_construct_branch(
         &mut self,
         branch: &ConstructBranch<Unresolved>,
     ) -> Result<Arc<process::Process<(), Unresolved>>, CompileError> {
-        Ok(match branch {
-            ConstructBranch::Then(_, expression) => {
+        let mut process = match &branch.terminator {
+            ConstructBranchTerminator::Then(_, expression) => {
                 let expression = self.compile_expression(expression)?;
                 process::Process::do_terminal(
                     Span::None,
@@ -2313,39 +2398,36 @@ impl Context {
                     process::TerminalCommand::Link(expression),
                 )
             }
-
-            ConstructBranch::Receive(span, pattern, branch, vars) => {
-                let process = self.compile_construct_branch(branch)?;
-                self.compile_pattern_receive(
+        };
+        for step in branch.steps.iter().rev() {
+            process = match step {
+                ConstructBranchStep::Receive(span, pattern, vars) => self.compile_pattern_receive(
                     pattern,
                     0,
                     span,
                     &LocalName::result(),
                     process,
                     vars.clone(),
-                )?
-            }
-
-            ConstructBranch::ReceiveType(span, parameter, branch) => {
-                let process = self.compile_construct_branch(branch)?;
-                process::Process::do_step(
+                )?,
+                ConstructBranchStep::ReceiveType(span, parameter) => process::Process::do_step(
                     span.clone(),
                     LocalName::result(),
                     VariableUsage::Unknown,
                     (),
                     process::Command::ReceiveType(parameter.clone()),
                     process,
-                )
-            }
-        })
+                ),
+            };
+        }
+        Ok(process)
     }
 
     pub(crate) fn compile_apply(
         &mut self,
         apply: &Apply<Unresolved>,
     ) -> Result<Arc<process::Process<(), Unresolved>>, CompileError> {
-        Ok(match apply {
-            Apply::Noop(span) => process::Process::do_terminal(
+        let mut process = match &apply.terminator {
+            ApplyTerminator::Noop(span) => process::Process::do_terminal(
                 span.clone(),
                 LocalName::result(),
                 VariableUsage::Unknown,
@@ -2358,32 +2440,7 @@ impl Context {
                 ))),
             ),
 
-            Apply::Send(span, expression, apply) => {
-                let expression = self.compile_expression(expression)?;
-                let process = self.compile_apply(apply)?;
-                process::Process::do_step(
-                    span.clone(),
-                    LocalName::object(),
-                    VariableUsage::Unknown,
-                    (),
-                    process::Command::Send(expression),
-                    process,
-                )
-            }
-
-            Apply::Signal(span, chosen, apply) => {
-                let process = self.compile_apply(apply)?;
-                process::Process::do_step(
-                    span.clone(),
-                    LocalName::object(),
-                    VariableUsage::Unknown,
-                    (),
-                    process::Command::Signal(chosen.clone()),
-                    process,
-                )
-            }
-
-            Apply::Case(span, ApplyBranches(expression_branches), else_branch) => {
+            ApplyTerminator::Case(span, ApplyBranches(expression_branches), else_branch) => {
                 let mut branches = Vec::new();
                 let mut processes = Vec::new();
                 for (branch_name, expression_branch) in expression_branches {
@@ -2405,11 +2462,11 @@ impl Context {
                 )
             }
 
-            Apply::Begin {
+            ApplyTerminator::Begin {
                 span,
                 unfounded,
                 label,
-                then: apply,
+                body: apply,
             } => {
                 let process = self.compile_apply(apply)?;
                 process::Process::do_terminal(
@@ -2426,7 +2483,7 @@ impl Context {
                 )
             }
 
-            Apply::Loop(span, label) => process::Process::do_terminal(
+            ApplyTerminator::Loop(span, label) => process::Process::do_terminal(
                 span.clone(),
                 LocalName::object(),
                 VariableUsage::Unknown,
@@ -2437,45 +2494,56 @@ impl Context {
                     Captures::new(),
                 ),
             ),
-
-            Apply::SendType(span, argument, apply) => {
-                let process = self.compile_apply(apply)?;
-                process::Process::do_step(
+        };
+        for step in apply.steps.iter().rev() {
+            process = match step {
+                ApplyStep::Send(span, expression) => process::Process::do_step(
+                    span.clone(),
+                    LocalName::object(),
+                    VariableUsage::Unknown,
+                    (),
+                    process::Command::Send(self.compile_expression(expression)?),
+                    process,
+                ),
+                ApplyStep::Signal(span, chosen) => process::Process::do_step(
+                    span.clone(),
+                    LocalName::object(),
+                    VariableUsage::Unknown,
+                    (),
+                    process::Command::Signal(chosen.clone()),
+                    process,
+                ),
+                ApplyStep::SendType(span, argument) => process::Process::do_step(
                     span.clone(),
                     LocalName::object(),
                     VariableUsage::Unknown,
                     (),
                     process::Command::SendType(argument.clone()),
                     process,
-                )
-            }
-
-            Apply::Default(span, expr, apply) => {
-                let default_expr = self.compile_expression(expr)?;
-                let ok_process = self.compile_apply(apply)?;
-                self.compile_default(span, LocalName::object(), default_expr, ok_process)
-            }
-
-            Apply::Try(span, label, apply) => {
-                let catch_block = self.use_catch(span, label)?;
-                let ok_process = self.compile_apply(apply)?;
-                self.compile_try(span, LocalName::object(), catch_block, ok_process)
-            }
-
-            Apply::Pipe(span, function, apply) => {
-                let function = self.compile_expression(function)?;
-                let then = self.compile_apply(apply)?;
-                self.compile_pipe(span, LocalName::object(), function, then)
-            }
-        })
+                ),
+                ApplyStep::Default(span, expr) => {
+                    let default_expr = self.compile_expression(expr)?;
+                    self.compile_default(span, LocalName::object(), default_expr, process)
+                }
+                ApplyStep::Try(span, label) => {
+                    let catch_block = self.use_catch(span, label)?;
+                    self.compile_try(span, LocalName::object(), catch_block, process)
+                }
+                ApplyStep::Pipe(span, function) => {
+                    let function = self.compile_expression(function)?;
+                    self.compile_pipe(span, LocalName::object(), function, process)
+                }
+            };
+        }
+        Ok(process)
     }
 
     pub(crate) fn compile_apply_branch(
         &mut self,
         branch: &ApplyBranch<Unresolved>,
     ) -> Result<Arc<process::Process<(), Unresolved>>, CompileError> {
-        Ok(match branch {
-            ApplyBranch::Then(span, name, expression) => {
+        let mut process = match &branch.terminator {
+            ApplyBranchTerminator::Then(span, name, expression) => {
                 let expression = self.compile_expression(expression)?;
                 process::Process::let_step(
                     span.clone(),
@@ -2497,20 +2565,7 @@ impl Context {
                     ),
                 )
             }
-
-            ApplyBranch::Receive(span, pattern, branch, vars) => {
-                let process = self.compile_apply_branch(branch)?;
-                self.compile_pattern_receive(
-                    pattern,
-                    0,
-                    span,
-                    &LocalName::object(),
-                    process,
-                    vars.clone(),
-                )?
-            }
-
-            ApplyBranch::Continue(span, expression) => {
+            ApplyBranchTerminator::Continue(span, expression) => {
                 let expression = self.compile_expression(expression)?;
                 process::Process::do_step(
                     span.clone(),
@@ -2527,47 +2582,101 @@ impl Context {
                     ),
                 )
             }
-
-            ApplyBranch::ReceiveType(span, parameter, branch) => {
-                let process = self.compile_apply_branch(branch)?;
-                process::Process::do_step(
+        };
+        for step in branch.steps.iter().rev() {
+            process = match step {
+                ApplyBranchStep::Receive(span, pattern, vars) => self.compile_pattern_receive(
+                    pattern,
+                    0,
+                    span,
+                    &LocalName::object(),
+                    process,
+                    vars.clone(),
+                )?,
+                ApplyBranchStep::ReceiveType(span, parameter) => process::Process::do_step(
                     span.clone(),
                     LocalName::object(),
                     VariableUsage::Unknown,
                     (),
                     process::Command::ReceiveType(parameter.clone()),
                     process,
-                )
-            }
-
-            ApplyBranch::Try(span, label, branch) => {
-                let catch_block = self.use_catch(span, label)?;
-                let process = self.compile_apply_branch(branch)?;
-                self.compile_try(span, LocalName::object(), catch_block, process)
-            }
-
-            ApplyBranch::Default(span, expr, branch) => {
-                let default_expr = self.compile_expression(expr)?;
-                let ok_process = self.compile_apply_branch(branch)?;
-                self.compile_default(span, LocalName::object(), default_expr, ok_process)
-            }
-        })
+                ),
+                ApplyBranchStep::Try(span, label) => {
+                    let catch_block = self.use_catch(span, label)?;
+                    self.compile_try(span, LocalName::object(), catch_block, process)
+                }
+                ApplyBranchStep::Default(span, expr) => {
+                    let default_expr = self.compile_expression(expr)?;
+                    self.compile_default(span, LocalName::object(), default_expr, process)
+                }
+            };
+        }
+        Ok(process)
     }
 
     pub(crate) fn compile_process(
         &mut self,
         process: &Process<Unresolved>,
     ) -> Result<Arc<process::Process<(), Unresolved>>, CompileError> {
-        Ok(match process {
-            Process::If {
-                span,
-                branches,
-                else_,
-                then,
-            } => {
-                if let Some(tail) = then {
-                    let tail = self.compile_process(tail)?;
-                    self.with_fallthrough(tail, |pass| {
+        self.compile_process_from(process, 0)
+    }
+
+    fn compile_process_from(
+        &mut self,
+        source: &Process<Unresolved>,
+        mut index: usize,
+    ) -> Result<Arc<process::Process<(), Unresolved>>, CompileError> {
+        let mut frames = Vec::new();
+        let mut process = loop {
+            let Some(step) = source.steps.get(index) else {
+                break self.compile_process_terminator(&source.terminator)?;
+            };
+            match step {
+                ProcessStep::Let {
+                    span,
+                    pattern,
+                    value,
+                } => {
+                    let value = self.expr_without_fallthrough(|pass| {
+                        pass.disable_catches(CatchDisabledReason::DifferentProcess);
+                        let value = pass.compile_expression(value)?;
+                        pass.enable_catches();
+                        Ok(value)
+                    })?;
+                    frames.push(ProcessLoweringFrame::Let {
+                        span: span.clone(),
+                        pattern: pattern.clone(),
+                        value,
+                    });
+                    index += 1;
+                }
+                ProcessStep::Command(command)
+                    if matches!(command.command.terminator, CommandTerminator::Then(_)) =>
+                {
+                    frames.push(self.prepare_process_command(command)?);
+                    index += 1;
+                }
+                ProcessStep::Catch {
+                    span,
+                    label,
+                    pattern,
+                    block,
+                } => {
+                    let block = self.without_fallthrough(|pass| {
+                        let block = pass.compile_process(block)?;
+                        pass.compile_pattern_catch_block(pattern, span, block)
+                    })?;
+                    break self.with_catch(label.clone(), block, |pass| {
+                        pass.compile_process_from(source, index + 1)
+                    })?;
+                }
+                ProcessStep::If {
+                    span,
+                    branches,
+                    else_,
+                } => {
+                    let tail = self.compile_process_from(source, index + 1)?;
+                    break self.with_fallthrough(tail, |pass| {
                         let else_proc = match else_ {
                             Some(proc) => pass.compile_process(proc)?,
                             None => process::Process::terminal(process::Terminator::Unreachable(
@@ -2577,21 +2686,33 @@ impl Context {
                         pass.compile_if_branches(branches, else_proc, |body, pass| {
                             pass.compile_process(body)
                         })
-                    })?
-                } else {
-                    let else_proc = match else_ {
-                        Some(proc) => self.compile_process(proc)?,
-                        None => process::Process::terminal(process::Terminator::Unreachable(
-                            span.clone(),
-                        )),
-                    };
-                    self.compile_if_branches(branches, else_proc, |body, pass| {
-                        pass.compile_process(body)
-                    })?
+                    })?;
+                }
+                ProcessStep::Command(command) => {
+                    break self.compile_process_command(command, Some((source, index + 1)))?;
                 }
             }
+        };
+        for frame in frames.into_iter().rev() {
+            process = self.apply_process_lowering_frame(frame, process)?;
+        }
+        Ok(process)
+    }
 
-            Process::Poll {
+    fn compile_process_terminator(
+        &mut self,
+        terminator: &ProcessTerminator<Unresolved>,
+    ) -> Result<Arc<process::Process<(), Unresolved>>, CompileError> {
+        Ok(match terminator {
+            ProcessTerminator::Poll {
+                span,
+                label,
+                clients,
+                name,
+                then,
+                else_,
+            }
+            | ProcessTerminator::Repoll {
                 span,
                 label,
                 clients,
@@ -2599,86 +2720,33 @@ impl Context {
                 then,
                 else_,
             } => {
+                let kind = if matches!(terminator, ProcessTerminator::Poll { .. }) {
+                    process::PollKind::Poll
+                } else {
+                    process::PollKind::Repoll
+                };
                 let clients: Result<Vec<_>, _> =
                     clients.iter().map(|e| self.compile_expression(e)).collect();
-                let clients = clients?;
                 self.make_poll_process(
                     span,
-                    process::PollKind::Poll,
+                    kind,
                     label,
-                    clients,
+                    clients?,
                     name.clone(),
                     |pass| pass.compile_process(then),
                     |pass| pass.compile_process(else_),
                 )?
             }
-
-            Process::Repoll {
-                span,
-                label,
-                clients,
-                name,
-                then,
-                else_,
-            } => {
-                let clients: Result<Vec<_>, _> =
-                    clients.iter().map(|e| self.compile_expression(e)).collect();
-                let clients = clients?;
-                self.make_poll_process(
-                    span,
-                    process::PollKind::Repoll,
-                    label,
-                    clients,
-                    name.clone(),
-                    |pass| pass.compile_process(then),
-                    |pass| pass.compile_process(else_),
-                )?
-            }
-
-            Process::Submit {
+            ProcessTerminator::Submit {
                 span,
                 label,
                 values,
             } => {
                 let values: Result<Vec<_>, _> =
                     values.iter().map(|e| self.compile_expression(e)).collect();
-                let values = values?;
-                self.make_submit_process(span, label, values)?
+                self.make_submit_process(span, label, values?)?
             }
-
-            Process::Let {
-                span,
-                pattern,
-                value,
-                then,
-            } => {
-                let value = self.expr_without_fallthrough(|pass| {
-                    pass.disable_catches(CatchDisabledReason::DifferentProcess);
-                    let value = pass.compile_expression(value)?;
-                    pass.enable_catches();
-                    Ok(value)
-                })?;
-                let then_process = self.compile_process(then)?;
-                self.compile_pattern_let(pattern, span, value, then_process)?
-            }
-
-            Process::Catch {
-                span,
-                label,
-                pattern,
-                block,
-                then,
-            } => {
-                let block = self.without_fallthrough(|pass| {
-                    let block = pass.compile_process(block)?;
-                    pass.compile_pattern_catch_block(pattern, span, block)
-                })?;
-                let process =
-                    self.with_catch(label.clone(), block, |pass| pass.compile_process(then))?;
-                process
-            }
-
-            Process::Throw(span, label, expression) => {
+            ProcessTerminator::Throw(span, label, expression) => {
                 let catch_block = self.use_catch(span, label)?;
                 let expression = self.expr_without_fallthrough(|pass| {
                     pass.disable_catches(CatchDisabledReason::DifferentProcess);
@@ -2695,51 +2763,62 @@ impl Context {
                     catch_block,
                 )
             }
+            ProcessTerminator::If {
+                span,
+                branches,
+                else_,
+            } => {
+                let else_proc = match else_ {
+                    Some(proc) => self.compile_process(proc)?,
+                    None => {
+                        process::Process::terminal(process::Terminator::Unreachable(span.clone()))
+                    }
+                };
+                self.compile_if_branches(branches, else_proc, |body, pass| {
+                    pass.compile_process(body)
+                })?
+            }
+            ProcessTerminator::Command(command) => self.compile_process_command(command, None)?,
+            ProcessTerminator::Fallthrough(span) => match self.use_fallthrough(span) {
+                Some(process) => process,
+                None => Err(CompileError::MustEndProcess(span.clone()))?,
+            },
+        })
+    }
 
-            Process::GlobalCommand(_, global_name, command) => {
+    fn compile_process_command(
+        &mut self,
+        source: &ProcessCommand<Unresolved>,
+        continuation: Option<(&Process<Unresolved>, usize)>,
+    ) -> Result<Arc<process::Process<(), Unresolved>>, CompileError> {
+        match &source.target {
+            CommandTarget::Global(global_name) => {
                 let span = global_name.span.clone();
                 let local_name = LocalName {
                     span: span.clone(),
                     string: ArcStr::from(global_name.to_string()),
                 };
-                process::Process::let_step(
+                let command = self.compile_command(&source.command, &local_name, continuation)?;
+                Ok(process::Process::let_step(
                     span.clone(),
-                    local_name.clone(),
+                    local_name,
                     None,
                     (),
                     Arc::new(process::Expression::Global(span, global_name.clone(), ())),
-                    self.compile_command(command, &local_name)?,
-                )
+                    command,
+                ))
             }
-
-            Process::Command(_, name, Command::Then(next)) => process::Process::do_step(
-                name.span.clone(),
-                name.clone(),
-                VariableUsage::Unknown,
-                (),
-                process::Command::Noop,
-                self.compile_process(next)?,
-            ),
-
-            Process::Command(_, name, command) => {
+            CommandTarget::Local(name) => {
                 let None = self.original_object_name else {
-                    // this should never happen. If it did it means we forgot to exit the alias-mode.
-                    unreachable!(
-                        "Can't be in more than one command chain at once. currently set to: {}",
-                        self.original_object_name.clone().unwrap().string
-                    )
+                    unreachable!("can't be in more than one command chain at once")
                 };
                 self.original_object_name = Some(name.clone());
-                let then_process = self.compile_command(command, &LocalName::subject())?;
+                let command =
+                    self.compile_command(&source.command, &LocalName::subject(), continuation)?;
                 let None = self.original_object_name else {
-                    // this should never happen. If it did it means we forgot to exit the alias-mode.
-                    unreachable!(
-                        "Can't be in more than one command chain at once. {:?} was: {}",
-                        command,
-                        self.original_object_name.clone().unwrap().string
-                    )
+                    unreachable!("command lowering did not leave alias mode")
                 };
-                process::Process::let_step(
+                Ok(process::Process::let_step(
                     name.span.clone(),
                     LocalName::subject(),
                     None,
@@ -2750,14 +2829,88 @@ impl Context {
                         (),
                         VariableUsage::Unknown,
                     )),
-                    then_process,
-                )
+                    command,
+                ))
             }
+        }
+    }
 
-            Process::Fallthrough(span) => match self.use_fallthrough(span) {
-                Some(process) => process,
-                None => Err(CompileError::MustEndProcess(span.clone()))?,
+    fn prepare_process_command(
+        &mut self,
+        source: &ProcessCommand<Unresolved>,
+    ) -> Result<ProcessLoweringFrame, CompileError> {
+        let object_name = match &source.target {
+            CommandTarget::Global(global_name) => LocalName {
+                span: global_name.span.clone(),
+                string: ArcStr::from(global_name.to_string()),
             },
+            CommandTarget::Local(name) => {
+                let None = self.original_object_name else {
+                    unreachable!("can't be in more than one command chain at once")
+                };
+                self.original_object_name = Some(name.clone());
+                LocalName::subject()
+            }
+        };
+        let frames = self.prepare_command_frames(&source.command.steps, &object_name)?;
+        if matches!(source.command.steps.last(), Some(CommandStep::Continue(_))) {
+            self.original_object_name = None;
+        }
+        let original_object_name = std::mem::take(&mut self.original_object_name);
+        Ok(ProcessLoweringFrame::Command {
+            target: source.target.clone(),
+            object_name,
+            original_object_name,
+            frames,
+        })
+    }
+
+    fn apply_process_lowering_frame(
+        &mut self,
+        frame: ProcessLoweringFrame,
+        process: Arc<process::Process<(), Unresolved>>,
+    ) -> Result<Arc<process::Process<(), Unresolved>>, CompileError> {
+        Ok(match frame {
+            ProcessLoweringFrame::Let {
+                span,
+                pattern,
+                value,
+            } => self.compile_pattern_let(&pattern, &span, value, process)?,
+            ProcessLoweringFrame::Command {
+                target,
+                object_name,
+                original_object_name,
+                frames,
+            } => {
+                let process = self.restore_object_name(original_object_name, process);
+                let process = self.apply_command_frames(frames, &object_name, process)?;
+                match target {
+                    CommandTarget::Global(global_name) => {
+                        let span = global_name.span.clone();
+                        process::Process::let_step(
+                            span.clone(),
+                            object_name,
+                            None,
+                            (),
+                            Arc::new(process::Expression::Global(span, global_name, ())),
+                            process,
+                        )
+                    }
+                    CommandTarget::Local(name) => process::Process::let_step(
+                        name.span.clone(),
+                        LocalName::subject(),
+                        None,
+                        (),
+                        Arc::new(process::Expression::Variable(
+                            name.span.clone(),
+                            name,
+                            (),
+                            VariableUsage::Unknown,
+                        )),
+                        process,
+                    ),
+                }
+            }
         })
     }
 
@@ -2765,13 +2918,27 @@ impl Context {
         &mut self,
         command: &Command<Unresolved>,
         object_name: &LocalName,
+        continuation: Option<(&Process<Unresolved>, usize)>,
     ) -> Result<Arc<process::Process<(), Unresolved>>, CompileError> {
-        let mut frames = Vec::new();
-        let mut command = command;
+        let frames = self.prepare_command_frames(&command.steps, object_name)?;
+        if matches!(command.steps.last(), Some(CommandStep::Continue(_))) {
+            self.original_object_name = None;
+        }
 
-        let mut process = loop {
-            match command {
-                Command::Send(span, argument, then) => {
+        let process =
+            self.compile_command_terminal(&command.terminator, object_name, continuation)?;
+        self.apply_command_frames(frames, object_name, process)
+    }
+
+    fn prepare_command_frames(
+        &mut self,
+        steps: &[CommandStep<Unresolved>],
+        object_name: &LocalName,
+    ) -> Result<Vec<CommandLoweringFrame>, CompileError> {
+        let mut frames = Vec::with_capacity(steps.len());
+        for step in steps {
+            match step {
+                CommandStep::Send(span, argument) => {
                     self.disable_catches(CatchDisabledReason::DifferentProcess);
                     let argument = self.compile_expression(argument)?;
                     self.enable_catches();
@@ -2782,18 +2949,16 @@ impl Context {
                         typ: (),
                         command: process::Command::Send(argument),
                     }));
-                    command = then;
                 }
-                Command::Receive(span, pattern, then, vars) => {
+                CommandStep::Receive(span, pattern, vars) => {
                     frames.push(CommandLoweringFrame::Receive {
                         span: span.clone(),
                         pattern: pattern.clone(),
                         vars: vars.clone(),
                         original_object_name: self.original_object_name.clone(),
                     });
-                    command = then;
                 }
-                Command::Signal(span, chosen, then) => {
+                CommandStep::Signal(span, chosen) => {
                     frames.push(CommandLoweringFrame::Step(process::Step::Do {
                         span: span.clone(),
                         name: object_name.clone(),
@@ -2801,9 +2966,17 @@ impl Context {
                         typ: (),
                         command: process::Command::Signal(chosen.clone()),
                     }));
-                    command = then;
                 }
-                Command::SendType(span, argument, then) => {
+                CommandStep::Continue(span) => {
+                    frames.push(CommandLoweringFrame::Step(process::Step::Do {
+                        span: span.clone(),
+                        name: object_name.clone(),
+                        usage: VariableUsage::Unknown,
+                        typ: (),
+                        command: process::Command::Continue,
+                    }));
+                }
+                CommandStep::SendType(span, argument) => {
                     frames.push(CommandLoweringFrame::Step(process::Step::Do {
                         span: span.clone(),
                         name: object_name.clone(),
@@ -2811,9 +2984,8 @@ impl Context {
                         typ: (),
                         command: process::Command::SendType(argument.clone()),
                     }));
-                    command = then;
                 }
-                Command::ReceiveType(span, parameter, then) => {
+                CommandStep::ReceiveType(span, parameter) => {
                     frames.push(CommandLoweringFrame::Step(process::Step::Do {
                         span: span.clone(),
                         name: object_name.clone(),
@@ -2821,23 +2993,20 @@ impl Context {
                         typ: (),
                         command: process::Command::ReceiveType(parameter.clone()),
                     }));
-                    command = then;
                 }
-                Command::Try(span, label, then) => {
+                CommandStep::Try(span, label) => {
                     frames.push(CommandLoweringFrame::Try {
                         span: span.clone(),
                         catch_block: self.use_catch(span, label)?,
                     });
-                    command = then;
                 }
-                Command::Default(span, expression, then) => {
+                CommandStep::Default(span, expression) => {
                     frames.push(CommandLoweringFrame::Default {
                         span: span.clone(),
                         expression: self.compile_expression(expression)?,
                     });
-                    command = then;
                 }
-                Command::Pipe(span, function, then) => {
+                CommandStep::Pipe(span, function) => {
                     self.disable_catches(CatchDisabledReason::DifferentProcess);
                     let function = self.compile_expression(function)?;
                     self.enable_catches();
@@ -2845,20 +3014,18 @@ impl Context {
                         span: span.clone(),
                         function,
                     });
-                    command = then;
-                }
-                Command::Then(_)
-                | Command::Link(..)
-                | Command::Case(..)
-                | Command::Break(_)
-                | Command::Continue(..)
-                | Command::Begin { .. }
-                | Command::Loop(..) => {
-                    break self.compile_command_terminal(command, object_name)?;
                 }
             }
-        };
+        }
+        Ok(frames)
+    }
 
+    fn apply_command_frames(
+        &mut self,
+        frames: Vec<CommandLoweringFrame>,
+        object_name: &LocalName,
+        mut process: Arc<process::Process<(), Unresolved>>,
+    ) -> Result<Arc<process::Process<(), Unresolved>>, CompileError> {
         let flush_steps =
             |steps: &mut Vec<process::Step<(), Unresolved>>,
              process: Arc<process::Process<(), Unresolved>>| {
@@ -2917,17 +3084,24 @@ impl Context {
 
     fn compile_command_terminal(
         &mut self,
-        command: &Command<Unresolved>,
+        command: &CommandTerminator<Unresolved>,
         object_name: &LocalName,
+        process_continuation: Option<(&Process<Unresolved>, usize)>,
     ) -> Result<Arc<process::Process<(), Unresolved>>, CompileError> {
         Ok(match command {
-            Command::Then(process) => {
+            CommandTerminator::Then(span) => {
                 let original = std::mem::take(&mut self.original_object_name);
-                let process = self.compile_process(process)?;
+                let process = match process_continuation {
+                    Some((source, index)) => self.compile_process_from(source, index)?,
+                    None => match self.use_fallthrough(span) {
+                        Some(process) => process,
+                        None => Err(CompileError::MustEndProcess(span.clone()))?,
+                    },
+                };
                 self.restore_object_name(original, process)
             }
 
-            Command::Link(span, expression) => {
+            CommandTerminator::Link(span, expression) => {
                 self.disable_catches(CatchDisabledReason::DifferentProcess);
                 let expression = self.compile_expression(expression)?;
                 self.enable_catches();
@@ -2941,58 +3115,7 @@ impl Context {
                 )
             }
 
-            Command::Send(span, argument, command) => {
-                self.disable_catches(CatchDisabledReason::DifferentProcess);
-                let argument = self.compile_expression(argument)?;
-                self.enable_catches();
-                let process = self.compile_command(command, object_name)?;
-                process::Process::do_step(
-                    span.clone(),
-                    object_name.clone(),
-                    VariableUsage::Unknown,
-                    (),
-                    process::Command::Send(argument),
-                    process,
-                )
-            }
-
-            Command::Receive(span, pattern, command, vars) => {
-                let original = self.original_object_name.clone();
-                let process = self.compile_command(command, object_name)?;
-                let None = self.original_object_name else {
-                    unreachable!("original_object_name should be none after command")
-                };
-                self.original_object_name = original;
-                let process = self.compile_pattern_receive(
-                    pattern,
-                    0,
-                    span,
-                    object_name,
-                    process,
-                    vars.clone(),
-                )?;
-                self.original_object_name = None;
-                process
-            }
-
-            Command::Signal(span, chosen, command) => {
-                let process = self.compile_command(command, object_name)?;
-                process::Process::do_step(
-                    span.clone(),
-                    object_name.clone(),
-                    VariableUsage::Unknown,
-                    (),
-                    process::Command::Signal(chosen.clone()),
-                    process,
-                )
-            }
-
-            Command::Case(
-                span,
-                CommandBranches(process_branches),
-                else_branch,
-                optional_process,
-            ) => {
+            CommandTerminator::Case(span, CommandBranches(process_branches), else_branch) => {
                 let original = std::mem::take(&mut self.original_object_name);
                 let object_name = match &original {
                     None => object_name,
@@ -3002,8 +3125,8 @@ impl Context {
                 let mut branches = Vec::new();
                 let mut processes = Vec::new();
 
-                let process = if let Some(process) = optional_process {
-                    let process = self.compile_process(process)?;
+                let process = if let Some((source, index)) = process_continuation {
+                    let process = self.compile_process_from(source, index)?;
                     self.with_fallthrough(process, |pass| {
                         for (branch_name, process_branch) in process_branches {
                             branches.push(branch_name.clone());
@@ -3046,7 +3169,7 @@ impl Context {
                 self.restore_object_name(original, process)
             }
 
-            Command::Break(span) => {
+            CommandTerminator::Break(span) => {
                 self.original_object_name = None;
                 process::Process::do_terminal(
                     span.clone(),
@@ -3057,26 +3180,18 @@ impl Context {
                 )
             }
 
-            Command::Continue(span, process) => {
-                self.original_object_name = None;
-                let process = self.compile_process(process)?;
-                process::Process::do_step(
-                    span.clone(),
-                    object_name.clone(),
-                    VariableUsage::Unknown,
-                    (),
-                    process::Command::Continue,
-                    process,
-                )
-            }
-
-            Command::Begin {
+            CommandTerminator::Begin {
                 span,
                 unfounded,
                 label,
-                then: command,
+                body: command,
+                continuation,
             } => {
-                let process = self.compile_command(command, object_name)?;
+                let nested_continuation = continuation
+                    .as_deref()
+                    .map(|continuation| (continuation, 0));
+                let continuation = nested_continuation.or(process_continuation);
+                let process = self.compile_command(command, object_name, continuation)?;
                 process::Process::do_terminal(
                     span.clone(),
                     object_name.clone(),
@@ -3091,7 +3206,7 @@ impl Context {
                 )
             }
 
-            Command::Loop(span, label) => {
+            CommandTerminator::Loop(span, label) => {
                 self.original_object_name = None;
                 process::Process::do_terminal(
                     span.clone(),
@@ -3105,50 +3220,6 @@ impl Context {
                     ),
                 )
             }
-
-            Command::SendType(span, argument, command) => {
-                let process = self.compile_command(command, object_name)?;
-                process::Process::do_step(
-                    span.clone(),
-                    object_name.clone(),
-                    VariableUsage::Unknown,
-                    (),
-                    process::Command::SendType(argument.clone()),
-                    process,
-                )
-            }
-
-            Command::ReceiveType(span, parameter, command) => {
-                let process = self.compile_command(command, object_name)?;
-                process::Process::do_step(
-                    span.clone(),
-                    object_name.clone(),
-                    VariableUsage::Unknown,
-                    (),
-                    process::Command::ReceiveType(parameter.clone()),
-                    process,
-                )
-            }
-
-            Command::Try(span, label, command) => {
-                let catch_block = self.use_catch(span, label)?;
-                let ok_process = self.compile_command(command, object_name)?;
-                self.compile_try(span, object_name.clone(), catch_block, ok_process)
-            }
-
-            Command::Default(span, expr, command) => {
-                let default_expr = self.compile_expression(expr)?;
-                let ok_process = self.compile_command(command, object_name)?;
-                self.compile_default(span, object_name.clone(), default_expr, ok_process)
-            }
-
-            Command::Pipe(span, function, command) => {
-                self.disable_catches(CatchDisabledReason::DifferentProcess);
-                let function = self.compile_expression(function)?;
-                self.enable_catches();
-                let process = self.compile_command(command, object_name)?;
-                self.compile_pipe(span, object_name.clone(), function, process)
-            }
         })
     }
 
@@ -3157,10 +3228,9 @@ impl Context {
         branch: &CommandBranch<Unresolved>,
         object_name: &LocalName,
     ) -> Result<Arc<process::Process<(), Unresolved>>, CompileError> {
-        Ok(match branch {
-            CommandBranch::Then(_, process) => self.compile_process(process)?,
-
-            CommandBranch::BindThen(span, name, process) => {
+        let mut process = match &branch.terminator {
+            CommandBranchTerminator::Then(_, process) => self.compile_process(process)?,
+            CommandBranchTerminator::BindThen(span, name, process) => {
                 let process = self.compile_process(process)?;
                 process::Process::let_step(
                     span.clone(),
@@ -3176,14 +3246,8 @@ impl Context {
                     process,
                 )
             }
-
-            CommandBranch::Receive(span, pattern, branch, vars) => {
-                let process = self.compile_command_branch(branch, object_name)?;
-                self.compile_pattern_receive(pattern, 0, span, object_name, process, vars.clone())?
-            }
-
-            CommandBranch::Continue(span, process) => {
-                let process = self.compile_process(process)?;
+            CommandBranchTerminator::Continue(span, source) => {
+                let process = self.compile_process(source)?;
                 process::Process::do_step(
                     span.clone(),
                     object_name.clone(),
@@ -3193,30 +3257,36 @@ impl Context {
                     process,
                 )
             }
-
-            CommandBranch::ReceiveType(span, parameter, branch) => {
-                let process = self.compile_command_branch(branch, object_name)?;
-                process::Process::do_step(
+        };
+        for step in branch.steps.iter().rev() {
+            process = match step {
+                CommandBranchStep::Receive(span, pattern, vars) => self.compile_pattern_receive(
+                    pattern,
+                    0,
+                    span,
+                    object_name,
+                    process,
+                    vars.clone(),
+                )?,
+                CommandBranchStep::ReceiveType(span, parameter) => process::Process::do_step(
                     span.clone(),
                     object_name.clone(),
                     VariableUsage::Unknown,
                     (),
                     process::Command::ReceiveType(parameter.clone()),
                     process,
-                )
-            }
-
-            CommandBranch::Try(span, label, branch) => {
-                let catch_block = self.use_catch(span, label)?;
-                let process = self.compile_command_branch(branch, object_name)?;
-                self.compile_try(span, object_name.clone(), catch_block, process)
-            }
-            CommandBranch::Default(span, expr, branch) => {
-                let default_expr = self.compile_expression(expr)?;
-                let ok_process = self.compile_command_branch(branch, object_name)?;
-                self.compile_default(span, object_name.clone(), default_expr, ok_process)
-            }
-        })
+                ),
+                CommandBranchStep::Try(span, label) => {
+                    let catch_block = self.use_catch(span, label)?;
+                    self.compile_try(span, object_name.clone(), catch_block, process)
+                }
+                CommandBranchStep::Default(span, expr) => {
+                    let default_expr = self.compile_expression(expr)?;
+                    self.compile_default(span, object_name.clone(), default_expr, process)
+                }
+            };
+        }
+        Ok(process)
     }
 
     fn compile_try(
@@ -3340,7 +3410,7 @@ impl Context {
         body: Arc<process::Process<(), Unresolved>>,
         subject: &LocalName,
     ) -> Result<Arc<process::Process<(), Unresolved>>, CompileError> {
-        if matches!(pattern, Pattern::Continue(_)) {
+        if pattern.is_continue() {
             return Ok(body);
         }
         self.compile_pattern_let(
@@ -3547,46 +3617,80 @@ impl Pass {
 }
 
 impl<S> Pattern<S> {
+    fn as_name(&self) -> Option<(&Span, &LocalName, &Option<Type<S>>)> {
+        if !self.steps.is_empty() {
+            return None;
+        }
+        match &self.terminal {
+            PatternTerminal::Name(span, name, annotation) => Some((span, name, annotation)),
+            PatternTerminal::Continue(_) => None,
+        }
+    }
+
+    fn is_continue(&self) -> bool {
+        self.steps.is_empty() && matches!(self.terminal, PatternTerminal::Continue(_))
+    }
+
     fn annotation(&self) -> Option<Type<S>>
     where
         S: Clone,
     {
-        match self {
-            Self::Name(_, _, annotation) => annotation.clone(),
-            Self::Receive(span, first, rest, vars) => {
-                let first = first.annotation()?;
-                let rest = rest.annotation()?;
-                Some(Type::Pair(
-                    span.clone(),
-                    Box::new(first),
-                    Box::new(rest),
-                    vars.clone(),
-                ))
-            }
-            Self::Continue(span) => Some(Type::Break(span.clone())),
-            Self::ReceiveType(span, parameter, rest) => {
-                let rest = rest.annotation()?;
-                Some(Type::Exists(
-                    span.clone(),
-                    parameter.clone(),
-                    Box::new(rest),
-                ))
-            }
-            Self::Try(_, _, _) => None,
-            Self::Default(_, _, rest) => rest.annotation(),
+        let mut annotation = match &self.terminal {
+            PatternTerminal::Name(_, _, annotation) => annotation.clone(),
+            PatternTerminal::Continue(span) => Some(Type::Break(span.clone())),
+        };
+        for step in self.steps.iter().rev() {
+            annotation = match step {
+                PatternStep::Receive(span, first, vars) => {
+                    let first = first.annotation()?;
+                    let rest = annotation?;
+                    Some(Type::Pair(
+                        span.clone(),
+                        Box::new(first),
+                        Box::new(rest),
+                        vars.clone(),
+                    ))
+                }
+                PatternStep::ReceiveType(span, parameter) => {
+                    let rest = annotation?;
+                    Some(Type::Exists(
+                        span.clone(),
+                        parameter.clone(),
+                        Box::new(rest),
+                    ))
+                }
+                PatternStep::Try(_, _) => None,
+                PatternStep::Default(_, _) => annotation,
+            };
         }
+        annotation
     }
 }
 
 impl<S> Spanning for Pattern<S> {
     fn span(&self) -> Span {
+        match self.steps.first() {
+            Some(step) => step.span(),
+            None => self.terminal.span(),
+        }
+    }
+}
+
+impl<S> Spanning for PatternStep<S> {
+    fn span(&self) -> Span {
         match self {
-            Self::Name(span, _, _)
-            | Self::Continue(span)
-            | Self::Receive(span, _, _, _)
-            | Self::ReceiveType(span, _, _)
-            | Self::Try(span, _, _)
-            | Self::Default(span, _, _) => span.clone(),
+            Self::Receive(span, _, _)
+            | Self::ReceiveType(span, _)
+            | Self::Try(span, _)
+            | Self::Default(span, _) => span.clone(),
+        }
+    }
+}
+
+impl<S> PatternTerminal<S> {
+    fn span(&self) -> Span {
+        match self {
+            Self::Name(span, _, _) | Self::Continue(span) => span.clone(),
         }
     }
 }
@@ -3623,112 +3727,230 @@ impl<S> Spanning for Expression<S> {
 
 impl<S> Spanning for Construct<S> {
     fn span(&self) -> Span {
+        match self.steps.first() {
+            Some(step) => step.span(),
+            None => self.terminator.span(),
+        }
+    }
+}
+
+impl<S> Spanning for ConstructStep<S> {
+    fn span(&self) -> Span {
         match self {
-            Self::Send(span, _, _)
-            | Self::Receive(span, _, _, _)
-            | Self::Signal(span, _, _)
-            | Self::Case(span, _, _)
+            Self::Send(span, _)
+            | Self::Receive(span, _, _)
+            | Self::Signal(span, _)
+            | Self::SendType(span, _)
+            | Self::ReceiveType(span, _) => span.clone(),
+        }
+    }
+}
+
+impl<S> ConstructTerminator<S> {
+    fn span(&self) -> Span {
+        match self {
+            Self::Then(expression) => expression.span(),
+            Self::Case(span, _, _)
             | Self::Break(span)
             | Self::Begin { span, .. }
-            | Self::Loop(span, _)
-            | Self::SendType(span, _, _)
-            | Self::ReceiveType(span, _, _) => span.clone(),
-
-            Self::Then(expression) => expression.span(),
+            | Self::Loop(span, _) => span.clone(),
         }
     }
 }
 
 impl<S> Spanning for ConstructBranch<S> {
     fn span(&self) -> Span {
+        match self.steps.first() {
+            Some(step) => step.span(),
+            None => self.terminator.span(),
+        }
+    }
+}
+
+impl<S> Spanning for ConstructBranchStep<S> {
+    fn span(&self) -> Span {
         match self {
-            Self::Then(span, _) | Self::Receive(span, _, _, _) | Self::ReceiveType(span, _, _) => {
-                span.clone()
-            }
+            Self::Receive(span, _, _) | Self::ReceiveType(span, _) => span.clone(),
+        }
+    }
+}
+
+impl<S> ConstructBranchTerminator<S> {
+    fn span(&self) -> Span {
+        match self {
+            Self::Then(span, _) => span.clone(),
         }
     }
 }
 
 impl<S> Spanning for Apply<S> {
     fn span(&self) -> Span {
+        match self.steps.first() {
+            Some(step) => step.span(),
+            None => self.terminator.span(),
+        }
+    }
+}
+
+impl<S> Spanning for ApplyStep<S> {
+    fn span(&self) -> Span {
         match self {
-            Self::Send(span, _, _)
-            | Self::Signal(span, _, _)
+            Self::Send(span, _)
+            | Self::Signal(span, _)
+            | Self::SendType(span, _)
+            | Self::Try(span, _)
+            | Self::Default(span, _)
+            | Self::Pipe(span, _) => span.clone(),
+        }
+    }
+}
+
+impl<S> ApplyTerminator<S> {
+    fn span(&self) -> Span {
+        match self {
+            Self::Noop(span)
             | Self::Case(span, _, _)
             | Self::Begin { span, .. }
-            | Self::Loop(span, _)
-            | Self::SendType(span, _, _)
-            | Self::Noop(span)
-            | Self::Try(span, _, _)
-            | Self::Default(span, _, _)
-            | Self::Pipe(span, _, _) => span.clone(),
+            | Self::Loop(span, _) => span.clone(),
         }
     }
 }
 
 impl<S> Spanning for ApplyBranch<S> {
     fn span(&self) -> Span {
+        match self.steps.first() {
+            Some(step) => step.span(),
+            None => self.terminator.span(),
+        }
+    }
+}
+
+impl<S> Spanning for ApplyBranchStep<S> {
+    fn span(&self) -> Span {
         match self {
-            Self::Then(span, _, _)
-            | Self::Receive(span, _, _, _)
-            | Self::Continue(span, _)
-            | Self::ReceiveType(span, _, _)
-            | Self::Try(span, _, _)
-            | Self::Default(span, _, _) => span.clone(),
+            Self::Receive(span, _, _)
+            | Self::ReceiveType(span, _)
+            | Self::Try(span, _)
+            | Self::Default(span, _) => span.clone(),
+        }
+    }
+}
+
+impl<S> ApplyBranchTerminator<S> {
+    fn span(&self) -> Span {
+        match self {
+            Self::Then(span, _, _) | Self::Continue(span, _) => span.clone(),
+        }
+    }
+}
+
+impl<S> Process<S> {
+    pub fn fallthrough(span: Span) -> Self {
+        Self {
+            steps: Vec::new(),
+            terminator: ProcessTerminator::Fallthrough(span),
         }
     }
 }
 
 impl<S> Spanning for Process<S> {
     fn span(&self) -> Span {
+        match self.steps.first() {
+            Some(step) => step.span(),
+            None => self.terminator.span(),
+        }
+    }
+}
+
+impl<S> Spanning for ProcessStep<S> {
+    fn span(&self) -> Span {
         match self {
-            Self::Let { span, .. } => span.clone(),
-            Self::Poll { span, .. } => span.clone(),
-            Self::Repoll { span, .. } => span.clone(),
-            Self::Submit { span, .. } => span.clone(),
-            Self::Catch { span, .. } => span.clone(),
-            Self::Throw(span, _, _) => span.clone(),
-            Self::If { span, .. } => span.clone(),
-            Self::GlobalCommand(span, _, _) => span.clone(),
-            Self::Command(span, _, _) => span.clone(),
-            Self::Fallthrough(span) => span.clone(),
+            Self::Let { span, .. } | Self::Catch { span, .. } | Self::If { span, .. } => {
+                span.clone()
+            }
+            Self::Command(command) => command.span.clone(),
+        }
+    }
+}
+
+impl<S> Spanning for ProcessTerminator<S> {
+    fn span(&self) -> Span {
+        match self {
+            Self::Poll { span, .. }
+            | Self::Repoll { span, .. }
+            | Self::Submit { span, .. }
+            | Self::If { span, .. }
+            | Self::Throw(span, ..)
+            | Self::Fallthrough(span) => span.clone(),
+            Self::Command(command) => command.span.clone(),
+        }
+    }
+}
+
+impl<S> CommandTerminator<S> {
+    pub fn span(&self) -> Span {
+        match self {
+            Self::Then(span)
+            | Self::Link(span, _)
+            | Self::Case(span, _, _)
+            | Self::Break(span)
+            | Self::Begin { span, .. }
+            | Self::Loop(span, _) => span.clone(),
         }
     }
 }
 
 impl<S> Spanning for Command<S> {
     fn span(&self) -> Span {
-        match self {
-            Self::Link(span, _)
-            | Self::Send(span, _, _)
-            | Self::Receive(span, _, _, _)
-            | Self::Signal(span, _, _)
-            | Self::Case(span, _, _, _)
-            | Self::Break(span)
-            | Self::Continue(span, _)
-            | Self::Begin { span, .. }
-            | Self::Loop(span, _)
-            | Self::SendType(span, _, _)
-            | Self::ReceiveType(span, _, _)
-            | Self::Try(span, _, _)
-            | Self::Default(span, _, _)
-            | Self::Pipe(span, _, _) => span.clone(),
+        match self.steps.first() {
+            Some(step) => step.span(),
+            None => self.terminator.span(),
+        }
+    }
+}
 
-            Self::Then(process) => process.span(),
+impl<S> Spanning for CommandStep<S> {
+    fn span(&self) -> Span {
+        match self {
+            Self::Send(span, _)
+            | Self::Receive(span, _, _)
+            | Self::Signal(span, _)
+            | Self::Continue(span)
+            | Self::SendType(span, _)
+            | Self::ReceiveType(span, _)
+            | Self::Try(span, _)
+            | Self::Default(span, _)
+            | Self::Pipe(span, _) => span.clone(),
         }
     }
 }
 
 impl<S> Spanning for CommandBranch<S> {
     fn span(&self) -> Span {
+        match self.steps.first() {
+            Some(step) => step.span(),
+            None => self.terminator.span(),
+        }
+    }
+}
+
+impl<S> Spanning for CommandBranchStep<S> {
+    fn span(&self) -> Span {
         match self {
-            Self::Then(span, _)
-            | Self::BindThen(span, _, _)
-            | Self::Receive(span, _, _, _)
-            | Self::Continue(span, _)
-            | Self::ReceiveType(span, _, _)
-            | Self::Try(span, _, _)
-            | Self::Default(span, _, _) => span.clone(),
+            Self::Receive(span, _, _)
+            | Self::ReceiveType(span, _)
+            | Self::Try(span, _)
+            | Self::Default(span, _) => span.clone(),
+        }
+    }
+}
+
+impl<S> CommandBranchTerminator<S> {
+    pub fn span(&self) -> Span {
+        match self {
+            Self::Then(span, _) | Self::BindThen(span, _, _) | Self::Continue(span, _) => {
+                span.clone()
+            }
         }
     }
 }
@@ -3741,42 +3963,35 @@ struct Restoration {
 }
 
 fn pattern_to_expression(pattern: &Pattern<Unresolved>) -> Option<Expression<Unresolved>> {
-    match pattern {
-        Pattern::Name(span, name, _) => Some(Expression::Variable(span.clone(), name.clone())),
-        Pattern::Receive(span, first, rest, _vars) => {
-            let first_expr = pattern_to_expression(first)?;
-            let then = construct_from_pattern(rest)?;
-            Some(Expression::Construction(
-                span.clone(),
-                Construct::Send(span.clone(), Box::new(first_expr), Box::new(then)),
-            ))
-        }
-        Pattern::Continue(span) => Some(Expression::Construction(
-            span.clone(),
-            Construct::Break(span.clone()),
-        )),
-        Pattern::ReceiveType(_, _, _) | Pattern::Try(_, _, _) | Pattern::Default(_, _, _) => None,
+    if let Some((span, name, _)) = pattern.as_name() {
+        return Some(Expression::Variable(span.clone(), name.clone()));
     }
+    Some(Expression::Construction(
+        pattern.span(),
+        construct_from_pattern(pattern)?,
+    ))
 }
 
 fn construct_from_pattern(pattern: &Pattern<Unresolved>) -> Option<Construct<Unresolved>> {
-    match pattern {
-        Pattern::Name(span, name, _) => Some(Construct::Then(Box::new(Expression::Variable(
-            span.clone(),
-            name.clone(),
-        )))),
-        Pattern::Receive(span, first, rest, _vars) => {
-            let expression = pattern_to_expression(first)?;
-            let then = construct_from_pattern(rest)?;
-            Some(Construct::Send(
-                span.clone(),
-                Box::new(expression),
-                Box::new(then),
-            ))
+    let terminator = match &pattern.terminal {
+        PatternTerminal::Name(span, name, _) => {
+            ConstructTerminator::Then(Box::new(Expression::Variable(span.clone(), name.clone())))
         }
-        Pattern::Continue(span) => Some(Construct::Break(span.clone())),
-        Pattern::ReceiveType(_, _, _) | Pattern::Try(_, _, _) | Pattern::Default(_, _, _) => None,
+        PatternTerminal::Continue(span) => ConstructTerminator::Break(span.clone()),
+    };
+    let mut steps = Vec::with_capacity(pattern.steps.len());
+    for step in &pattern.steps {
+        match step {
+            PatternStep::Receive(span, payload, _) => steps.push(ConstructStep::Send(
+                span.clone(),
+                Box::new(pattern_to_expression(payload)?),
+            )),
+            PatternStep::ReceiveType(..) | PatternStep::Try(..) | PatternStep::Default(..) => {
+                return None;
+            }
+        }
     }
+    Some(Construct { steps, terminator })
 }
 
 fn reconstruction_for_is(
@@ -3788,11 +4003,11 @@ fn reconstruction_for_is(
     let Expression::Variable(_, name) = value else {
         return None;
     };
-    let payload = construct_from_pattern(pattern)?;
-    let reconstruction = Expression::Construction(
-        span.clone(),
-        Construct::Signal(span.clone(), variant.clone(), Box::new(payload)),
-    );
+    let mut payload = construct_from_pattern(pattern)?;
+    payload
+        .steps
+        .insert(0, ConstructStep::Signal(span.clone(), variant.clone()));
+    let reconstruction = Expression::Construction(span.clone(), payload);
     Some(Restoration {
         span: span.clone(),
         name: name.clone(),
@@ -3823,11 +4038,17 @@ fn collect_restorations(condition: &Condition<Unresolved>) -> Vec<Restoration> {
 
 fn link_process_from_expr(expr: &Expression<Unresolved>) -> Process<Unresolved> {
     let span = expr.span();
-    Process::Command(
-        span.clone(),
-        LocalName::result(),
-        Command::Link(span, Box::new(expr.clone())),
-    )
+    Process {
+        steps: Vec::new(),
+        terminator: ProcessTerminator::Command(ProcessCommand {
+            span: span.clone(),
+            target: CommandTarget::Local(LocalName::result()),
+            command: Command {
+                steps: Vec::new(),
+                terminator: CommandTerminator::Link(span, Box::new(expr.clone())),
+            },
+        }),
+    }
 }
 
 #[cfg(test)]
@@ -3839,13 +4060,17 @@ mod flat_ir_tests {
         const STEP_COUNT: usize = 20_000;
         let subject = LocalName::from(literal!("subject"));
         let chosen = LocalName::from(literal!("next"));
-        let mut command = Command::Break(Span::None);
+        let mut steps = Vec::with_capacity(STEP_COUNT);
         for _ in 0..STEP_COUNT {
-            command = Command::Signal(Span::None, chosen.clone(), Box::new(command));
+            steps.push(CommandStep::Signal(Span::None, chosen.clone()));
         }
+        let command = Command {
+            steps,
+            terminator: CommandTerminator::Break(Span::None),
+        };
 
         let mut context = Context::new();
-        let lowered = context.compile_command(&command, &subject).unwrap();
+        let lowered = context.compile_command(&command, &subject, None).unwrap();
         assert_eq!(lowered.steps.len(), STEP_COUNT);
         assert!(matches!(
             lowered.terminator,
@@ -3857,9 +4082,78 @@ mod flat_ir_tests {
 
         let (fixed, _) = lowered.fix_captures();
         assert_eq!(fixed.steps.len(), STEP_COUNT);
+    }
 
-        // The source AST is intentionally recursive and outside this refactor's scope. Avoid a
-        // recursive destructor walk obscuring what this test is measuring.
-        std::mem::forget(command);
+    #[test]
+    fn lowers_long_high_level_sequences_without_recursive_spines() {
+        const STEP_COUNT: usize = 20_000;
+        let value = LocalName::from(literal!("value"));
+        let binding = LocalName::from(literal!("binding"));
+        let exit = LocalName::from(literal!("exit"));
+        let chosen = LocalName::from(literal!("next"));
+
+        let process = Process {
+            steps: (0..STEP_COUNT)
+                .map(|_| ProcessStep::Let {
+                    span: Span::None,
+                    pattern: Pattern {
+                        steps: Vec::new(),
+                        terminal: PatternTerminal::Name(Span::None, binding.clone(), None),
+                    },
+                    value: Box::new(Expression::Variable(Span::None, value.clone())),
+                })
+                .collect(),
+            terminator: ProcessTerminator::Command(ProcessCommand {
+                span: Span::None,
+                target: CommandTarget::Local(exit),
+                command: Command {
+                    steps: Vec::new(),
+                    terminator: CommandTerminator::Break(Span::None),
+                },
+            }),
+        };
+        let lowered = Context::new().compile_process(&process).unwrap();
+        assert_eq!(lowered.steps.len(), STEP_COUNT + 1);
+
+        let construct = Construct {
+            steps: (0..STEP_COUNT)
+                .map(|_| ConstructStep::Signal(Span::None, chosen.clone()))
+                .collect(),
+            terminator: ConstructTerminator::Break(Span::None),
+        };
+        let lowered = Context::new().compile_construct(&construct).unwrap();
+        assert_eq!(lowered.steps.len(), STEP_COUNT);
+
+        let apply = Apply {
+            steps: (0..STEP_COUNT)
+                .map(|_| ApplyStep::Signal(Span::None, chosen.clone()))
+                .collect(),
+            terminator: ApplyTerminator::Noop(Span::None),
+        };
+        let lowered = Context::new().compile_apply(&apply).unwrap();
+        assert_eq!(lowered.steps.len(), STEP_COUNT);
+
+        let pattern = Pattern {
+            steps: (0..STEP_COUNT)
+                .map(|_| {
+                    PatternStep::ReceiveType(
+                        Span::None,
+                        TypeParameter::any(LocalName::from(literal!("a"))),
+                    )
+                })
+                .collect(),
+            terminal: PatternTerminal::Name(Span::None, binding, None),
+        };
+        let tail = process::Process::do_terminal(
+            Span::None,
+            LocalName::result(),
+            VariableUsage::Unknown,
+            (),
+            process::TerminalCommand::Break,
+        );
+        let lowered = Context::new()
+            .compile_pattern_helper(&pattern, 0, tail)
+            .unwrap();
+        assert_eq!(lowered.steps.len(), STEP_COUNT + 1);
     }
 }

--- a/crates/par-core/src/frontend_impl/language.rs
+++ b/crates/par-core/src/frontend_impl/language.rs
@@ -832,6 +832,28 @@ struct Pass {
     disabled_reasons: Vec<CatchDisabledReason>,
 }
 
+enum CommandLoweringFrame {
+    Step(process::Step<(), Unresolved>),
+    Receive {
+        span: Span,
+        pattern: Pattern<Unresolved>,
+        vars: Vec<TypeParameter>,
+        original_object_name: Option<LocalName>,
+    },
+    Try {
+        span: Span,
+        catch_block: Arc<process::Process<(), Unresolved>>,
+    },
+    Default {
+        span: Span,
+        expression: Arc<process::Expression<(), Unresolved>>,
+    },
+    Pipe {
+        span: Span,
+        function: Arc<process::Expression<(), Unresolved>>,
+    },
+}
+
 impl Context {
     pub(crate) fn new() -> Self {
         Self {
@@ -847,19 +869,19 @@ impl Context {
     ) -> Arc<process::Process<(), Unresolved>> {
         match name {
             None => process,
-            Some(original) => Arc::new(process::Process::Let {
-                span: original.span.clone(),
-                name: original.clone(),
-                annotation: None,
-                typ: (),
-                value: Arc::new(process::Expression::Variable(
+            Some(original) => process::Process::let_step(
+                original.span.clone(),
+                original.clone(),
+                None,
+                (),
+                Arc::new(process::Expression::Variable(
                     original.span.clone(),
                     LocalName::subject(),
                     (),
                     VariableUsage::Unknown,
                 )),
-                then: process,
-            }),
+                process,
+            ),
         }
     }
 
@@ -1148,7 +1170,7 @@ impl Context {
         if !self.passes.fallthrough.take().unwrap().used {
             return Err(CompileError::UnreachableCode(body.span()));
         }
-        let result = Arc::new(process::Process::Block(
+        let result = process::Process::terminal(process::Terminator::Block(
             body.span(),
             block_index,
             body,
@@ -1186,13 +1208,13 @@ impl Context {
             chan_type: (),
             expr_type: (),
             process: self.with_fallthrough(body, |pass| {
-                Ok(Arc::new(process::Process::Do {
-                    span: span.clone(),
-                    name: LocalName::result(),
-                    usage: VariableUsage::Unknown,
-                    typ: (),
-                    command: process::Command::Link(f(pass)?),
-                }))
+                Ok(process::Process::do_terminal(
+                    span.clone(),
+                    LocalName::result(),
+                    VariableUsage::Unknown,
+                    (),
+                    process::TerminalCommand::Link(f(pass)?),
+                ))
             })?,
         }))
     }
@@ -1314,7 +1336,7 @@ impl Context {
         let build = |pass: &mut Self| {
             let then = then(pass)?;
             let else_ = pass.without_poll(|pass| else_(pass))?;
-            Ok(Arc::new(process::Process::Poll {
+            Ok(process::Process::terminal(process::Terminator::Poll {
                 span: span.clone(),
                 kind: kind.clone(),
                 driver: driver.clone(),
@@ -1357,7 +1379,7 @@ impl Context {
             })?,
         };
 
-        Ok(Arc::new(process::Process::Submit {
+        Ok(process::Process::terminal(process::Terminator::Submit {
             span: span.clone(),
             driver,
             point,
@@ -1399,7 +1421,7 @@ impl Context {
         if !current.unwrap().used {
             return Err(CompileError::UnreachableCode(body.span()));
         }
-        Ok(Arc::new(process::Process::Block(
+        Ok(process::Process::terminal(process::Terminator::Block(
             body.span(),
             block_index,
             body,
@@ -1422,13 +1444,13 @@ impl Context {
             chan_type: (),
             expr_type: (),
             process: self.with_catch(label, body, |pass| {
-                Ok(Arc::new(process::Process::Do {
-                    span: span.clone(),
-                    name: LocalName::result(),
-                    usage: VariableUsage::Unknown,
-                    typ: (),
-                    command: process::Command::Link(f(pass)?),
-                }))
+                Ok(process::Process::do_terminal(
+                    span.clone(),
+                    LocalName::result(),
+                    VariableUsage::Unknown,
+                    (),
+                    process::TerminalCommand::Link(f(pass)?),
+                ))
             })?,
         }))
     }
@@ -1473,23 +1495,24 @@ impl Context {
         process: Arc<process::Process<(), Unresolved>>,
     ) -> Result<Arc<process::Process<(), Unresolved>>, CompileError> {
         if let Pattern::Name(_, name, annotation) = pattern {
-            return Ok(Arc::new(process::Process::Let {
-                span: span.clone(),
-                name: name.clone(),
-                annotation: annotation.clone(),
-                typ: (),
-                value: expression,
-                then: process,
-            }));
+            return Ok(process::Process::let_step(
+                span.clone(),
+                name.clone(),
+                annotation.clone(),
+                (),
+                expression,
+                process,
+            ));
         }
-        Ok(Arc::new(process::Process::Let {
-            span: span.clone(),
-            name: LocalName::match_(0),
-            annotation: pattern.annotation(),
-            typ: (),
-            value: expression,
-            then: self.compile_pattern_helper(pattern, 0, process)?,
-        }))
+        let then = self.compile_pattern_helper(pattern, 0, process)?;
+        Ok(process::Process::let_step(
+            span.clone(),
+            LocalName::match_(0),
+            pattern.annotation(),
+            (),
+            expression,
+            then,
+        ))
     }
 
     pub(crate) fn compile_pattern_chan(
@@ -1527,33 +1550,34 @@ impl Context {
         block: Arc<process::Process<(), Unresolved>>,
     ) -> Result<Arc<process::Process<(), Unresolved>>, CompileError> {
         if let Pattern::Name(_, name, annotation) = pattern {
-            return Ok(Arc::new(process::Process::Let {
-                span: span.clone(),
-                name: name.clone(),
-                annotation: annotation.clone(),
-                typ: (),
-                value: Arc::new(process::Expression::Variable(
+            return Ok(process::Process::let_step(
+                span.clone(),
+                name.clone(),
+                annotation.clone(),
+                (),
+                Arc::new(process::Expression::Variable(
                     span.clone(),
                     LocalName::error(),
                     (),
                     VariableUsage::Unknown,
                 )),
-                then: block,
-            }));
+                block,
+            ));
         }
-        Ok(Arc::new(process::Process::Let {
-            span: span.clone(),
-            name: LocalName::match_(0),
-            annotation: None,
-            typ: (),
-            value: Arc::new(process::Expression::Variable(
+        let then = self.compile_pattern_helper(pattern, 0, block)?;
+        Ok(process::Process::let_step(
+            span.clone(),
+            LocalName::match_(0),
+            None,
+            (),
+            Arc::new(process::Expression::Variable(
                 span.clone(),
                 LocalName::error(),
                 (),
                 VariableUsage::Unknown,
             )),
-            then: self.compile_pattern_helper(pattern, 0, block)?,
-        }))
+            then,
+        ))
     }
 
     pub(crate) fn compile_pattern_receive(
@@ -1566,33 +1590,24 @@ impl Context {
         vars: Vec<TypeParameter>,
     ) -> Result<Arc<process::Process<(), Unresolved>>, CompileError> {
         if let Pattern::Name(_, name, annotation) = pattern {
-            return Ok(Arc::new(process::Process::Do {
-                span: span.clone(),
-                name: subject.clone(),
-                usage: VariableUsage::Unknown,
-                typ: (),
-                command: process::Command::Receive(
-                    name.clone(),
-                    annotation.clone(),
-                    (),
-                    process,
-                    vars,
-                ),
-            }));
-        }
-        Ok(Arc::new(process::Process::Do {
-            span: span.clone(),
-            name: subject.clone(),
-            usage: VariableUsage::Unknown,
-            typ: (),
-            command: process::Command::Receive(
-                LocalName::match_(level),
-                pattern.annotation(),
+            return Ok(process::Process::do_step(
+                span.clone(),
+                subject.clone(),
+                VariableUsage::Unknown,
                 (),
-                self.compile_pattern_helper(pattern, level, process)?,
-                vars,
-            ),
-        }))
+                process::Command::Receive(name.clone(), annotation.clone(), (), vars),
+                process,
+            ));
+        }
+        let then = self.compile_pattern_helper(pattern, level, process)?;
+        Ok(process::Process::do_step(
+            span.clone(),
+            subject.clone(),
+            VariableUsage::Unknown,
+            (),
+            process::Command::Receive(LocalName::match_(level), pattern.annotation(), (), vars),
+            then,
+        ))
     }
 
     fn compile_pattern_helper(
@@ -1602,19 +1617,19 @@ impl Context {
         process: Arc<process::Process<(), Unresolved>>,
     ) -> Result<Arc<process::Process<(), Unresolved>>, CompileError> {
         match pattern {
-            Pattern::Name(span, name, annotation) => Ok(Arc::new(process::Process::Let {
-                span: span.clone(),
-                name: name.clone(),
-                annotation: annotation.clone(),
-                typ: (),
-                value: Arc::new(process::Expression::Variable(
+            Pattern::Name(span, name, annotation) => Ok(process::Process::let_step(
+                span.clone(),
+                name.clone(),
+                annotation.clone(),
+                (),
+                Arc::new(process::Expression::Variable(
                     span.clone(),
                     LocalName::match_(level),
                     (),
                     VariableUsage::Unknown,
                 )),
-                then: process,
-            })),
+                process,
+            )),
 
             Pattern::Receive(span, first, rest, vars) => {
                 let then_process = self.compile_pattern_helper(rest, level, process)?;
@@ -1628,41 +1643,43 @@ impl Context {
                 )
             }
 
-            Pattern::Continue(span) => Ok(Arc::new(process::Process::Do {
-                span: span.clone(),
-                name: LocalName::match_(level),
-                usage: VariableUsage::Unknown,
-                typ: (),
-                command: process::Command::Continue(process),
-            })),
+            Pattern::Continue(span) => Ok(process::Process::do_step(
+                span.clone(),
+                LocalName::match_(level),
+                VariableUsage::Unknown,
+                (),
+                process::Command::Continue,
+                process,
+            )),
 
-            Pattern::ReceiveType(span, parameter, rest) => Ok(Arc::new(process::Process::Do {
-                span: span.clone(),
-                name: LocalName::match_(level),
-                usage: VariableUsage::Unknown,
-                typ: (),
-                command: process::Command::ReceiveType(
-                    parameter.clone(),
-                    self.compile_pattern_helper(rest, level, process)?,
-                ),
-            })),
+            Pattern::ReceiveType(span, parameter, rest) => {
+                let then = self.compile_pattern_helper(rest, level, process)?;
+                Ok(process::Process::do_step(
+                    span.clone(),
+                    LocalName::match_(level),
+                    VariableUsage::Unknown,
+                    (),
+                    process::Command::ReceiveType(parameter.clone()),
+                    then,
+                ))
+            }
 
             Pattern::Try(span, label, rest) => {
                 let catch_block = self.use_catch(span, label)?;
                 let catch_block = if let Some(original) = &self.original_object_name {
-                    Arc::new(process::Process::Let {
-                        span: original.span.clone(),
-                        name: original.clone(),
-                        annotation: None,
-                        typ: (),
-                        value: Arc::new(process::Expression::Variable(
+                    process::Process::let_step(
+                        original.span.clone(),
+                        original.clone(),
+                        None,
+                        (),
+                        Arc::new(process::Expression::Variable(
                             original.span.clone(),
                             LocalName::subject(),
                             (),
                             VariableUsage::Unknown,
                         )),
-                        then: catch_block,
-                    })
+                        catch_block,
+                    )
                 } else {
                     catch_block
                 };
@@ -1696,49 +1713,45 @@ impl Context {
             }
 
             Expression::List(span, items) => {
-                let mut process = Arc::new(process::Process::Do {
-                    span: span.clone(),
-                    name: LocalName::result(),
-                    usage: VariableUsage::Unknown,
-                    typ: (),
-                    command: process::Command::Signal(
-                        LocalName {
-                            span: span.clone(),
-                            string: literal!("end"),
-                        },
-                        Arc::new(process::Process::Do {
-                            span: span.clone(),
-                            name: LocalName::result(),
-                            usage: VariableUsage::Unknown,
-                            typ: (),
-                            command: process::Command::Break,
-                        }),
-                    ),
-                });
+                let mut process = process::Process::do_terminal(
+                    span.clone(),
+                    LocalName::result(),
+                    VariableUsage::Unknown,
+                    (),
+                    process::TerminalCommand::Break,
+                );
+                process = process::Process::do_step(
+                    span.clone(),
+                    LocalName::result(),
+                    VariableUsage::Unknown,
+                    (),
+                    process::Command::Signal(LocalName {
+                        span: span.clone(),
+                        string: literal!("end"),
+                    }),
+                    process,
+                );
                 for item in items.iter().rev() {
                     let span = item.span();
-                    process = Arc::new(process::Process::Do {
-                        span: span.clone(),
-                        name: LocalName::result(),
-                        usage: VariableUsage::Unknown,
-                        typ: (),
-                        command: process::Command::Signal(
-                            LocalName {
-                                span: span.clone(),
-                                string: literal!("item"),
-                            },
-                            Arc::new(process::Process::Do {
-                                span,
-                                name: LocalName::result(),
-                                usage: VariableUsage::Unknown,
-                                typ: (),
-                                command: process::Command::Send(
-                                    self.compile_expression(item)?,
-                                    process,
-                                ),
-                            }),
-                        ),
-                    });
+                    process = process::Process::do_step(
+                        span.clone(),
+                        LocalName::result(),
+                        VariableUsage::Unknown,
+                        (),
+                        process::Command::Send(self.compile_expression(item)?),
+                        process,
+                    );
+                    process = process::Process::do_step(
+                        span.clone(),
+                        LocalName::result(),
+                        VariableUsage::Unknown,
+                        (),
+                        process::Command::Signal(LocalName {
+                            span,
+                            string: literal!("item"),
+                        }),
+                        process,
+                    );
                 }
                 Arc::new(process::Expression::Chan {
                     span: span.clone(),
@@ -1848,44 +1861,28 @@ impl Context {
             }
 
             Expression::Condition(span, condition) => {
-                let true_process = Arc::new(process::Process::Do {
-                    span: span.clone(),
-                    name: LocalName::result(),
-                    usage: VariableUsage::Unknown,
-                    typ: (),
-                    command: process::Command::Signal(
-                        LocalName {
+                let make_bool = |variant| {
+                    let end = process::Process::do_terminal(
+                        span.clone(),
+                        LocalName::result(),
+                        VariableUsage::Unknown,
+                        (),
+                        process::TerminalCommand::Break,
+                    );
+                    process::Process::do_step(
+                        span.clone(),
+                        LocalName::result(),
+                        VariableUsage::Unknown,
+                        (),
+                        process::Command::Signal(LocalName {
                             span: span.clone(),
-                            string: literal!("true"),
-                        },
-                        Arc::new(process::Process::Do {
-                            span: span.clone(),
-                            name: LocalName::result(),
-                            usage: VariableUsage::Unknown,
-                            typ: (),
-                            command: process::Command::Break,
+                            string: ArcStr::from(variant),
                         }),
-                    ),
-                });
-                let false_process = Arc::new(process::Process::Do {
-                    span: span.clone(),
-                    name: LocalName::result(),
-                    usage: VariableUsage::Unknown,
-                    typ: (),
-                    command: process::Command::Signal(
-                        LocalName {
-                            span: span.clone(),
-                            string: literal!("false"),
-                        },
-                        Arc::new(process::Process::Do {
-                            span: span.clone(),
-                            name: LocalName::result(),
-                            usage: VariableUsage::Unknown,
-                            typ: (),
-                            command: process::Command::Break,
-                        }),
-                    ),
-                });
+                        end,
+                    )
+                };
+                let true_process = make_bool("true");
+                let false_process = make_bool("false");
                 let process = self.compile_condition_process(
                     condition.as_ref(),
                     true_process,
@@ -1940,18 +1937,18 @@ impl Context {
                     chan_annotation: None,
                     chan_type: (),
                     expr_type: (),
-                    process: Arc::new(process::Process::Let {
-                        span: span.clone(),
-                        name: LocalName::object(),
-                        annotation: Some(typ.clone()),
-                        typ: (),
-                        value: expression,
-                        then: Arc::new(process::Process::Do {
-                            span: span.clone(),
-                            name: LocalName::result(),
-                            usage: VariableUsage::Unknown,
-                            typ: (),
-                            command: process::Command::Link(Arc::new(
+                    process: process::Process::let_step(
+                        span.clone(),
+                        LocalName::object(),
+                        Some(typ.clone()),
+                        (),
+                        expression,
+                        process::Process::do_terminal(
+                            span.clone(),
+                            LocalName::result(),
+                            VariableUsage::Unknown,
+                            (),
+                            process::TerminalCommand::Link(Arc::new(
                                 process::Expression::Variable(
                                     span.clone(),
                                     LocalName::object(),
@@ -1959,8 +1956,8 @@ impl Context {
                                     VariableUsage::Unknown,
                                 ),
                             )),
-                        }),
-                    }),
+                        ),
+                    ),
                 })
             }
 
@@ -1995,13 +1992,13 @@ impl Context {
                         pattern,
                         span,
                         expression,
-                        Arc::new(process::Process::Do {
-                            span: span.clone(),
-                            name: LocalName::result(),
-                            usage: VariableUsage::Unknown,
-                            typ: (),
-                            command: process::Command::Link(body),
-                        }),
+                        process::Process::do_terminal(
+                            span.clone(),
+                            LocalName::result(),
+                            VariableUsage::Unknown,
+                            (),
+                            process::TerminalCommand::Link(body),
+                        ),
                     )?,
                 })
             }
@@ -2013,13 +2010,13 @@ impl Context {
                 block,
                 then,
             } => {
-                let block = Arc::new(process::Process::Do {
-                    span: span.clone(),
-                    name: LocalName::result(),
-                    usage: VariableUsage::Unknown,
-                    typ: (),
-                    command: process::Command::Link(self.compile_expression(block)?),
-                });
+                let block = process::Process::do_terminal(
+                    span.clone(),
+                    LocalName::result(),
+                    VariableUsage::Unknown,
+                    (),
+                    process::TerminalCommand::Link(self.compile_expression(block)?),
+                );
                 let block = self.compile_pattern_catch_block(pattern, span, block)?;
                 self.expr_with_catch(span, label.clone(), block, |pass| {
                     pass.compile_expression(then)
@@ -2036,14 +2033,14 @@ impl Context {
                         chan_annotation: None,
                         chan_type: (),
                         expr_type: (),
-                        process: Arc::new(process::Process::Let {
-                            span: span.clone(),
-                            name: LocalName::error(),
-                            annotation: None,
-                            typ: (),
-                            value: pass.compile_expression(expression)?,
-                            then: catch_block,
-                        }),
+                        process: process::Process::let_step(
+                            span.clone(),
+                            LocalName::error(),
+                            None,
+                            (),
+                            pass.compile_expression(expression)?,
+                            catch_block,
+                        ),
                     }))
                 })?
             }
@@ -2055,7 +2052,9 @@ impl Context {
             } => {
                 let else_proc = match else_ {
                     Some(expr) => self.compile_process(&link_process_from_expr(expr))?,
-                    None => Arc::new(process::Process::Unreachable(span.clone())),
+                    None => {
+                        process::Process::terminal(process::Terminator::Unreachable(span.clone()))
+                    }
                 };
                 let compiled = self.compile_if_branches(branches, else_proc, |body, pass| {
                     pass.compile_process(&link_process_from_expr(body))
@@ -2079,13 +2078,13 @@ impl Context {
                 let expression = self.compile_expression(expression)?;
                 self.expr_with_fallthrough(
                     span,
-                    Arc::new(process::Process::Do {
-                        span: span.clone(),
-                        name: LocalName::result(),
-                        usage: VariableUsage::Unknown,
-                        typ: (),
-                        command: process::Command::Link(expression),
-                    }),
+                    process::Process::do_terminal(
+                        span.clone(),
+                        LocalName::result(),
+                        VariableUsage::Unknown,
+                        (),
+                        process::TerminalCommand::Link(expression),
+                    ),
                     |pass| {
                         Ok(Arc::new(process::Expression::Chan {
                             span: span.clone(),
@@ -2138,14 +2137,14 @@ impl Context {
                     chan_annotation: None,
                     chan_type: (),
                     expr_type: (),
-                    process: Arc::new(process::Process::Let {
-                        span: span.clone(),
-                        name: LocalName::object(),
-                        annotation: None,
-                        typ: (),
-                        value: expr,
-                        then: process,
-                    }),
+                    process: process::Process::let_step(
+                        span.clone(),
+                        LocalName::object(),
+                        None,
+                        (),
+                        expr,
+                        process,
+                    ),
                 })
             }
         });
@@ -2164,25 +2163,26 @@ impl Context {
         Ok(match construct {
             Construct::Then(expression) => {
                 let expression = self.compile_expression(expression)?;
-                Arc::new(process::Process::Do {
-                    span: Span::None,
-                    name: LocalName::result(),
-                    usage: VariableUsage::Unknown,
-                    typ: (),
-                    command: process::Command::Link(expression),
-                })
+                process::Process::do_terminal(
+                    Span::None,
+                    LocalName::result(),
+                    VariableUsage::Unknown,
+                    (),
+                    process::TerminalCommand::Link(expression),
+                )
             }
 
             Construct::Send(span, argument, construct) => {
                 let argument = self.compile_expression(argument)?;
                 let process = self.compile_construct(construct)?;
-                Arc::new(process::Process::Do {
-                    span: span.clone(),
-                    name: LocalName::result(),
-                    usage: VariableUsage::Unknown,
-                    typ: (),
-                    command: process::Command::Send(argument, process),
-                })
+                process::Process::do_step(
+                    span.clone(),
+                    LocalName::result(),
+                    VariableUsage::Unknown,
+                    (),
+                    process::Command::Send(argument),
+                    process,
+                )
             }
 
             Construct::Receive(span, pattern, construct, vars) => {
@@ -2199,13 +2199,14 @@ impl Context {
 
             Construct::Signal(span, chosen, construct) => {
                 let process = self.compile_construct(construct)?;
-                Arc::new(process::Process::Do {
-                    span: span.clone(),
-                    name: LocalName::result(),
-                    usage: VariableUsage::Unknown,
-                    typ: (),
-                    command: process::Command::Signal(chosen.clone(), process),
-                })
+                process::Process::do_step(
+                    span.clone(),
+                    LocalName::result(),
+                    VariableUsage::Unknown,
+                    (),
+                    process::Command::Signal(chosen.clone()),
+                    process,
+                )
             }
 
             Construct::Case(span, ConstructBranches(construct_branches), else_branch) => {
@@ -2221,22 +2222,22 @@ impl Context {
                 };
                 let branches = Arc::from(branches);
                 let processes = Box::from(processes);
-                Arc::new(process::Process::Do {
-                    span: span.clone(),
-                    name: LocalName::result(),
-                    usage: VariableUsage::Unknown,
-                    typ: (),
-                    command: process::Command::Case(branches, processes, else_process),
-                })
+                process::Process::do_terminal(
+                    span.clone(),
+                    LocalName::result(),
+                    VariableUsage::Unknown,
+                    (),
+                    process::TerminalCommand::Case(branches, processes, else_process),
+                )
             }
 
-            Construct::Break(span) => Arc::new(process::Process::Do {
-                span: span.clone(),
-                name: LocalName::result(),
-                usage: VariableUsage::Unknown,
-                typ: (),
-                command: process::Command::Break,
-            }),
+            Construct::Break(span) => process::Process::do_terminal(
+                span.clone(),
+                LocalName::result(),
+                VariableUsage::Unknown,
+                (),
+                process::TerminalCommand::Break,
+            ),
 
             Construct::Begin {
                 span,
@@ -2245,52 +2246,54 @@ impl Context {
                 then: construct,
             } => {
                 let process = self.compile_construct(construct)?;
-                Arc::new(process::Process::Do {
-                    span: span.clone(),
-                    name: LocalName::result(),
-                    usage: VariableUsage::Unknown,
-                    typ: (),
-                    command: process::Command::Begin {
+                process::Process::do_terminal(
+                    span.clone(),
+                    LocalName::result(),
+                    VariableUsage::Unknown,
+                    (),
+                    process::TerminalCommand::Begin {
                         unfounded: *unfounded,
                         label: label.clone(),
                         captures: Captures::new(),
                         body: process,
                     },
-                })
+                )
             }
 
-            Construct::Loop(span, label) => Arc::new(process::Process::Do {
-                span: span.clone(),
-                name: LocalName::result(),
-                usage: VariableUsage::Unknown,
-                typ: (),
-                command: process::Command::Loop(
+            Construct::Loop(span, label) => process::Process::do_terminal(
+                span.clone(),
+                LocalName::result(),
+                VariableUsage::Unknown,
+                (),
+                process::TerminalCommand::Loop(
                     label.clone(),
                     LocalName::invalid(),
                     Captures::new(),
                 ),
-            }),
+            ),
 
             Construct::SendType(span, argument, construct) => {
                 let process = self.compile_construct(construct)?;
-                Arc::new(process::Process::Do {
-                    span: span.clone(),
-                    name: LocalName::result(),
-                    usage: VariableUsage::Unknown,
-                    typ: (),
-                    command: process::Command::SendType(argument.clone(), process),
-                })
+                process::Process::do_step(
+                    span.clone(),
+                    LocalName::result(),
+                    VariableUsage::Unknown,
+                    (),
+                    process::Command::SendType(argument.clone()),
+                    process,
+                )
             }
 
             Construct::ReceiveType(span, parameter, construct) => {
                 let process = self.compile_construct(construct)?;
-                Arc::new(process::Process::Do {
-                    span: span.clone(),
-                    name: LocalName::result(),
-                    usage: VariableUsage::Unknown,
-                    typ: (),
-                    command: process::Command::ReceiveType(parameter.clone(), process),
-                })
+                process::Process::do_step(
+                    span.clone(),
+                    LocalName::result(),
+                    VariableUsage::Unknown,
+                    (),
+                    process::Command::ReceiveType(parameter.clone()),
+                    process,
+                )
             }
         })
     }
@@ -2302,13 +2305,13 @@ impl Context {
         Ok(match branch {
             ConstructBranch::Then(_, expression) => {
                 let expression = self.compile_expression(expression)?;
-                Arc::new(process::Process::Do {
-                    span: Span::None,
-                    name: LocalName::result(),
-                    usage: VariableUsage::Unknown,
-                    typ: (),
-                    command: process::Command::Link(expression),
-                })
+                process::Process::do_terminal(
+                    Span::None,
+                    LocalName::result(),
+                    VariableUsage::Unknown,
+                    (),
+                    process::TerminalCommand::Link(expression),
+                )
             }
 
             ConstructBranch::Receive(span, pattern, branch, vars) => {
@@ -2325,13 +2328,14 @@ impl Context {
 
             ConstructBranch::ReceiveType(span, parameter, branch) => {
                 let process = self.compile_construct_branch(branch)?;
-                Arc::new(process::Process::Do {
-                    span: span.clone(),
-                    name: LocalName::result(),
-                    usage: VariableUsage::Unknown,
-                    typ: (),
-                    command: process::Command::ReceiveType(parameter.clone(), process),
-                })
+                process::Process::do_step(
+                    span.clone(),
+                    LocalName::result(),
+                    VariableUsage::Unknown,
+                    (),
+                    process::Command::ReceiveType(parameter.clone()),
+                    process,
+                )
             }
         })
     }
@@ -2341,40 +2345,42 @@ impl Context {
         apply: &Apply<Unresolved>,
     ) -> Result<Arc<process::Process<(), Unresolved>>, CompileError> {
         Ok(match apply {
-            Apply::Noop(span) => Arc::new(process::Process::Do {
-                span: span.clone(),
-                name: LocalName::result(),
-                usage: VariableUsage::Unknown,
-                typ: (),
-                command: process::Command::Link(Arc::new(process::Expression::Variable(
+            Apply::Noop(span) => process::Process::do_terminal(
+                span.clone(),
+                LocalName::result(),
+                VariableUsage::Unknown,
+                (),
+                process::TerminalCommand::Link(Arc::new(process::Expression::Variable(
                     span.clone(),
                     LocalName::object(),
                     (),
                     VariableUsage::Unknown,
                 ))),
-            }),
+            ),
 
             Apply::Send(span, expression, apply) => {
                 let expression = self.compile_expression(expression)?;
                 let process = self.compile_apply(apply)?;
-                Arc::new(process::Process::Do {
-                    span: span.clone(),
-                    name: LocalName::object(),
-                    usage: VariableUsage::Unknown,
-                    typ: (),
-                    command: process::Command::Send(expression, process),
-                })
+                process::Process::do_step(
+                    span.clone(),
+                    LocalName::object(),
+                    VariableUsage::Unknown,
+                    (),
+                    process::Command::Send(expression),
+                    process,
+                )
             }
 
             Apply::Signal(span, chosen, apply) => {
                 let process = self.compile_apply(apply)?;
-                Arc::new(process::Process::Do {
-                    span: span.clone(),
-                    name: LocalName::object(),
-                    usage: VariableUsage::Unknown,
-                    typ: (),
-                    command: process::Command::Signal(chosen.clone(), process),
-                })
+                process::Process::do_step(
+                    span.clone(),
+                    LocalName::object(),
+                    VariableUsage::Unknown,
+                    (),
+                    process::Command::Signal(chosen.clone()),
+                    process,
+                )
             }
 
             Apply::Case(span, ApplyBranches(expression_branches), else_branch) => {
@@ -2390,13 +2396,13 @@ impl Context {
                 };
                 let branches = Arc::from(branches);
                 let processes = Box::from(processes);
-                Arc::new(process::Process::Do {
-                    span: span.clone(),
-                    name: LocalName::object(),
-                    usage: VariableUsage::Unknown,
-                    typ: (),
-                    command: process::Command::Case(branches, processes, else_process),
-                })
+                process::Process::do_terminal(
+                    span.clone(),
+                    LocalName::object(),
+                    VariableUsage::Unknown,
+                    (),
+                    process::TerminalCommand::Case(branches, processes, else_process),
+                )
             }
 
             Apply::Begin {
@@ -2406,41 +2412,42 @@ impl Context {
                 then: apply,
             } => {
                 let process = self.compile_apply(apply)?;
-                Arc::new(process::Process::Do {
-                    span: span.clone(),
-                    name: LocalName::object(),
-                    usage: VariableUsage::Unknown,
-                    typ: (),
-                    command: process::Command::Begin {
+                process::Process::do_terminal(
+                    span.clone(),
+                    LocalName::object(),
+                    VariableUsage::Unknown,
+                    (),
+                    process::TerminalCommand::Begin {
                         unfounded: *unfounded,
                         label: label.clone(),
                         captures: Captures::new(),
                         body: process,
                     },
-                })
+                )
             }
 
-            Apply::Loop(span, label) => Arc::new(process::Process::Do {
-                span: span.clone(),
-                name: LocalName::object(),
-                usage: VariableUsage::Unknown,
-                typ: (),
-                command: process::Command::Loop(
+            Apply::Loop(span, label) => process::Process::do_terminal(
+                span.clone(),
+                LocalName::object(),
+                VariableUsage::Unknown,
+                (),
+                process::TerminalCommand::Loop(
                     label.clone(),
                     LocalName::invalid(),
                     Captures::new(),
                 ),
-            }),
+            ),
 
             Apply::SendType(span, argument, apply) => {
                 let process = self.compile_apply(apply)?;
-                Arc::new(process::Process::Do {
-                    span: span.clone(),
-                    name: LocalName::object(),
-                    usage: VariableUsage::Unknown,
-                    typ: (),
-                    command: process::Command::SendType(argument.clone(), process),
-                })
+                process::Process::do_step(
+                    span.clone(),
+                    LocalName::object(),
+                    VariableUsage::Unknown,
+                    (),
+                    process::Command::SendType(argument.clone()),
+                    process,
+                )
             }
 
             Apply::Default(span, expr, apply) => {
@@ -2470,25 +2477,25 @@ impl Context {
         Ok(match branch {
             ApplyBranch::Then(span, name, expression) => {
                 let expression = self.compile_expression(expression)?;
-                Arc::new(process::Process::Let {
-                    span: span.clone(),
-                    name: name.clone(),
-                    annotation: None,
-                    typ: (),
-                    value: Arc::new(process::Expression::Variable(
+                process::Process::let_step(
+                    span.clone(),
+                    name.clone(),
+                    None,
+                    (),
+                    Arc::new(process::Expression::Variable(
                         span.clone(),
                         LocalName::object(),
                         (),
                         VariableUsage::Unknown,
                     )),
-                    then: Arc::new(process::Process::Do {
-                        span: span.clone(),
-                        name: LocalName::result(),
-                        usage: VariableUsage::Unknown,
-                        typ: (),
-                        command: process::Command::Link(expression),
-                    }),
-                })
+                    process::Process::do_terminal(
+                        span.clone(),
+                        LocalName::result(),
+                        VariableUsage::Unknown,
+                        (),
+                        process::TerminalCommand::Link(expression),
+                    ),
+                )
             }
 
             ApplyBranch::Receive(span, pattern, branch, vars) => {
@@ -2505,30 +2512,32 @@ impl Context {
 
             ApplyBranch::Continue(span, expression) => {
                 let expression = self.compile_expression(expression)?;
-                Arc::new(process::Process::Do {
-                    span: span.clone(),
-                    name: LocalName::object(),
-                    usage: VariableUsage::Unknown,
-                    typ: (),
-                    command: process::Command::Continue(Arc::new(process::Process::Do {
-                        span: span.clone(),
-                        name: LocalName::result(),
-                        usage: VariableUsage::Unknown,
-                        typ: (),
-                        command: process::Command::Link(expression),
-                    })),
-                })
+                process::Process::do_step(
+                    span.clone(),
+                    LocalName::object(),
+                    VariableUsage::Unknown,
+                    (),
+                    process::Command::Continue,
+                    process::Process::do_terminal(
+                        span.clone(),
+                        LocalName::result(),
+                        VariableUsage::Unknown,
+                        (),
+                        process::TerminalCommand::Link(expression),
+                    ),
+                )
             }
 
             ApplyBranch::ReceiveType(span, parameter, branch) => {
                 let process = self.compile_apply_branch(branch)?;
-                Arc::new(process::Process::Do {
-                    span: span.clone(),
-                    name: LocalName::object(),
-                    usage: VariableUsage::Unknown,
-                    typ: (),
-                    command: process::Command::ReceiveType(parameter.clone(), process),
-                })
+                process::Process::do_step(
+                    span.clone(),
+                    LocalName::object(),
+                    VariableUsage::Unknown,
+                    (),
+                    process::Command::ReceiveType(parameter.clone()),
+                    process,
+                )
             }
 
             ApplyBranch::Try(span, label, branch) => {
@@ -2561,7 +2570,9 @@ impl Context {
                     self.with_fallthrough(tail, |pass| {
                         let else_proc = match else_ {
                             Some(proc) => pass.compile_process(proc)?,
-                            None => Arc::new(process::Process::Unreachable(span.clone())),
+                            None => process::Process::terminal(process::Terminator::Unreachable(
+                                span.clone(),
+                            )),
                         };
                         pass.compile_if_branches(branches, else_proc, |body, pass| {
                             pass.compile_process(body)
@@ -2570,7 +2581,9 @@ impl Context {
                 } else {
                     let else_proc = match else_ {
                         Some(proc) => self.compile_process(proc)?,
-                        None => Arc::new(process::Process::Unreachable(span.clone())),
+                        None => process::Process::terminal(process::Terminator::Unreachable(
+                            span.clone(),
+                        )),
                     };
                     self.compile_if_branches(branches, else_proc, |body, pass| {
                         pass.compile_process(body)
@@ -2673,14 +2686,14 @@ impl Context {
                     pass.enable_catches();
                     expression
                 })?;
-                Arc::new(process::Process::Let {
-                    span: span.clone(),
-                    name: LocalName::error(),
-                    annotation: None,
-                    typ: (),
-                    value: expression,
-                    then: catch_block,
-                })
+                process::Process::let_step(
+                    span.clone(),
+                    LocalName::error(),
+                    None,
+                    (),
+                    expression,
+                    catch_block,
+                )
             }
 
             Process::GlobalCommand(_, global_name, command) => {
@@ -2689,23 +2702,24 @@ impl Context {
                     span: span.clone(),
                     string: ArcStr::from(global_name.to_string()),
                 };
-                Arc::new(process::Process::Let {
-                    span: span.clone(),
-                    name: local_name.clone(),
-                    annotation: None,
-                    typ: (),
-                    value: Arc::new(process::Expression::Global(span, global_name.clone(), ())),
-                    then: self.compile_command(command, &local_name)?,
-                })
+                process::Process::let_step(
+                    span.clone(),
+                    local_name.clone(),
+                    None,
+                    (),
+                    Arc::new(process::Expression::Global(span, global_name.clone(), ())),
+                    self.compile_command(command, &local_name)?,
+                )
             }
 
-            Process::Command(_, name, Command::Then(next)) => Arc::new(process::Process::Do {
-                span: name.span.clone(),
-                name: name.clone(),
-                usage: VariableUsage::Unknown,
-                typ: (),
-                command: process::Command::Noop(self.compile_process(next)?),
-            }),
+            Process::Command(_, name, Command::Then(next)) => process::Process::do_step(
+                name.span.clone(),
+                name.clone(),
+                VariableUsage::Unknown,
+                (),
+                process::Command::Noop,
+                self.compile_process(next)?,
+            ),
 
             Process::Command(_, name, command) => {
                 let None = self.original_object_name else {
@@ -2725,19 +2739,19 @@ impl Context {
                         self.original_object_name.clone().unwrap().string
                     )
                 };
-                Arc::new(process::Process::Let {
-                    span: name.span.clone(),
-                    name: LocalName::subject(),
-                    annotation: None,
-                    typ: (),
-                    value: Arc::new(process::Expression::Variable(
+                process::Process::let_step(
+                    name.span.clone(),
+                    LocalName::subject(),
+                    None,
+                    (),
+                    Arc::new(process::Expression::Variable(
                         name.span.clone(),
                         name.clone(),
                         (),
                         VariableUsage::Unknown,
                     )),
-                    then: then_process,
-                })
+                    then_process,
+                )
             }
 
             Process::Fallthrough(span) => match self.use_fallthrough(span) {
@@ -2748,6 +2762,160 @@ impl Context {
     }
 
     pub(crate) fn compile_command(
+        &mut self,
+        command: &Command<Unresolved>,
+        object_name: &LocalName,
+    ) -> Result<Arc<process::Process<(), Unresolved>>, CompileError> {
+        let mut frames = Vec::new();
+        let mut command = command;
+
+        let mut process = loop {
+            match command {
+                Command::Send(span, argument, then) => {
+                    self.disable_catches(CatchDisabledReason::DifferentProcess);
+                    let argument = self.compile_expression(argument)?;
+                    self.enable_catches();
+                    frames.push(CommandLoweringFrame::Step(process::Step::Do {
+                        span: span.clone(),
+                        name: object_name.clone(),
+                        usage: VariableUsage::Unknown,
+                        typ: (),
+                        command: process::Command::Send(argument),
+                    }));
+                    command = then;
+                }
+                Command::Receive(span, pattern, then, vars) => {
+                    frames.push(CommandLoweringFrame::Receive {
+                        span: span.clone(),
+                        pattern: pattern.clone(),
+                        vars: vars.clone(),
+                        original_object_name: self.original_object_name.clone(),
+                    });
+                    command = then;
+                }
+                Command::Signal(span, chosen, then) => {
+                    frames.push(CommandLoweringFrame::Step(process::Step::Do {
+                        span: span.clone(),
+                        name: object_name.clone(),
+                        usage: VariableUsage::Unknown,
+                        typ: (),
+                        command: process::Command::Signal(chosen.clone()),
+                    }));
+                    command = then;
+                }
+                Command::SendType(span, argument, then) => {
+                    frames.push(CommandLoweringFrame::Step(process::Step::Do {
+                        span: span.clone(),
+                        name: object_name.clone(),
+                        usage: VariableUsage::Unknown,
+                        typ: (),
+                        command: process::Command::SendType(argument.clone()),
+                    }));
+                    command = then;
+                }
+                Command::ReceiveType(span, parameter, then) => {
+                    frames.push(CommandLoweringFrame::Step(process::Step::Do {
+                        span: span.clone(),
+                        name: object_name.clone(),
+                        usage: VariableUsage::Unknown,
+                        typ: (),
+                        command: process::Command::ReceiveType(parameter.clone()),
+                    }));
+                    command = then;
+                }
+                Command::Try(span, label, then) => {
+                    frames.push(CommandLoweringFrame::Try {
+                        span: span.clone(),
+                        catch_block: self.use_catch(span, label)?,
+                    });
+                    command = then;
+                }
+                Command::Default(span, expression, then) => {
+                    frames.push(CommandLoweringFrame::Default {
+                        span: span.clone(),
+                        expression: self.compile_expression(expression)?,
+                    });
+                    command = then;
+                }
+                Command::Pipe(span, function, then) => {
+                    self.disable_catches(CatchDisabledReason::DifferentProcess);
+                    let function = self.compile_expression(function)?;
+                    self.enable_catches();
+                    frames.push(CommandLoweringFrame::Pipe {
+                        span: span.clone(),
+                        function,
+                    });
+                    command = then;
+                }
+                Command::Then(_)
+                | Command::Link(..)
+                | Command::Case(..)
+                | Command::Break(_)
+                | Command::Continue(..)
+                | Command::Begin { .. }
+                | Command::Loop(..) => {
+                    break self.compile_command_terminal(command, object_name)?;
+                }
+            }
+        };
+
+        let flush_steps =
+            |steps: &mut Vec<process::Step<(), Unresolved>>,
+             process: Arc<process::Process<(), Unresolved>>| {
+                if steps.is_empty() {
+                    return process;
+                }
+                steps.reverse();
+                let mut builder = process::ProcessBuilder::new();
+                for step in steps.drain(..) {
+                    builder.push(step);
+                }
+                builder.finish_with(process)
+            };
+
+        let mut steps = Vec::new();
+        for frame in frames.into_iter().rev() {
+            match frame {
+                CommandLoweringFrame::Step(step) => steps.push(step),
+                CommandLoweringFrame::Receive {
+                    span,
+                    pattern,
+                    vars,
+                    original_object_name,
+                } => {
+                    process = flush_steps(&mut steps, process);
+                    let None = self.original_object_name else {
+                        unreachable!("original_object_name should be none after command")
+                    };
+                    self.original_object_name = original_object_name;
+                    process = self.compile_pattern_receive(
+                        &pattern,
+                        0,
+                        &span,
+                        object_name,
+                        process,
+                        vars,
+                    )?;
+                    self.original_object_name = None;
+                }
+                CommandLoweringFrame::Try { span, catch_block } => {
+                    process = flush_steps(&mut steps, process);
+                    process = self.compile_try(&span, object_name.clone(), catch_block, process);
+                }
+                CommandLoweringFrame::Default { span, expression } => {
+                    process = flush_steps(&mut steps, process);
+                    process = self.compile_default(&span, object_name.clone(), expression, process);
+                }
+                CommandLoweringFrame::Pipe { span, function } => {
+                    process = flush_steps(&mut steps, process);
+                    process = self.compile_pipe(&span, object_name.clone(), function, process);
+                }
+            }
+        }
+        Ok(flush_steps(&mut steps, process))
+    }
+
+    fn compile_command_terminal(
         &mut self,
         command: &Command<Unresolved>,
         object_name: &LocalName,
@@ -2764,13 +2932,13 @@ impl Context {
                 let expression = self.compile_expression(expression)?;
                 self.enable_catches();
                 self.original_object_name = None;
-                Arc::new(process::Process::Do {
-                    span: span.clone(),
-                    name: object_name.clone(),
-                    usage: VariableUsage::Unknown,
-                    typ: (),
-                    command: process::Command::Link(expression),
-                })
+                process::Process::do_terminal(
+                    span.clone(),
+                    object_name.clone(),
+                    VariableUsage::Unknown,
+                    (),
+                    process::TerminalCommand::Link(expression),
+                )
             }
 
             Command::Send(span, argument, command) => {
@@ -2778,13 +2946,14 @@ impl Context {
                 let argument = self.compile_expression(argument)?;
                 self.enable_catches();
                 let process = self.compile_command(command, object_name)?;
-                Arc::new(process::Process::Do {
-                    span: span.clone(),
-                    name: object_name.clone(),
-                    usage: VariableUsage::Unknown,
-                    typ: (),
-                    command: process::Command::Send(argument, process),
-                })
+                process::Process::do_step(
+                    span.clone(),
+                    object_name.clone(),
+                    VariableUsage::Unknown,
+                    (),
+                    process::Command::Send(argument),
+                    process,
+                )
             }
 
             Command::Receive(span, pattern, command, vars) => {
@@ -2808,13 +2977,14 @@ impl Context {
 
             Command::Signal(span, chosen, command) => {
                 let process = self.compile_command(command, object_name)?;
-                Arc::new(process::Process::Do {
-                    span: span.clone(),
-                    name: object_name.clone(),
-                    usage: VariableUsage::Unknown,
-                    typ: (),
-                    command: process::Command::Signal(chosen.clone(), process),
-                })
+                process::Process::do_step(
+                    span.clone(),
+                    object_name.clone(),
+                    VariableUsage::Unknown,
+                    (),
+                    process::Command::Signal(chosen.clone()),
+                    process,
+                )
             }
 
             Command::Case(
@@ -2846,13 +3016,13 @@ impl Context {
                         };
                         let branches = Arc::from(branches);
                         let processes = Box::from(processes);
-                        Ok(Arc::new(process::Process::Do {
-                            span: span.clone(),
-                            name: object_name.clone(),
-                            usage: VariableUsage::Unknown,
-                            typ: (),
-                            command: process::Command::Case(branches, processes, else_process),
-                        }))
+                        Ok(process::Process::do_terminal(
+                            span.clone(),
+                            object_name.clone(),
+                            VariableUsage::Unknown,
+                            (),
+                            process::TerminalCommand::Case(branches, processes, else_process),
+                        ))
                     })?
                 } else {
                     for (branch_name, process_branch) in process_branches {
@@ -2865,38 +3035,39 @@ impl Context {
                     };
                     let branches = Arc::from(branches);
                     let processes = Box::from(processes);
-                    Arc::new(process::Process::Do {
-                        span: span.clone(),
-                        name: object_name.clone(),
-                        usage: VariableUsage::Unknown,
-                        typ: (),
-                        command: process::Command::Case(branches, processes, else_process),
-                    })
+                    process::Process::do_terminal(
+                        span.clone(),
+                        object_name.clone(),
+                        VariableUsage::Unknown,
+                        (),
+                        process::TerminalCommand::Case(branches, processes, else_process),
+                    )
                 };
                 self.restore_object_name(original, process)
             }
 
             Command::Break(span) => {
                 self.original_object_name = None;
-                Arc::new(process::Process::Do {
-                    span: span.clone(),
-                    name: object_name.clone(),
-                    usage: VariableUsage::Unknown,
-                    typ: (),
-                    command: process::Command::Break,
-                })
+                process::Process::do_terminal(
+                    span.clone(),
+                    object_name.clone(),
+                    VariableUsage::Unknown,
+                    (),
+                    process::TerminalCommand::Break,
+                )
             }
 
             Command::Continue(span, process) => {
                 self.original_object_name = None;
                 let process = self.compile_process(process)?;
-                Arc::new(process::Process::Do {
-                    span: span.clone(),
-                    name: object_name.clone(),
-                    usage: VariableUsage::Unknown,
-                    typ: (),
-                    command: process::Command::Continue(process),
-                })
+                process::Process::do_step(
+                    span.clone(),
+                    object_name.clone(),
+                    VariableUsage::Unknown,
+                    (),
+                    process::Command::Continue,
+                    process,
+                )
             }
 
             Command::Begin {
@@ -2906,55 +3077,57 @@ impl Context {
                 then: command,
             } => {
                 let process = self.compile_command(command, object_name)?;
-                Arc::new(process::Process::Do {
-                    span: span.clone(),
-                    name: object_name.clone(),
-                    usage: VariableUsage::Unknown,
-                    typ: (),
-                    command: process::Command::Begin {
+                process::Process::do_terminal(
+                    span.clone(),
+                    object_name.clone(),
+                    VariableUsage::Unknown,
+                    (),
+                    process::TerminalCommand::Begin {
                         unfounded: *unfounded,
                         label: label.clone(),
                         captures: Captures::new(),
                         body: process,
                     },
-                })
+                )
             }
 
             Command::Loop(span, label) => {
                 self.original_object_name = None;
-                Arc::new(process::Process::Do {
-                    span: span.clone(),
-                    name: object_name.clone(),
-                    usage: VariableUsage::Unknown,
-                    typ: (),
-                    command: process::Command::Loop(
+                process::Process::do_terminal(
+                    span.clone(),
+                    object_name.clone(),
+                    VariableUsage::Unknown,
+                    (),
+                    process::TerminalCommand::Loop(
                         label.clone(),
                         LocalName::invalid(),
                         Captures::new(),
                     ),
-                })
+                )
             }
 
             Command::SendType(span, argument, command) => {
                 let process = self.compile_command(command, object_name)?;
-                Arc::new(process::Process::Do {
-                    span: span.clone(),
-                    name: object_name.clone(),
-                    usage: VariableUsage::Unknown,
-                    typ: (),
-                    command: process::Command::SendType(argument.clone(), process),
-                })
+                process::Process::do_step(
+                    span.clone(),
+                    object_name.clone(),
+                    VariableUsage::Unknown,
+                    (),
+                    process::Command::SendType(argument.clone()),
+                    process,
+                )
             }
 
             Command::ReceiveType(span, parameter, command) => {
                 let process = self.compile_command(command, object_name)?;
-                Arc::new(process::Process::Do {
-                    span: span.clone(),
-                    name: object_name.clone(),
-                    usage: VariableUsage::Unknown,
-                    typ: (),
-                    command: process::Command::ReceiveType(parameter.clone(), process),
-                })
+                process::Process::do_step(
+                    span.clone(),
+                    object_name.clone(),
+                    VariableUsage::Unknown,
+                    (),
+                    process::Command::ReceiveType(parameter.clone()),
+                    process,
+                )
             }
 
             Command::Try(span, label, command) => {
@@ -2989,19 +3162,19 @@ impl Context {
 
             CommandBranch::BindThen(span, name, process) => {
                 let process = self.compile_process(process)?;
-                Arc::new(process::Process::Let {
-                    span: span.clone(),
-                    name: name.clone(),
-                    annotation: None,
-                    typ: (),
-                    value: Arc::new(process::Expression::Variable(
+                process::Process::let_step(
+                    span.clone(),
+                    name.clone(),
+                    None,
+                    (),
+                    Arc::new(process::Expression::Variable(
                         span.clone(),
                         object_name.clone(),
                         (),
                         VariableUsage::Unknown,
                     )),
-                    then: process,
-                })
+                    process,
+                )
             }
 
             CommandBranch::Receive(span, pattern, branch, vars) => {
@@ -3011,24 +3184,26 @@ impl Context {
 
             CommandBranch::Continue(span, process) => {
                 let process = self.compile_process(process)?;
-                Arc::new(process::Process::Do {
-                    span: span.clone(),
-                    name: object_name.clone(),
-                    usage: VariableUsage::Unknown,
-                    typ: (),
-                    command: process::Command::Continue(process),
-                })
+                process::Process::do_step(
+                    span.clone(),
+                    object_name.clone(),
+                    VariableUsage::Unknown,
+                    (),
+                    process::Command::Continue,
+                    process,
+                )
             }
 
             CommandBranch::ReceiveType(span, parameter, branch) => {
                 let process = self.compile_command_branch(branch, object_name)?;
-                Arc::new(process::Process::Do {
-                    span: span.clone(),
-                    name: object_name.clone(),
-                    usage: VariableUsage::Unknown,
-                    typ: (),
-                    command: process::Command::ReceiveType(parameter.clone(), process),
-                })
+                process::Process::do_step(
+                    span.clone(),
+                    object_name.clone(),
+                    VariableUsage::Unknown,
+                    (),
+                    process::Command::ReceiveType(parameter.clone()),
+                    process,
+                )
             }
 
             CommandBranch::Try(span, label, branch) => {
@@ -3051,35 +3226,35 @@ impl Context {
         catch_block: Arc<process::Process<(), Unresolved>>,
         ok_process: Arc<process::Process<(), Unresolved>>,
     ) -> Arc<process::Process<(), Unresolved>> {
-        Arc::new(process::Process::Do {
-            span: span.clone(),
-            name: variable.clone(),
-            usage: VariableUsage::Unknown,
-            typ: (),
-            command: process::Command::Case(
+        process::Process::do_terminal(
+            span.clone(),
+            variable.clone(),
+            VariableUsage::Unknown,
+            (),
+            process::TerminalCommand::Case(
                 Arc::from([
                     LocalName::from(literal!("err")),
                     LocalName::from(literal!("ok")),
                 ]),
                 Box::from([
-                    Arc::new(process::Process::Let {
-                        span: span.clone(),
-                        name: LocalName::error(),
-                        annotation: None,
-                        typ: (),
-                        value: Arc::new(process::Expression::Variable(
+                    process::Process::let_step(
+                        span.clone(),
+                        LocalName::error(),
+                        None,
+                        (),
+                        Arc::new(process::Expression::Variable(
                             span.clone(),
                             variable,
                             (),
                             VariableUsage::Unknown,
                         )),
-                        then: catch_block,
-                    }),
+                        catch_block,
+                    ),
                     ok_process,
                 ]),
                 None,
             ),
-        })
+        )
     }
 
     fn compile_default(
@@ -3090,30 +3265,30 @@ impl Context {
         ok_process: Arc<process::Process<(), Unresolved>>,
     ) -> Arc<process::Process<(), Unresolved>> {
         self.with_fallthrough(ok_process, |pass| {
-            Ok(Arc::new(process::Process::Do {
-                span: span.clone(),
-                name: variable.clone(),
-                usage: VariableUsage::Unknown,
-                typ: (),
-                command: process::Command::Case(
+            Ok(process::Process::do_terminal(
+                span.clone(),
+                variable.clone(),
+                VariableUsage::Unknown,
+                (),
+                process::TerminalCommand::Case(
                     Arc::from([
                         LocalName::from(literal!("none")),
                         LocalName::from(literal!("some")),
                     ]),
                     Box::from([
-                        Arc::new(process::Process::Let {
-                            span: span.clone(),
-                            name: variable.clone(),
-                            annotation: None,
-                            typ: (),
-                            value: default_expr,
-                            then: pass.use_fallthrough(span).unwrap(),
-                        }),
+                        process::Process::let_step(
+                            span.clone(),
+                            variable.clone(),
+                            None,
+                            (),
+                            default_expr,
+                            pass.use_fallthrough(span).unwrap(),
+                        ),
                         pass.use_fallthrough(span).unwrap(),
                     ]),
                     None,
                 ),
-            }))
+            ))
         })
         .unwrap()
     }
@@ -3125,40 +3300,38 @@ impl Context {
         function: Arc<process::Expression<(), Unresolved>>,
         then: Arc<process::Process<(), Unresolved>>,
     ) -> Arc<process::Process<(), Unresolved>> {
-        Arc::new(process::Process::Let {
-            span: span.clone(),
-            name: LocalName::temp(),
-            annotation: None,
-            typ: (),
-            value: function,
-            then: Arc::new(process::Process::Do {
-                span: span.clone(),
-                name: LocalName::temp(),
-                usage: VariableUsage::Unknown,
-                typ: (),
-                command: process::Command::Send(
+        process::Process::let_step(
+            span.clone(),
+            LocalName::temp(),
+            None,
+            (),
+            function,
+            process::Process::do_step(
+                span.clone(),
+                LocalName::temp(),
+                VariableUsage::Unknown,
+                (),
+                process::Command::Send(Arc::new(process::Expression::Variable(
+                    span.clone(),
+                    variable.clone(),
+                    (),
+                    VariableUsage::Unknown,
+                ))),
+                process::Process::let_step(
+                    span.clone(),
+                    variable,
+                    None,
+                    (),
                     Arc::new(process::Expression::Variable(
                         span.clone(),
-                        variable.clone(),
+                        LocalName::temp(),
                         (),
                         VariableUsage::Unknown,
                     )),
-                    Arc::new(process::Process::Let {
-                        span: span.clone(),
-                        name: variable,
-                        annotation: None,
-                        typ: (),
-                        value: Arc::new(process::Expression::Variable(
-                            span.clone(),
-                            LocalName::temp(),
-                            (),
-                            VariableUsage::Unknown,
-                        )),
-                        then,
-                    }),
+                    then,
                 ),
-            }),
-        })
+            ),
+        )
     }
 
     fn attach_pattern_to_process_compiled(
@@ -3190,14 +3363,14 @@ impl Context {
     ) -> Result<Arc<process::Process<(), Unresolved>>, CompileError> {
         restores.iter().rev().try_fold(tail, |acc, restore| {
             let value = self.compile_expression(&restore.value)?;
-            Ok(Arc::new(process::Process::Let {
-                span: restore.span.clone(),
-                name: restore.name.clone(),
-                annotation: None,
-                typ: (),
+            Ok(process::Process::let_step(
+                restore.span.clone(),
+                restore.name.clone(),
+                None,
+                (),
                 value,
-                then: acc,
-            }))
+                acc,
+            ))
         })
     }
 
@@ -3211,18 +3384,18 @@ impl Context {
             Condition::Bool(_, expr) => {
                 let temp = LocalName::temp();
                 let expr = self.compile_expression(expr)?;
-                Arc::new(process::Process::Let {
-                    span: Span::None,
-                    name: temp.clone(),
-                    annotation: None,
-                    typ: (),
-                    value: expr,
-                    then: Arc::new(process::Process::Do {
-                        span: Span::None,
-                        name: temp.clone(),
-                        usage: VariableUsage::Unknown,
-                        typ: (),
-                        command: process::Command::Case(
+                process::Process::let_step(
+                    Span::None,
+                    temp.clone(),
+                    None,
+                    (),
+                    expr,
+                    process::Process::do_terminal(
+                        Span::None,
+                        temp.clone(),
+                        VariableUsage::Unknown,
+                        (),
+                        process::TerminalCommand::Case(
                             Arc::from([
                                 LocalName::from(literal!("false")),
                                 LocalName::from(literal!("true")),
@@ -3230,8 +3403,8 @@ impl Context {
                             Box::from([failure, success]),
                             None,
                         ),
-                    }),
-                })
+                    ),
+                )
             }
             Condition::Is {
                 span,
@@ -3247,27 +3420,27 @@ impl Context {
                 let success_process =
                     self.attach_pattern_to_process_compiled(pattern, success, &subject_name)?;
 
-                let command_process = Arc::new(process::Process::Do {
-                    span: span.clone(),
-                    name: subject_name.clone(),
-                    usage: VariableUsage::Unknown,
-                    typ: (),
-                    command: process::Command::Case(
+                let command_process = process::Process::do_terminal(
+                    span.clone(),
+                    subject_name.clone(),
+                    VariableUsage::Unknown,
+                    (),
+                    process::TerminalCommand::Case(
                         Arc::from([variant.clone()]),
                         Box::from([success_process]),
                         Some(failure),
                     ),
-                });
+                );
 
                 match binding_value {
-                    Some(value) => Arc::new(process::Process::Let {
-                        span: span.clone(),
-                        name: subject_name.clone(),
-                        annotation: None,
-                        typ: (),
+                    Some(value) => process::Process::let_step(
+                        span.clone(),
+                        subject_name.clone(),
+                        None,
+                        (),
                         value,
-                        then: command_process,
-                    }),
+                        command_process,
+                    ),
                     None => command_process,
                 }
             }
@@ -3365,7 +3538,7 @@ impl Pass {
 
     fn use_at(&mut self, span: &Span) -> Arc<process::Process<(), Unresolved>> {
         self.used = true;
-        Arc::new(process::Process::Goto(
+        process::Process::terminal(process::Terminator::Goto(
             span.clone(),
             self.block_index,
             Captures::new(),
@@ -3655,4 +3828,38 @@ fn link_process_from_expr(expr: &Expression<Unresolved>) -> Process<Unresolved> 
         LocalName::result(),
         Command::Link(span, Box::new(expr.clone())),
     )
+}
+
+#[cfg(test)]
+mod flat_ir_tests {
+    use super::*;
+
+    #[test]
+    fn lowers_long_command_chain_without_recursive_ir_walk() {
+        const STEP_COUNT: usize = 20_000;
+        let subject = LocalName::from(literal!("subject"));
+        let chosen = LocalName::from(literal!("next"));
+        let mut command = Command::Break(Span::None);
+        for _ in 0..STEP_COUNT {
+            command = Command::Signal(Span::None, chosen.clone(), Box::new(command));
+        }
+
+        let mut context = Context::new();
+        let lowered = context.compile_command(&command, &subject).unwrap();
+        assert_eq!(lowered.steps.len(), STEP_COUNT);
+        assert!(matches!(
+            lowered.terminator,
+            process::Terminator::Do {
+                command: process::TerminalCommand::Break,
+                ..
+            }
+        ));
+
+        let (fixed, _) = lowered.fix_captures();
+        assert_eq!(fixed.steps.len(), STEP_COUNT);
+
+        // The source AST is intentionally recursive and outside this refactor's scope. Avoid a
+        // recursive destructor walk obscuring what this test is measuring.
+        std::mem::forget(command);
+    }
 }

--- a/crates/par-core/src/frontend_impl/parse.rs
+++ b/crates/par-core/src/frontend_impl/parse.rs
@@ -1,8 +1,12 @@
 use super::{
     language::{
-        Apply, ApplyBranch, ApplyBranches, ArithmeticOperator, Command, CommandBranch,
-        CommandBranches, ComparisonOperator, ComparisonStep, Condition, Construct, ConstructBranch,
-        ConstructBranches, Expression, GlobalName, Pattern, Process, TemplatePart, TypeConstraint,
+        Apply, ApplyBranch, ApplyBranchStep, ApplyBranchTerminator, ApplyBranches, ApplyStep,
+        ApplyTerminator, ArithmeticOperator, Command, CommandBranch, CommandBranchStep,
+        CommandBranchTerminator, CommandBranches, CommandStep, CommandTarget, CommandTerminator,
+        ComparisonOperator, ComparisonStep, Condition, Construct, ConstructBranch,
+        ConstructBranchStep, ConstructBranchTerminator, ConstructBranches, ConstructStep,
+        ConstructTerminator, Expression, GlobalName, Pattern, PatternStep, PatternTerminal,
+        Process, ProcessCommand, ProcessStep, ProcessTerminator, TemplatePart, TypeConstraint,
         TypeParameter, Unresolved,
     },
     lexer::{
@@ -1072,30 +1076,6 @@ fn fold_type_prefix<T>(
     })
 }
 
-fn fold_pattern_prefix<T>(
-    items: Vec<PatternPrefixItem>,
-    rest: T,
-    mut explicit: impl FnMut(TypeParameter, T) -> T,
-    mut value: impl FnMut(Pattern<Unresolved>, T) -> T,
-) -> T {
-    items.into_iter().rfold(rest, |rest, item| match item {
-        PatternPrefixItem::Explicit(name) => explicit(name, rest),
-        PatternPrefixItem::Value(pattern) => value(pattern, rest),
-    })
-}
-
-fn fold_send_prefix<T>(
-    items: Vec<SendPrefixItem>,
-    rest: T,
-    mut explicit: impl FnMut(Type<Unresolved>, T) -> T,
-    mut value: impl FnMut(Expression<Unresolved>, T) -> T,
-) -> T {
-    items.into_iter().rfold(rest, |rest, item| match item {
-        SendPrefixItem::Explicit(typ) => explicit(typ, rest),
-        SendPrefixItem::Value(expression) => value(expression, rest),
-    })
-}
-
 fn type_constraint(input: &mut Input) -> Result<TypeConstraint> {
     let checkpoint = input.checkpoint();
     if t::<Error>(TokenKind::Box).parse_next(input).is_ok() {
@@ -1341,50 +1321,69 @@ fn annotation(input: &mut Input) -> Result<Option<Type<Unresolved>>> {
 
 // pattern           = { pattern_name | pattern_receive | pattern_continue | pattern_recv_type }
 fn pattern(input: &mut Input) -> Result<Pattern<Unresolved>> {
-    alt((
-        pattern_name,
-        pattern_receive,
-        pattern_generic_receive,
-        pattern_continue,
-        pattern_default,
-        pattern_try,
-    ))
-    .parse_next(input)
+    let mut steps = Vec::new();
+    loop {
+        match alt((
+            pattern_name,
+            pattern_receive,
+            pattern_generic_receive,
+            pattern_continue,
+            pattern_default,
+            pattern_try,
+        ))
+        .parse_next(input)?
+        {
+            PatternPiece::Steps(mut parsed) => steps.append(&mut parsed),
+            PatternPiece::Terminal(terminal) => return Ok(Pattern { steps, terminal }),
+        }
+    }
 }
 
-fn pattern_name(input: &mut Input) -> Result<Pattern<Unresolved>> {
+enum PatternPiece {
+    Steps(Vec<PatternStep<Unresolved>>),
+    Terminal(PatternTerminal<Unresolved>),
+}
+
+fn pattern_name(input: &mut Input) -> Result<PatternPiece> {
     (local_name, annotation)
         .map(|(name, annotation)| {
-            Pattern::Name(
+            PatternPiece::Terminal(PatternTerminal::Name(
                 match &annotation {
                     Some(typ) => name.span.join(typ.span()),
                     None => name.span(),
                 },
                 name,
                 annotation,
-            )
+            ))
         })
         .parse_next(input)
 }
 
-fn pattern_receive(input: &mut Input) -> Result<Pattern<Unresolved>> {
+fn pattern_receive(input: &mut Input) -> Result<PatternPiece> {
     commit_after(
         t(TokenKind::LParen),
-        (list1(pattern_prefix_item), t(TokenKind::RParen), pattern),
+        (list1(pattern_prefix_item), t(TokenKind::RParen)),
     )
-    .map(|(open, (items, _close, rest))| {
-        let span = open.span.join(rest.span());
-        fold_pattern_prefix(
-            items,
-            rest,
-            |name, rest| Pattern::ReceiveType(span.clone(), name, Box::new(rest)),
-            |arg, rest| Pattern::Receive(span.clone(), Box::new(arg), Box::new(rest), vec![]),
+    .map(|(open, (items, close))| {
+        let span = open.span.join(close.span());
+        PatternPiece::Steps(
+            items
+                .into_iter()
+                .map(|item| match item {
+                    PatternPrefixItem::Explicit(name) => {
+                        PatternStep::ReceiveType(span.clone(), name)
+                    }
+                    PatternPrefixItem::Value(pattern) => {
+                        PatternStep::Receive(span.clone(), Box::new(pattern), vec![])
+                    }
+                })
+                .collect(),
         )
     })
     .parse_next(input)
 }
 
-fn pattern_generic_receive(input: &mut Input) -> Result<Pattern<Unresolved>> {
+fn pattern_generic_receive(input: &mut Input) -> Result<PatternPiece> {
     commit_after(
         t(TokenKind::Lt),
         (
@@ -1393,37 +1392,45 @@ fn pattern_generic_receive(input: &mut Input) -> Result<Pattern<Unresolved>> {
             t(TokenKind::LParen),
             pattern,
             t(TokenKind::RParen),
-            pattern,
         ),
     )
     .map(
-        |(vars_open, (vars, _vars_close, _pattern_open, arg, _pattern_close, rest))| {
-            let span = vars_open.span.join(rest.span());
-            Pattern::Receive(span.clone(), Box::new(arg), Box::new(rest), vars)
+        |(vars_open, (vars, _vars_close, _pattern_open, arg, pattern_close))| {
+            let span = vars_open.span.join(pattern_close.span());
+            PatternPiece::Steps(vec![PatternStep::Receive(span, Box::new(arg), vars)])
         },
     )
     .parse_next(input)
 }
 
-fn pattern_continue(input: &mut Input) -> Result<Pattern<Unresolved>> {
+fn pattern_continue(input: &mut Input) -> Result<PatternPiece> {
     t(TokenKind::Bang)
-        .map(|token| Pattern::Continue(token.span()))
+        .map(|token| PatternPiece::Terminal(PatternTerminal::Continue(token.span())))
         .parse_next(input)
 }
 
-fn pattern_try(input: &mut Input) -> Result<Pattern<Unresolved>> {
-    commit_after(t(TokenKind::Try), (label, pattern))
-        .map(|(pre, (label, rest))| Pattern::Try(pre.span.join(rest.span()), label, Box::new(rest)))
+fn pattern_try(input: &mut Input) -> Result<PatternPiece> {
+    commit_after(t(TokenKind::Try), label)
+        .map(|(pre, label)| {
+            let span = match &label {
+                Some(label) => pre.span.join(label.span()),
+                None => pre.span(),
+            };
+            PatternPiece::Steps(vec![PatternStep::Try(span, label)])
+        })
         .parse_next(input)
 }
 
-fn pattern_default(input: &mut Input) -> Result<Pattern<Unresolved>> {
+fn pattern_default(input: &mut Input) -> Result<PatternPiece> {
     commit_after(
         (t(TokenKind::Default), t(TokenKind::LParen)),
-        (expression, t(TokenKind::RParen), pattern),
+        (expression, t(TokenKind::RParen)),
     )
-    .map(|((pre, _), (expr, _close, rest))| {
-        Pattern::Default(pre.span.join(rest.span()), Box::new(expr), Box::new(rest))
+    .map(|((pre, _), (expr, close))| {
+        PatternPiece::Steps(vec![PatternStep::Default(
+            pre.span.join(close.span()),
+            Box::new(expr),
+        )])
     })
     .parse_next(input)
 }
@@ -1433,24 +1440,29 @@ fn condition(input: &mut Input) -> Result<Condition<Unresolved>> {
 }
 
 fn condition_payload_pattern(input: &mut Input) -> Result<Pattern<Unresolved>> {
-    alt((pattern_payload_receive, pattern_continue, pattern_name)).parse_next(input)
+    alt((
+        pattern_payload_receive,
+        t(TokenKind::Bang).map(|token| Pattern {
+            steps: Vec::new(),
+            terminal: PatternTerminal::Continue(token.span()),
+        }),
+        (local_name, annotation).map(|(name, annotation)| Pattern {
+            steps: Vec::new(),
+            terminal: PatternTerminal::Name(
+                match &annotation {
+                    Some(typ) => name.span.join(typ.span()),
+                    None => name.span(),
+                },
+                name,
+                annotation,
+            ),
+        }),
+    ))
+    .parse_next(input)
 }
 
 fn pattern_payload_receive(input: &mut Input) -> Result<Pattern<Unresolved>> {
-    commit_after(
-        t(TokenKind::LParen),
-        (list1(pattern_prefix_item), t(TokenKind::RParen), pattern),
-    )
-    .map(|(open, (items, _close, rest))| {
-        let span = open.span.join(rest.span());
-        fold_pattern_prefix(
-            items,
-            rest,
-            |name, rest| Pattern::ReceiveType(span.clone(), name, Box::new(rest)),
-            |arg, rest| Pattern::Receive(span.clone(), Box::new(arg), Box::new(rest), vec![]),
-        )
-    })
-    .parse_next(input)
+    preceded(peek(t(TokenKind::LParen)), pattern).parse_next(input)
 }
 
 fn expression_to_condition(expr: Expression<Unresolved>) -> Condition<Unresolved> {
@@ -2264,7 +2276,7 @@ fn expr_do(input: &mut Input) -> Result<Expression<Unresolved>> {
             span: pre.span.join(expression.span()),
             process: match process {
                 Some((_, process)) => Box::new(process),
-                None => Box::new(Process::Fallthrough(open.span.only_end())),
+                None => Box::new(Process::fallthrough(open.span.only_end())),
             },
             then: Box::new(expression),
         },
@@ -2295,150 +2307,194 @@ fn expr_chan(input: &mut Input) -> Result<Expression<Unresolved>> {
         pattern,
         process: match process {
             Some((_, process)) => Box::new(process),
-            None => Box::new(Process::Fallthrough(open.span.only_end())),
+            None => Box::new(Process::fallthrough(open.span.only_end())),
         },
     })
     .parse_next(input)
 }
 
 fn construction(input: &mut Input) -> Result<(Span, Construct<Unresolved>)> {
-    alt((
-        cons_then,
-        cons_begin,
-        cons_unfounded,
-        cons_loop,
-        cons_signal,
-        cons_case,
-        cons_break,
-        cons_send,
-        cons_receive,
-        cons_generic_receive,
-    ))
-    .context(StrContext::Label("construction"))
-    .parse_next(input)
+    parse_construction(input, false)
 }
 
 fn data_construction(input: &mut Input) -> Result<(Span, Construct<Unresolved>)> {
-    alt((
-        data_cons_signal,
-        data_cons_break,
-        data_cons_send,
-        data_cons_then,
-    ))
-    .context(StrContext::Label("data construction"))
-    .parse_next(input)
+    parse_construction(input, true)
 }
 
-fn cons_then(input: &mut Input) -> Result<(Span, Construct<Unresolved>)> {
+enum ConstructionPiece {
+    Steps(Span, Vec<ConstructStep<Unresolved>>),
+    Terminator(Span, ConstructTerminator<Unresolved>),
+}
+
+fn parse_construction(input: &mut Input, data_only: bool) -> Result<(Span, Construct<Unresolved>)> {
+    let mut steps = Vec::new();
+    let mut span: Option<Span> = None;
+    loop {
+        let piece = if data_only {
+            alt((
+                data_cons_signal,
+                data_cons_break,
+                data_cons_send,
+                data_cons_then,
+            ))
+            .context(StrContext::Label("data construction"))
+            .parse_next(input)?
+        } else {
+            alt((
+                cons_then,
+                cons_begin,
+                cons_unfounded,
+                cons_loop,
+                cons_signal,
+                cons_case,
+                cons_break,
+                cons_send,
+                cons_receive,
+                cons_generic_receive,
+            ))
+            .context(StrContext::Label("construction"))
+            .parse_next(input)?
+        };
+        match piece {
+            ConstructionPiece::Steps(piece_span, mut piece_steps) => {
+                span = Some(match span {
+                    Some(span) => span.join(piece_span),
+                    None => piece_span,
+                });
+                steps.append(&mut piece_steps);
+            }
+            ConstructionPiece::Terminator(piece_span, terminator) => {
+                let span = match span {
+                    Some(span) => span.join(piece_span),
+                    None => piece_span,
+                };
+                return Ok((span, Construct { steps, terminator }));
+            }
+        }
+    }
+}
+
+fn cons_then(input: &mut Input) -> Result<ConstructionPiece> {
     expression_without_construction
         .map(|expr| {
             let span = expr.span();
-            (span, Construct::Then(Box::new(expr)))
+            ConstructionPiece::Terminator(span, ConstructTerminator::Then(Box::new(expr)))
         })
         .parse_next(input)
 }
 
-fn data_cons_then(input: &mut Input) -> Result<(Span, Construct<Unresolved>)> {
+fn data_cons_then(input: &mut Input) -> Result<ConstructionPiece> {
     data_expression_terminal
         .map(|expr| {
             let span = expr.span();
-            (span, Construct::Then(Box::new(expr)))
+            ConstructionPiece::Terminator(span, ConstructTerminator::Then(Box::new(expr)))
         })
         .parse_next(input)
 }
 
-fn cons_send(input: &mut Input) -> Result<(Span, Construct<Unresolved>)> {
+fn cons_send(input: &mut Input) -> Result<ConstructionPiece> {
     commit_after(
         t(TokenKind::LParen),
         (
             list1(|input: &mut Input| send_prefix_item(TokenKind::RParen, input)),
             t(TokenKind::RParen),
-            construction,
         ),
     )
-    .map(|(open, (items, close, (then_full_span, then)))| {
+    .map(|(open, (items, close))| {
         let short_span = open.span.join(close.span());
-        let full_span = open.span.join(then_full_span);
-        let construct = fold_send_prefix(
-            items,
-            then,
-            |typ, then| Construct::SendType(short_span.clone(), typ, Box::new(then)),
-            |arg, then| Construct::Send(short_span.clone(), Box::new(arg), Box::new(then)),
-        );
-        (full_span, construct)
+        ConstructionPiece::Steps(
+            short_span.clone(),
+            items
+                .into_iter()
+                .map(|item| match item {
+                    SendPrefixItem::Explicit(typ) => {
+                        ConstructStep::SendType(short_span.clone(), typ)
+                    }
+                    SendPrefixItem::Value(arg) => {
+                        ConstructStep::Send(short_span.clone(), Box::new(arg))
+                    }
+                })
+                .collect(),
+        )
     })
     .parse_next(input)
 }
 
-fn data_cons_send(input: &mut Input) -> Result<(Span, Construct<Unresolved>)> {
+fn data_cons_send(input: &mut Input) -> Result<ConstructionPiece> {
     commit_after(
         t(TokenKind::LParen),
         (
             list1(|input: &mut Input| send_prefix_item(TokenKind::RParen, input)),
             t(TokenKind::RParen),
-            data_construction,
         ),
     )
-    .map(|(open, (items, close, (then_full_span, then)))| {
+    .map(|(open, (items, close))| {
         let short_span = open.span.join(close.span());
-        let full_span = open.span.join(then_full_span);
-        let construct = fold_send_prefix(
-            items,
-            then,
-            |typ, then| Construct::SendType(short_span.clone(), typ, Box::new(then)),
-            |arg, then| Construct::Send(short_span.clone(), Box::new(arg), Box::new(then)),
-        );
-        (full_span, construct)
+        ConstructionPiece::Steps(
+            short_span.clone(),
+            items
+                .into_iter()
+                .map(|item| match item {
+                    SendPrefixItem::Explicit(typ) => {
+                        ConstructStep::SendType(short_span.clone(), typ)
+                    }
+                    SendPrefixItem::Value(arg) => {
+                        ConstructStep::Send(short_span.clone(), Box::new(arg))
+                    }
+                })
+                .collect(),
+        )
     })
     .parse_next(input)
 }
 
-fn cons_receive(input: &mut Input) -> Result<(Span, Construct<Unresolved>)> {
+fn cons_receive(input: &mut Input) -> Result<ConstructionPiece> {
     commit_after(
         t(TokenKind::LBrack),
-        (
-            list1(pattern_prefix_item),
-            t(TokenKind::RBrack),
-            construction,
-        ),
+        (list1(pattern_prefix_item), t(TokenKind::RBrack)),
     )
-    .map(|(open, (items, close, (then_full_span, then)))| {
+    .map(|(open, (items, close))| {
         let short_span = open.span.join(close.span());
-        let full_span = open.span.join(then_full_span);
-        let construct = fold_pattern_prefix(
-            items,
-            then,
-            |name, then| Construct::ReceiveType(short_span.clone(), name, Box::new(then)),
-            |pattern, then| Construct::Receive(short_span.clone(), pattern, Box::new(then), vec![]),
-        );
-        (full_span, construct)
+        ConstructionPiece::Steps(
+            short_span.clone(),
+            items
+                .into_iter()
+                .map(|item| match item {
+                    PatternPrefixItem::Explicit(name) => {
+                        ConstructStep::ReceiveType(short_span.clone(), name)
+                    }
+                    PatternPrefixItem::Value(pattern) => {
+                        ConstructStep::Receive(short_span.clone(), pattern, vec![])
+                    }
+                })
+                .collect(),
+        )
     })
     .parse_next(input)
 }
 
-fn data_cons_signal(input: &mut Input) -> Result<(Span, Construct<Unresolved>)> {
-    (t(TokenKind::Dot), (local_name, data_construction))
-        .map(|(pre, (chosen, (then_full_span, construct)))| {
+fn data_cons_signal(input: &mut Input) -> Result<ConstructionPiece> {
+    (t(TokenKind::Dot), local_name)
+        .map(|(pre, chosen)| {
             let short_span = pre.span.join(chosen.span());
-            let full_span = pre.span.join(then_full_span);
-            (
-                full_span,
-                Construct::Signal(short_span, chosen, Box::new(construct)),
+            ConstructionPiece::Steps(
+                short_span.clone(),
+                vec![ConstructStep::Signal(short_span, chosen)],
             )
         })
         .parse_next(input)
 }
 
-fn data_cons_break(input: &mut Input) -> Result<(Span, Construct<Unresolved>)> {
+fn data_cons_break(input: &mut Input) -> Result<ConstructionPiece> {
     t(TokenKind::Bang)
         .map(|token| {
             let span = token.span();
-            (span.clone(), Construct::Break(span))
+            ConstructionPiece::Terminator(span.clone(), ConstructTerminator::Break(span))
         })
         .parse_next(input)
 }
 
-fn cons_generic_receive(input: &mut Input) -> Result<(Span, Construct<Unresolved>)> {
+fn cons_generic_receive(input: &mut Input) -> Result<ConstructionPiece> {
     commit_after(
         t(TokenKind::Lt),
         (
@@ -2447,62 +2503,56 @@ fn cons_generic_receive(input: &mut Input) -> Result<(Span, Construct<Unresolved
             t(TokenKind::LBrack),
             pattern,
             t(TokenKind::RBrack),
-            construction,
         ),
     )
     .map(
-        |(
-            vars_open,
-            (vars, _vars_close, _pattern_open, arg, pattern_close, (then_full_span, rest)),
-        )| {
+        |(vars_open, (vars, _vars_close, _pattern_open, arg, pattern_close))| {
             let short_span = vars_open.span.join(pattern_close.span());
-            let full_span = vars_open.span.join(then_full_span);
-            (
-                full_span,
-                Construct::Receive(short_span, arg, Box::new(rest), vars),
+            ConstructionPiece::Steps(
+                short_span.clone(),
+                vec![ConstructStep::Receive(short_span, arg, vars)],
             )
         },
     )
     .parse_next(input)
 }
 
-fn cons_signal(input: &mut Input) -> Result<(Span, Construct<Unresolved>)> {
+fn cons_signal(input: &mut Input) -> Result<ConstructionPiece> {
     // Note this can't be a commit_after because its possible that this is not a signal construction, and instead a branch of an either.
-    (t(TokenKind::Dot), (local_name, construction))
-        .map(|(pre, (chosen, (then_full_span, construct)))| {
+    (t(TokenKind::Dot), local_name)
+        .map(|(pre, chosen)| {
             let short_span = pre.span.join(chosen.span());
-            let full_span = pre.span.join(then_full_span);
-            (
-                full_span,
-                Construct::Signal(short_span, chosen, Box::new(construct)),
+            ConstructionPiece::Steps(
+                short_span.clone(),
+                vec![ConstructStep::Signal(short_span, chosen)],
             )
         })
         .parse_next(input)
 }
 
-fn cons_case(input: &mut Input) -> Result<(Span, Construct<Unresolved>)> {
+fn cons_case(input: &mut Input) -> Result<ConstructionPiece> {
     commit_after(t(TokenKind::Case), branches_body(cons_branch))
         .map(|(pre, (branches_span, branches, else_branch))| {
             let full_span = pre.span.join(branches_span);
             let short_span = pre.span();
-            (
+            ConstructionPiece::Terminator(
                 full_span,
-                Construct::Case(short_span, ConstructBranches(branches), else_branch),
+                ConstructTerminator::Case(short_span, ConstructBranches(branches), else_branch),
             )
         })
         .parse_next(input)
 }
 
-fn cons_break(input: &mut Input) -> Result<(Span, Construct<Unresolved>)> {
+fn cons_break(input: &mut Input) -> Result<ConstructionPiece> {
     t(TokenKind::Bang)
         .map(|token| {
             let span = token.span();
-            (span.clone(), Construct::Break(span))
+            ConstructionPiece::Terminator(span.clone(), ConstructTerminator::Break(span))
         })
         .parse_next(input)
 }
 
-fn cons_begin(input: &mut Input) -> Result<(Span, Construct<Unresolved>)> {
+fn cons_begin(input: &mut Input) -> Result<ConstructionPiece> {
     commit_after(t(TokenKind::Begin), (label, construction))
         .map(|(begin_kw, (label, (then_full_span, construct)))| {
             let short_span = match &label {
@@ -2510,20 +2560,20 @@ fn cons_begin(input: &mut Input) -> Result<(Span, Construct<Unresolved>)> {
                 None => begin_kw.span(),
             };
             let full_span = begin_kw.span.join(then_full_span);
-            (
+            ConstructionPiece::Terminator(
                 full_span,
-                Construct::Begin {
+                ConstructTerminator::Begin {
                     span: short_span,
                     unfounded: false,
                     label,
-                    then: Box::new(construct),
+                    body: Box::new(construct),
                 },
             )
         })
         .parse_next(input)
 }
 
-fn cons_unfounded(input: &mut Input) -> Result<(Span, Construct<Unresolved>)> {
+fn cons_unfounded(input: &mut Input) -> Result<ConstructionPiece> {
     commit_after(t(TokenKind::Unfounded), (label, construction))
         .map(|(unfounded_kw, (label, (then_full_span, construct)))| {
             let short_span = match &label {
@@ -2531,70 +2581,90 @@ fn cons_unfounded(input: &mut Input) -> Result<(Span, Construct<Unresolved>)> {
                 None => unfounded_kw.span(),
             };
             let full_span = unfounded_kw.span.join(then_full_span);
-            (
+            ConstructionPiece::Terminator(
                 full_span,
-                Construct::Begin {
+                ConstructTerminator::Begin {
                     span: short_span,
                     unfounded: true,
                     label,
-                    then: Box::new(construct),
+                    body: Box::new(construct),
                 },
             )
         })
         .parse_next(input)
 }
 
-fn cons_loop(input: &mut Input) -> Result<(Span, Construct<Unresolved>)> {
+fn cons_loop(input: &mut Input) -> Result<ConstructionPiece> {
     commit_after(t(TokenKind::Loop), label)
         .map(|(token, label)| {
             let span = match &label {
                 Some(label) => token.span.join(label.span()),
                 None => token.span(),
             };
-            (span.clone(), Construct::Loop(span, label))
+            ConstructionPiece::Terminator(span.clone(), ConstructTerminator::Loop(span, label))
         })
         .parse_next(input)
 }
 
 fn cons_branch(input: &mut Input) -> Result<ConstructBranch<Unresolved>> {
-    alt((
-        cons_branch_then,
-        cons_branch_receive,
-        cons_branch_generic_receive,
-    ))
-    .parse_next(input)
+    let mut steps = Vec::new();
+    loop {
+        match alt((
+            cons_branch_then,
+            cons_branch_receive,
+            cons_branch_generic_receive,
+        ))
+        .parse_next(input)?
+        {
+            ConstructBranchPiece::Steps(mut parsed) => steps.append(&mut parsed),
+            ConstructBranchPiece::Terminator(terminator) => {
+                return Ok(ConstructBranch { steps, terminator });
+            }
+        }
+    }
 }
 
-fn cons_branch_then(input: &mut Input) -> Result<ConstructBranch<Unresolved>> {
+enum ConstructBranchPiece {
+    Steps(Vec<ConstructBranchStep<Unresolved>>),
+    Terminator(ConstructBranchTerminator<Unresolved>),
+}
+
+fn cons_branch_then(input: &mut Input) -> Result<ConstructBranchPiece> {
     commit_after(t(TokenKind::FatArrow), expression)
         .map(|(pre, expression)| {
-            ConstructBranch::Then(pre.span.join(expression.span()), expression)
+            ConstructBranchPiece::Terminator(ConstructBranchTerminator::Then(
+                pre.span.join(expression.span()),
+                expression,
+            ))
         })
         .parse_next(input)
 }
 
-fn cons_branch_receive(input: &mut Input) -> Result<ConstructBranch<Unresolved>> {
+fn cons_branch_receive(input: &mut Input) -> Result<ConstructBranchPiece> {
     commit_after(
         t(TokenKind::LParen),
-        (
-            list1(pattern_prefix_item),
-            t(TokenKind::RParen),
-            cons_branch,
-        ),
+        (list1(pattern_prefix_item), t(TokenKind::RParen)),
     )
-    .map(|(open, (items, _close, rest))| {
-        let span = open.span.join(rest.span());
-        fold_pattern_prefix(
-            items,
-            rest,
-            |name, rest| ConstructBranch::ReceiveType(span.clone(), name, Box::new(rest)),
-            |pattern, rest| ConstructBranch::Receive(span.clone(), pattern, Box::new(rest), vec![]),
+    .map(|(open, (items, close))| {
+        let span = open.span.join(close.span());
+        ConstructBranchPiece::Steps(
+            items
+                .into_iter()
+                .map(|item| match item {
+                    PatternPrefixItem::Explicit(name) => {
+                        ConstructBranchStep::ReceiveType(span.clone(), name)
+                    }
+                    PatternPrefixItem::Value(pattern) => {
+                        ConstructBranchStep::Receive(span.clone(), pattern, vec![])
+                    }
+                })
+                .collect(),
         )
     })
     .parse_next(input)
 }
 
-fn cons_branch_generic_receive(input: &mut Input) -> Result<ConstructBranch<Unresolved>> {
+fn cons_branch_generic_receive(input: &mut Input) -> Result<ConstructBranchPiece> {
     commit_after(
         t(TokenKind::Lt),
         (
@@ -2603,13 +2673,12 @@ fn cons_branch_generic_receive(input: &mut Input) -> Result<ConstructBranch<Unre
             t(TokenKind::LParen),
             pattern,
             t(TokenKind::RParen),
-            cons_branch,
         ),
     )
     .map(
-        |(vars_open, (vars, _vars_close, _pattern_open, arg, _pattern_close, rest))| {
-            let span = vars_open.span.join(rest.span());
-            ConstructBranch::Receive(span.clone(), arg, Box::new(rest), vars)
+        |(vars_open, (vars, _vars_close, _pattern_open, arg, pattern_close))| {
+            let span = vars_open.span.join(pattern_close.span());
+            ConstructBranchPiece::Steps(vec![ConstructBranchStep::Receive(span, arg, vars)])
         },
     )
     .parse_next(input)
@@ -2635,68 +2704,96 @@ fn application(input: &mut Input) -> Result<Expression<Unresolved>> {
 }
 
 fn apply(input: &mut Input) -> Result<Option<(Span, Apply<Unresolved>)>> {
-    opt(alt((
-        apply_begin,
-        apply_unfounded,
-        apply_loop,
-        apply_signal,
-        apply_case,
-        apply_send,
-        apply_default,
-        apply_try,
-        apply_pipe,
-    )))
-    .parse_next(input)
+    let mut steps = Vec::new();
+    let mut span: Option<Span> = None;
+    loop {
+        let piece = opt(alt((
+            apply_begin,
+            apply_unfounded,
+            apply_loop,
+            apply_signal,
+            apply_case,
+            apply_send,
+            apply_default,
+            apply_try,
+            apply_pipe,
+        )))
+        .parse_next(input)?;
+        match piece {
+            Some(ApplyPiece::Steps(piece_span, mut parsed)) => {
+                span = Some(match span {
+                    Some(span) => span.join(piece_span),
+                    None => piece_span,
+                });
+                steps.append(&mut parsed);
+            }
+            Some(ApplyPiece::Terminator(piece_span, terminator)) => {
+                let full_span = match span {
+                    Some(span) => span.join(piece_span),
+                    None => piece_span,
+                };
+                return Ok(Some((full_span, Apply { steps, terminator })));
+            }
+            None => {
+                return Ok(span.map(|span| {
+                    let end = span.only_end();
+                    (
+                        span,
+                        Apply {
+                            steps,
+                            terminator: ApplyTerminator::Noop(end),
+                        },
+                    )
+                }));
+            }
+        }
+    }
 }
 
-fn apply_send(input: &mut Input) -> Result<(Span, Apply<Unresolved>)> {
+enum ApplyPiece {
+    Steps(Span, Vec<ApplyStep<Unresolved>>),
+    Terminator(Span, ApplyTerminator<Unresolved>),
+}
+
+fn apply_send(input: &mut Input) -> Result<ApplyPiece> {
     commit_after(
         t(TokenKind::LParen),
         (
             list1(|input: &mut Input| send_prefix_item(TokenKind::RParen, input)),
             t(TokenKind::RParen),
-            apply,
         ),
     )
-    .map(|(open, (items, close, then))| {
-        let (then_full_span, then) = match then {
-            Some((span, apply)) => (span, apply),
-            None => {
-                let s = close.span.only_end();
-                (s.clone(), Apply::Noop(s))
-            }
-        };
+    .map(|(open, (items, close))| {
         let short_span = open.span.join(close.span());
-        let full_span = open.span.join(then_full_span);
-        let apply = fold_send_prefix(
-            items,
-            then,
-            |typ, then| Apply::SendType(short_span.clone(), typ, Box::new(then)),
-            |arg, then| Apply::Send(short_span.clone(), Box::new(arg), Box::new(then)),
-        );
-        (full_span, apply)
+        ApplyPiece::Steps(
+            short_span.clone(),
+            items
+                .into_iter()
+                .map(|item| match item {
+                    SendPrefixItem::Explicit(typ) => ApplyStep::SendType(short_span.clone(), typ),
+                    SendPrefixItem::Value(arg) => {
+                        ApplyStep::Send(short_span.clone(), Box::new(arg))
+                    }
+                })
+                .collect(),
+        )
     })
     .parse_next(input)
 }
 
-fn apply_signal(input: &mut Input) -> Result<(Span, Apply<Unresolved>)> {
-    (t(TokenKind::Dot), (local_name, apply))
-        .map(|(pre, (chosen, then))| {
-            let (then_full_span, then) = match then {
-                Some((span, apply)) => (span, apply),
-                None => {
-                    let s = chosen.span.only_end();
-                    (s.clone(), Apply::Noop(s))
-                }
-            };
+fn apply_signal(input: &mut Input) -> Result<ApplyPiece> {
+    (t(TokenKind::Dot), local_name)
+        .map(|(pre, chosen)| {
             let short_span = pre.span.join(chosen.span());
-            let full_span = pre.span.join(then_full_span);
-            (full_span, Apply::Signal(short_span, chosen, Box::new(then)))
+            ApplyPiece::Steps(
+                short_span.clone(),
+                vec![ApplyStep::Signal(short_span, chosen)],
+            )
         })
         .parse_next(input)
 }
 
-fn apply_case(input: &mut Input) -> Result<(Span, Apply<Unresolved>)> {
+fn apply_case(input: &mut Input) -> Result<ApplyPiece> {
     commit_after(
         (t(TokenKind::Dot), t(TokenKind::Case)),
         branches_body(apply_branch),
@@ -2704,26 +2801,38 @@ fn apply_case(input: &mut Input) -> Result<(Span, Apply<Unresolved>)> {
     .map(|((pre, case_kw), (branches_span, branches, else_branch))| {
         let full_span = pre.span.join(branches_span);
         let short_span = pre.span.join(case_kw.span());
-        (
+        ApplyPiece::Terminator(
             full_span,
-            Apply::Case(short_span, ApplyBranches(branches), else_branch),
+            ApplyTerminator::Case(short_span, ApplyBranches(branches), else_branch),
         )
     })
     .parse_next(input)
 }
 
-fn apply_begin(input: &mut Input) -> Result<(Span, Apply<Unresolved>)> {
+fn apply_begin(input: &mut Input) -> Result<ApplyPiece> {
     commit_after((t(TokenKind::Dot), t(TokenKind::Begin)), (label, apply))
         .map(|((pre, begin_kw), (label, then))| {
             let (then_full_span, then) = match (&label, then) {
                 (_, Some((span, apply))) => (span, apply),
                 (Some(label), None) => {
                     let s = label.span.only_end();
-                    (s.clone(), Apply::Noop(s))
+                    (
+                        s.clone(),
+                        Apply {
+                            steps: Vec::new(),
+                            terminator: ApplyTerminator::Noop(s),
+                        },
+                    )
                 }
                 (None, None) => {
                     let s = begin_kw.span.only_end();
-                    (s.clone(), Apply::Noop(s))
+                    (
+                        s.clone(),
+                        Apply {
+                            steps: Vec::new(),
+                            terminator: ApplyTerminator::Noop(s),
+                        },
+                    )
                 }
             };
             let short_span = match &label {
@@ -2731,31 +2840,43 @@ fn apply_begin(input: &mut Input) -> Result<(Span, Apply<Unresolved>)> {
                 None => pre.span.join(begin_kw.span()),
             };
             let full_span = pre.span.join(then_full_span);
-            (
+            ApplyPiece::Terminator(
                 full_span,
-                Apply::Begin {
+                ApplyTerminator::Begin {
                     span: short_span,
                     unfounded: false,
                     label,
-                    then: Box::new(then),
+                    body: Box::new(then),
                 },
             )
         })
         .parse_next(input)
 }
 
-fn apply_unfounded(input: &mut Input) -> Result<(Span, Apply<Unresolved>)> {
+fn apply_unfounded(input: &mut Input) -> Result<ApplyPiece> {
     commit_after((t(TokenKind::Dot), t(TokenKind::Unfounded)), (label, apply))
         .map(|((pre, unfounded_kw), (label, then))| {
             let (then_full_span, then) = match (&label, then) {
                 (_, Some((span, apply))) => (span, apply),
                 (Some(label), None) => {
                     let s = label.span.only_end();
-                    (s.clone(), Apply::Noop(s))
+                    (
+                        s.clone(),
+                        Apply {
+                            steps: Vec::new(),
+                            terminator: ApplyTerminator::Noop(s),
+                        },
+                    )
                 }
                 (None, None) => {
                     let s = unfounded_kw.span.only_end();
-                    (s.clone(), Apply::Noop(s))
+                    (
+                        s.clone(),
+                        Apply {
+                            steps: Vec::new(),
+                            terminator: ApplyTerminator::Noop(s),
+                        },
+                    )
                 }
             };
             let short_span = match &label {
@@ -2763,151 +2884,140 @@ fn apply_unfounded(input: &mut Input) -> Result<(Span, Apply<Unresolved>)> {
                 None => pre.span.join(unfounded_kw.span()),
             };
             let full_span = pre.span.join(then_full_span);
-            (
+            ApplyPiece::Terminator(
                 full_span,
-                Apply::Begin {
+                ApplyTerminator::Begin {
                     span: short_span,
                     unfounded: true,
                     label,
-                    then: Box::new(then),
+                    body: Box::new(then),
                 },
             )
         })
         .parse_next(input)
 }
 
-fn apply_loop(input: &mut Input) -> Result<(Span, Apply<Unresolved>)> {
+fn apply_loop(input: &mut Input) -> Result<ApplyPiece> {
     commit_after((t(TokenKind::Dot), t(TokenKind::Loop)), label)
         .map(|((pre1, pre2), label)| {
             let span = match &label {
                 Some(label) => pre1.span.join(label.span()),
                 None => pre1.span.join(pre2.span()),
             };
-            (span.clone(), Apply::Loop(span, label))
+            ApplyPiece::Terminator(span.clone(), ApplyTerminator::Loop(span, label))
         })
         .parse_next(input)
 }
 
-fn apply_try(input: &mut Input) -> Result<(Span, Apply<Unresolved>)> {
-    commit_after((t(TokenKind::Dot), t(TokenKind::Try)), (label, apply))
-        .map(|((dot, pre), (label, then))| {
-            let (then_full_span, then) = match then {
-                Some((span, apply)) => (span, apply),
-                None => {
-                    let s = pre.span.only_end();
-                    (s.clone(), Apply::Noop(s))
-                }
-            };
+fn apply_try(input: &mut Input) -> Result<ApplyPiece> {
+    commit_after((t(TokenKind::Dot), t(TokenKind::Try)), label)
+        .map(|((dot, pre), label)| {
             let short_span = match &label {
                 Some(label) => dot.span.join(label.span()),
                 None => dot.span.join(pre.span()),
             };
-            let full_span = dot.span.join(then_full_span);
-            (full_span, Apply::Try(short_span, label, Box::new(then)))
+            ApplyPiece::Steps(short_span.clone(), vec![ApplyStep::Try(short_span, label)])
         })
         .parse_next(input)
 }
 
-fn apply_default(input: &mut Input) -> Result<(Span, Apply<Unresolved>)> {
+fn apply_default(input: &mut Input) -> Result<ApplyPiece> {
     commit_after(
         (t(TokenKind::Dot), t(TokenKind::Default)),
-        (
-            t(TokenKind::LParen),
-            expression,
-            t(TokenKind::RParen),
-            apply,
-        ),
+        (t(TokenKind::LParen), expression, t(TokenKind::RParen)),
     )
-    .map(|((dot, _pre), (_, expr, close, then))| {
-        let (then_full_span, then) = match then {
-            Some((span, apply)) => (span, apply),
-            None => {
-                let s = close.span.only_end();
-                (s.clone(), Apply::Noop(s))
-            }
-        };
+    .map(|((dot, _pre), (_, expr, close))| {
         let short_span = dot.span.join(close.span());
-        let full_span = dot.span.join(then_full_span);
-        (
-            full_span,
-            Apply::Default(short_span, Box::new(expr), Box::new(then)),
+        ApplyPiece::Steps(
+            short_span.clone(),
+            vec![ApplyStep::Default(short_span, Box::new(expr))],
         )
     })
     .parse_next(input)
 }
 
-fn apply_pipe(input: &mut Input) -> Result<(Span, Apply<Unresolved>)> {
+fn apply_pipe(input: &mut Input) -> Result<ApplyPiece> {
     commit_after(
         t(TokenKind::ThinArrow),
-        (
-            alt((
-                global_name.map(|name| Expression::Global(name.span(), name)),
-                local_name.map(|name| Expression::Variable(name.span(), name)),
-                expr_grouped,
-            )),
-            apply,
-        ),
+        alt((
+            global_name.map(|name| Expression::Global(name.span(), name)),
+            local_name.map(|name| Expression::Variable(name.span(), name)),
+            expr_grouped,
+        )),
     )
-    .map(|(pre, (function, then))| {
-        let (then_full_span, then) = match then {
-            Some((span, apply)) => (span, apply),
-            None => {
-                let s = function.span().only_end();
-                (s.clone(), Apply::Noop(s))
-            }
-        };
+    .map(|(pre, function)| {
         let short_span = pre.span.join(function.span());
-        let full_span = pre.span.join(then_full_span);
-        (
-            full_span,
-            Apply::Pipe(short_span, Box::new(function), Box::new(then)),
+        ApplyPiece::Steps(
+            short_span.clone(),
+            vec![ApplyStep::Pipe(short_span, Box::new(function))],
         )
     })
     .parse_next(input)
 }
 
 fn apply_branch(input: &mut Input) -> Result<ApplyBranch<Unresolved>> {
-    alt((
-        apply_branch_then,
-        apply_branch_receive,
-        apply_branch_generic_receive,
-        apply_branch_continue,
-        apply_branch_try,
-        apply_branch_default,
-    ))
-    .parse_next(input)
+    let mut steps = Vec::new();
+    loop {
+        match alt((
+            apply_branch_then,
+            apply_branch_receive,
+            apply_branch_generic_receive,
+            apply_branch_continue,
+            apply_branch_try,
+            apply_branch_default,
+        ))
+        .parse_next(input)?
+        {
+            ApplyBranchPiece::Steps(mut parsed) => steps.append(&mut parsed),
+            ApplyBranchPiece::Terminator(terminator) => {
+                return Ok(ApplyBranch { steps, terminator });
+            }
+        }
+    }
 }
 
-fn apply_branch_then(input: &mut Input) -> Result<ApplyBranch<Unresolved>> {
+enum ApplyBranchPiece {
+    Steps(Vec<ApplyBranchStep<Unresolved>>),
+    Terminator(ApplyBranchTerminator<Unresolved>),
+}
+
+fn apply_branch_then(input: &mut Input) -> Result<ApplyBranchPiece> {
     (local_name, cut_err((t(TokenKind::FatArrow), expression)))
         .map(|(name, (_, expression))| {
-            ApplyBranch::Then(name.span.join(expression.span()), name, expression)
+            ApplyBranchPiece::Terminator(ApplyBranchTerminator::Then(
+                name.span.join(expression.span()),
+                name,
+                expression,
+            ))
         })
         .parse_next(input)
 }
 
-fn apply_branch_receive(input: &mut Input) -> Result<ApplyBranch<Unresolved>> {
+fn apply_branch_receive(input: &mut Input) -> Result<ApplyBranchPiece> {
     commit_after(
         t(TokenKind::LParen),
-        (
-            list1(pattern_prefix_item),
-            t(TokenKind::RParen),
-            apply_branch,
-        ),
+        (list1(pattern_prefix_item), t(TokenKind::RParen)),
     )
-    .map(|(open, (items, _close, rest))| {
-        let span = open.span.join(rest.span());
-        fold_pattern_prefix(
-            items,
-            rest,
-            |name, rest| ApplyBranch::ReceiveType(span.clone(), name, Box::new(rest)),
-            |pattern, rest| ApplyBranch::Receive(span.clone(), pattern, Box::new(rest), vec![]),
+    .map(|(open, (items, close))| {
+        let span = open.span.join(close.span());
+        ApplyBranchPiece::Steps(
+            items
+                .into_iter()
+                .map(|item| match item {
+                    PatternPrefixItem::Explicit(name) => {
+                        ApplyBranchStep::ReceiveType(span.clone(), name)
+                    }
+                    PatternPrefixItem::Value(pattern) => {
+                        ApplyBranchStep::Receive(span.clone(), pattern, vec![])
+                    }
+                })
+                .collect(),
         )
     })
     .parse_next(input)
 }
 
-fn apply_branch_generic_receive(input: &mut Input) -> Result<ApplyBranch<Unresolved>> {
+fn apply_branch_generic_receive(input: &mut Input) -> Result<ApplyBranchPiece> {
     commit_after(
         t(TokenKind::Lt),
         (
@@ -2916,46 +3026,71 @@ fn apply_branch_generic_receive(input: &mut Input) -> Result<ApplyBranch<Unresol
             t(TokenKind::LParen),
             pattern,
             t(TokenKind::RParen),
-            apply_branch,
         ),
     )
     .map(
-        |(vars_open, (vars, _vars_close, _pattern_open, arg, _pattern_close, rest))| {
-            let span = vars_open.span.join(rest.span());
-            ApplyBranch::Receive(span.clone(), arg, Box::new(rest), vars)
+        |(vars_open, (vars, _vars_close, _pattern_open, arg, pattern_close))| {
+            let span = vars_open.span.join(pattern_close.span());
+            ApplyBranchPiece::Steps(vec![ApplyBranchStep::Receive(span, arg, vars)])
         },
     )
     .parse_next(input)
 }
 
-fn apply_branch_continue(input: &mut Input) -> Result<ApplyBranch<Unresolved>> {
+fn apply_branch_continue(input: &mut Input) -> Result<ApplyBranchPiece> {
     commit_after(t(TokenKind::Bang), (t(TokenKind::FatArrow), expression))
         .map(|(token, (_, expression))| {
-            ApplyBranch::Continue(token.span.join(expression.span()), expression)
+            ApplyBranchPiece::Terminator(ApplyBranchTerminator::Continue(
+                token.span.join(expression.span()),
+                expression,
+            ))
         })
         .parse_next(input)
 }
 
-fn apply_branch_try(input: &mut Input) -> Result<ApplyBranch<Unresolved>> {
-    commit_after(t(TokenKind::Try), (label, apply_branch))
-        .map(|(kw, (label, rest))| {
-            ApplyBranch::Try(kw.span.join(rest.span()), label, Box::new(rest))
+fn apply_branch_try(input: &mut Input) -> Result<ApplyBranchPiece> {
+    commit_after(t(TokenKind::Try), label)
+        .map(|(kw, label)| {
+            let span = match &label {
+                Some(label) => kw.span.join(label.span()),
+                None => kw.span(),
+            };
+            ApplyBranchPiece::Steps(vec![ApplyBranchStep::Try(span, label)])
         })
         .parse_next(input)
 }
 
-fn apply_branch_default(input: &mut Input) -> Result<ApplyBranch<Unresolved>> {
+fn apply_branch_default(input: &mut Input) -> Result<ApplyBranchPiece> {
     commit_after(
         (t(TokenKind::Default), t(TokenKind::LParen)),
-        (expression, t(TokenKind::RParen), apply_branch),
+        (expression, t(TokenKind::RParen)),
     )
-    .map(|((kw, _), (expr, _close, rest))| {
-        ApplyBranch::Default(kw.span.join(rest.span()), Box::new(expr), Box::new(rest))
+    .map(|((kw, _), (expr, close))| {
+        ApplyBranchPiece::Steps(vec![ApplyBranchStep::Default(
+            kw.span.join(close.span()),
+            Box::new(expr),
+        )])
     })
     .parse_next(input)
 }
 
-fn process(input: &mut Input) -> Result<(Span, Process<Unresolved>)> {
+enum ProcessContinuation {
+    Optional,
+    Required,
+}
+
+enum ProcessHead {
+    Linear(ProcessStep<Unresolved>, ProcessContinuation),
+    If {
+        span: Span,
+        branches: Vec<(Condition<Unresolved>, Process<Unresolved>)>,
+        else_: Option<Box<Process<Unresolved>>>,
+    },
+    Command(ProcessCommand<Unresolved>),
+    Terminator(ProcessTerminator<Unresolved>),
+}
+
+fn process_head(input: &mut Input) -> Result<(Span, ProcessHead)> {
     alt((
         proc_if,
         proc_poll,
@@ -2972,31 +3107,157 @@ fn process(input: &mut Input) -> Result<(Span, Process<Unresolved>)> {
     .parse_next(input)
 }
 
-fn proc_let(input: &mut Input) -> Result<(Span, Process<Unresolved>)> {
-    commit_after(
-        t(TokenKind::Let),
-        (pattern, t(TokenKind::Eq), expression, opt(process)),
-    )
-    .map(|(pre, (pattern, _, expression, then_opt))| {
-        let span = pre.span.join(expression.span());
-        let (full_span, then) = match then_opt {
-            Some((then_full_span, then)) => (pre.span.join(then_full_span), Box::new(then)),
-            None => (
-                span.clone(),
-                Box::new(Process::Fallthrough(expression.span().only_end())),
-            ),
-        };
-        (
-            full_span,
-            Process::Let {
+fn pass_process_head(input: &mut Input) -> Result<(Span, ProcessHead)> {
+    alt((proc_if, proc_let, global_command, command)).parse_next(input)
+}
+
+fn process(input: &mut Input) -> Result<(Span, Process<Unresolved>)> {
+    let (first_span, mut head) = process_head(input)?;
+    let mut steps = Vec::new();
+    let mut full_span = first_span.clone();
+
+    loop {
+        let _ = opt(t(TokenKind::Semicolon)).parse_next(input)?;
+        match head {
+            ProcessHead::Linear(step, continuation) => {
+                steps.push(step);
+                let next = match continuation {
+                    ProcessContinuation::Optional => opt(process_head).parse_next(input)?,
+                    ProcessContinuation::Required => Some(process_head(input)?),
+                };
+                match next {
+                    Some((span, next)) => {
+                        full_span = first_span.join(span);
+                        head = next;
+                    }
+                    None => {
+                        let span = full_span.only_end();
+                        return Ok((
+                            full_span,
+                            Process {
+                                steps,
+                                terminator: ProcessTerminator::Fallthrough(span),
+                            },
+                        ));
+                    }
+                }
+            }
+            ProcessHead::If {
                 span,
-                pattern,
-                then,
-                value: Box::new(expression),
+                branches,
+                else_,
+            } => match opt(pass_process_head).parse_next(input)? {
+                Some((next_span, next)) => {
+                    steps.push(ProcessStep::If {
+                        span,
+                        branches,
+                        else_,
+                    });
+                    full_span = first_span.join(next_span);
+                    head = next;
+                }
+                None => {
+                    return Ok((
+                        full_span,
+                        Process {
+                            steps,
+                            terminator: ProcessTerminator::If {
+                                span,
+                                branches,
+                                else_,
+                            },
+                        },
+                    ));
+                }
             },
-        )
-    })
-    .parse_next(input)
+            ProcessHead::Command(mut command) => {
+                if let CommandTerminator::Begin {
+                    body, continuation, ..
+                } = &mut command.command.terminator
+                    && command_accepts_process_tail(body)
+                {
+                    if let Some((tail_span, tail)) = opt(process).parse_next(input)? {
+                        *continuation = Some(Box::new(tail));
+                        full_span = first_span.join(tail_span);
+                    }
+                    return Ok((
+                        full_span,
+                        Process {
+                            steps,
+                            terminator: ProcessTerminator::Command(command),
+                        },
+                    ));
+                }
+                let continuation = match command.command.terminator {
+                    CommandTerminator::Then(_) => Some(ProcessContinuation::Optional),
+                    CommandTerminator::Case(..) => None,
+                    _ => {
+                        return Ok((
+                            full_span,
+                            Process {
+                                steps,
+                                terminator: ProcessTerminator::Command(command),
+                            },
+                        ));
+                    }
+                };
+                let next = match continuation {
+                    Some(ProcessContinuation::Optional) => opt(process_head).parse_next(input)?,
+                    Some(ProcessContinuation::Required) => unreachable!(),
+                    None => opt(pass_process_head).parse_next(input)?,
+                };
+                match next {
+                    Some((next_span, next)) => {
+                        steps.push(ProcessStep::Command(command));
+                        full_span = first_span.join(next_span);
+                        head = next;
+                    }
+                    None if matches!(command.command.terminator, CommandTerminator::Then(_)) => {
+                        let span = command.command.terminator.span();
+                        steps.push(ProcessStep::Command(command));
+                        return Ok((
+                            full_span,
+                            Process {
+                                steps,
+                                terminator: ProcessTerminator::Fallthrough(span),
+                            },
+                        ));
+                    }
+                    None => {
+                        return Ok((
+                            full_span,
+                            Process {
+                                steps,
+                                terminator: ProcessTerminator::Command(command),
+                            },
+                        ));
+                    }
+                }
+            }
+            ProcessHead::Terminator(terminator) => {
+                return Ok((full_span, Process { steps, terminator }));
+            }
+        }
+    }
+}
+
+fn proc_let(input: &mut Input) -> Result<(Span, ProcessHead)> {
+    commit_after(t(TokenKind::Let), (pattern, t(TokenKind::Eq), expression))
+        .map(|(pre, (pattern, _, expression))| {
+            let span = pre.span.join(expression.span());
+            (
+                span.clone(),
+                ProcessHead::Linear(
+                    ProcessStep::Let {
+                        span,
+                        pattern,
+                        value: Box::new(expression),
+                    },
+                    ProcessContinuation::Optional,
+                ),
+            )
+        })
+        .parse_next(input)
 }
 
 fn compound_assign_operator(input: &mut Input) -> Result<(Span, ArithmeticOperator)> {
@@ -3009,42 +3270,37 @@ fn compound_assign_operator(input: &mut Input) -> Result<(Span, ArithmeticOperat
     .parse_next(input)
 }
 
-fn proc_compound_assign(input: &mut Input) -> Result<(Span, Process<Unresolved>)> {
-    commit_after(
-        (local_name, compound_assign_operator),
-        (expression, opt(process)),
-    )
-    .map(|((name, (op_span, op)), (right, then_opt))| {
-        let left = Expression::Variable(name.span(), name.clone());
-        let value = Expression::Arithmetic {
-            span: left.span().join(right.span()),
-            op_span,
-            op,
-            left: Box::new(left),
-            right: Box::new(right),
-        };
-        let span = name.span.join(value.span());
-        let (full_span, then) = match then_opt {
-            Some((then_full_span, then)) => (name.span.join(then_full_span), Box::new(then)),
-            None => (
+fn proc_compound_assign(input: &mut Input) -> Result<(Span, ProcessHead)> {
+    commit_after((local_name, compound_assign_operator), expression)
+        .map(|((name, (op_span, op)), right)| {
+            let left = Expression::Variable(name.span(), name.clone());
+            let value = Expression::Arithmetic {
+                span: left.span().join(right.span()),
+                op_span,
+                op,
+                left: Box::new(left),
+                right: Box::new(right),
+            };
+            let span = name.span.join(value.span());
+            (
                 span.clone(),
-                Box::new(Process::Fallthrough(value.span().only_end())),
-            ),
-        };
-        (
-            full_span,
-            Process::Let {
-                span,
-                pattern: Pattern::Name(name.span(), name, None),
-                value: Box::new(value),
-                then,
-            },
-        )
-    })
-    .parse_next(input)
+                ProcessHead::Linear(
+                    ProcessStep::Let {
+                        span,
+                        pattern: Pattern {
+                            steps: Vec::new(),
+                            terminal: PatternTerminal::Name(name.span(), name, None),
+                        },
+                        value: Box::new(value),
+                    },
+                    ProcessContinuation::Optional,
+                ),
+            )
+        })
+        .parse_next(input)
 }
 
-fn proc_catch(input: &mut Input) -> Result<(Span, Process<Unresolved>)> {
+fn proc_catch(input: &mut Input) -> Result<(Span, ProcessHead)> {
     commit_after(
         t(TokenKind::Catch),
         (
@@ -3054,41 +3310,45 @@ fn proc_catch(input: &mut Input) -> Result<(Span, Process<Unresolved>)> {
             t(TokenKind::LCurly),
             process,
             t(TokenKind::RCurly),
-            process,
         ),
     )
     .map(
-        |(pre, (label, pattern, _, _, (_block_full_span, block), _, (then_full_span, then)))| {
+        |(pre, (label, pattern, _, _, (_block_full_span, block), _))| {
             let span = pre.span.join(block.span());
-            let full_span = pre.span.join(then_full_span);
             (
-                full_span,
-                Process::Catch {
-                    span,
-                    label,
-                    pattern,
-                    block: Box::new(block),
-                    then: Box::new(then),
-                },
+                span.clone(),
+                ProcessHead::Linear(
+                    ProcessStep::Catch {
+                        span,
+                        label,
+                        pattern,
+                        block: Box::new(block),
+                    },
+                    ProcessContinuation::Required,
+                ),
             )
         },
     )
     .parse_next(input)
 }
 
-fn proc_throw(input: &mut Input) -> Result<(Span, Process<Unresolved>)> {
+fn proc_throw(input: &mut Input) -> Result<(Span, ProcessHead)> {
     commit_after(t(TokenKind::Throw), (label, expression))
         .map(|(pre, (label, expression))| {
             let span = pre.span.join(expression.span());
             (
                 span.clone(),
-                Process::Throw(span, label, Box::new(expression)),
+                ProcessHead::Terminator(ProcessTerminator::Throw(
+                    span,
+                    label,
+                    Box::new(expression),
+                )),
             )
         })
         .parse_next(input)
 }
 
-fn proc_poll(input: &mut Input) -> Result<(Span, Process<Unresolved>)> {
+fn proc_poll(input: &mut Input) -> Result<(Span, ProcessHead)> {
     commit_after(
         t(TokenKind::Poll),
         (
@@ -3136,28 +3396,28 @@ fn proc_poll(input: &mut Input) -> Result<(Span, Process<Unresolved>)> {
         )| {
             let then = then
                 .map(|(_, p)| p)
-                .unwrap_or(Process::Fallthrough(body_open.span.join(body_close.span())));
+                .unwrap_or(Process::fallthrough(body_open.span.join(body_close.span())));
             let else_body = else_body
                 .map(|(_, p)| p)
-                .unwrap_or(Process::Fallthrough(else_open.span.join(else_close.span())));
+                .unwrap_or(Process::fallthrough(else_open.span.join(else_close.span())));
             let span = kw.span.join(close.span());
             (
                 span.clone(),
-                Process::Poll {
+                ProcessHead::Terminator(ProcessTerminator::Poll {
                     span,
                     label,
                     clients,
                     name,
                     then: Box::new(then),
                     else_: Box::new(else_body),
-                },
+                }),
             )
         },
     )
     .parse_next(input)
 }
 
-fn proc_repoll(input: &mut Input) -> Result<(Span, Process<Unresolved>)> {
+fn proc_repoll(input: &mut Input) -> Result<(Span, ProcessHead)> {
     commit_after(
         t(TokenKind::Repoll),
         (
@@ -3205,28 +3465,28 @@ fn proc_repoll(input: &mut Input) -> Result<(Span, Process<Unresolved>)> {
         )| {
             let then = then
                 .map(|(_, p)| p)
-                .unwrap_or(Process::Fallthrough(body_open.span.join(body_close.span())));
+                .unwrap_or(Process::fallthrough(body_open.span.join(body_close.span())));
             let else_body = else_body
                 .map(|(_, p)| p)
-                .unwrap_or(Process::Fallthrough(else_open.span.join(else_close.span())));
+                .unwrap_or(Process::fallthrough(else_open.span.join(else_close.span())));
             let span = kw.span.join(close.span());
             (
                 span.clone(),
-                Process::Repoll {
+                ProcessHead::Terminator(ProcessTerminator::Repoll {
                     span,
                     label,
                     clients,
                     name,
                     then: Box::new(then),
                     else_: Box::new(else_body),
-                },
+                }),
             )
         },
     )
     .parse_next(input)
 }
 
-fn proc_submit(input: &mut Input) -> Result<(Span, Process<Unresolved>)> {
+fn proc_submit(input: &mut Input) -> Result<(Span, ProcessHead)> {
     commit_after(
         t(TokenKind::Submit),
         (
@@ -3240,21 +3500,21 @@ fn proc_submit(input: &mut Input) -> Result<(Span, Process<Unresolved>)> {
         let span = kw.span.join(close.span());
         (
             span.clone(),
-            Process::Submit {
+            ProcessHead::Terminator(ProcessTerminator::Submit {
                 span,
                 label,
                 values,
-            },
+            }),
         )
     })
     .parse_next(input)
 }
 
-fn proc_if(input: &mut Input) -> Result<(Span, Process<Unresolved>)> {
+fn proc_if(input: &mut Input) -> Result<(Span, ProcessHead)> {
     alt((proc_if_inline, proc_if_block)).parse_next(input)
 }
 
-fn proc_if_block(input: &mut Input) -> Result<(Span, Process<Unresolved>)> {
+fn proc_if_block(input: &mut Input) -> Result<(Span, ProcessHead)> {
     commit_after(
         (t(TokenKind::If), t(TokenKind::LCurly)),
         (
@@ -3265,24 +3525,18 @@ fn proc_if_block(input: &mut Input) -> Result<(Span, Process<Unresolved>)> {
                 opt(t(TokenKind::Comma)),
             )),
             t(TokenKind::RCurly),
-            opt(pass_process),
         ),
     )
-    .map(|((kw, open), (branches, else_body, close, then_process))| {
+    .map(|((kw, open), (branches, else_body, close))| {
         let span = kw.span.join(close.span());
-        let full_span = match &then_process {
-            Some((then_full_span, _)) => kw.span.join(then_full_span.clone()),
-            None => span.clone(),
-        };
         (
-            full_span,
-            Process::If {
+            span.clone(),
+            ProcessHead::If {
                 span,
                 branches,
                 else_: else_body.map(|(_, body, _)| {
-                    Box::new(body.unwrap_or(Process::Fallthrough(open.span.only_end())))
+                    Box::new(body.unwrap_or(Process::fallthrough(open.span.only_end())))
                 }),
-                then: then_process.map(|(_, p)| Box::new(p)),
             },
         )
     })
@@ -3302,7 +3556,7 @@ fn proc_if_branch(input: &mut Input) -> Result<(Condition<Unresolved>, Process<U
             (
                 condition,
                 body.map(|(_, p)| p)
-                    .unwrap_or(Process::Fallthrough(open.span.join(close.span()))),
+                    .unwrap_or(Process::fallthrough(open.span.join(close.span()))),
             )
         })
         .parse_next(input)
@@ -3317,13 +3571,13 @@ fn proc_if_else_body(input: &mut Input) -> Result<Option<Process<Unresolved>>> {
     )
         .map(|(_, open, body, close)| {
             body.map(|(_, p)| p)
-                .unwrap_or(Process::Fallthrough(open.span.join(close.span())))
+                .unwrap_or(Process::fallthrough(open.span.join(close.span())))
         })
         .map(Some)
         .parse_next(input)
 }
 
-fn proc_if_inline(input: &mut Input) -> Result<(Span, Process<Unresolved>)> {
+fn proc_if_inline(input: &mut Input) -> Result<(Span, ProcessHead)> {
     (
         t(TokenKind::If),
         alt((
@@ -3335,68 +3589,80 @@ fn proc_if_inline(input: &mut Input) -> Result<(Span, Process<Unresolved>)> {
         t(TokenKind::LCurly),
         opt(process),
         t(TokenKind::RCurly),
-        opt(pass_process),
     )
-        .map(|(kw, condition, _, open, then_proc, close, else_process)| {
-            let (tail_full_span, tail_proc) = match else_process {
-                Some((full_span, p)) => (full_span, p),
-                None => {
-                    let s = close.span().only_end();
-                    (s.clone(), Process::Fallthrough(s))
-                }
-            };
-            let span = kw.span.join(tail_proc.span());
-            let full_span = kw.span.join(tail_full_span);
+        .map(|(kw, condition, _, open, then_proc, close)| {
+            let span = kw.span.join(close.span());
             (
-                full_span,
-                Process::If {
+                span.clone(),
+                ProcessHead::If {
                     span,
                     branches: vec![(
                         condition,
                         then_proc
                             .map(|(_, p)| p)
-                            .unwrap_or(Process::Fallthrough(open.span.join(close.span()))),
+                            .unwrap_or(Process::fallthrough(open.span.join(close.span()))),
                     )],
-                    else_: Some(Box::new(Process::Fallthrough(close.span().only_end()))),
-                    then: Some(Box::new(tail_proc)),
+                    else_: Some(Box::new(Process::fallthrough(close.span().only_end()))),
                 },
             )
         })
         .parse_next(input)
 }
 
-fn global_command(input: &mut Input) -> Result<(Span, Process<Unresolved>)> {
+fn global_command(input: &mut Input) -> Result<(Span, ProcessHead)> {
     (global_name, cmd)
         .map(|(name, cmd)| match cmd {
             Some((full_span, cmd)) => {
                 let span = name.span.join(full_span);
-                (span.clone(), Process::GlobalCommand(span, name, cmd))
+                (
+                    span.clone(),
+                    ProcessHead::Command(ProcessCommand {
+                        span,
+                        target: CommandTarget::Global(name),
+                        command: cmd,
+                    }),
+                )
             }
             None => {
                 let span = name.span();
                 let noop_span = name.span.only_end();
                 (
                     span.clone(),
-                    Process::GlobalCommand(span, name, noop_cmd(noop_span)),
+                    ProcessHead::Command(ProcessCommand {
+                        span,
+                        target: CommandTarget::Global(name),
+                        command: noop_cmd(noop_span),
+                    }),
                 )
             }
         })
         .parse_next(input)
 }
 
-fn command(input: &mut Input) -> Result<(Span, Process<Unresolved>)> {
+fn command(input: &mut Input) -> Result<(Span, ProcessHead)> {
     (local_name, cmd)
         .map(|(name, cmd)| match cmd {
             Some((full_span, cmd)) => {
                 let span = name.span.join(full_span);
-                (span.clone(), Process::Command(span, name, cmd))
+                (
+                    span.clone(),
+                    ProcessHead::Command(ProcessCommand {
+                        span,
+                        target: CommandTarget::Local(name),
+                        command: cmd,
+                    }),
+                )
             }
             None => {
                 let span = name.span();
                 let noop_span = name.span.only_end();
                 (
                     span.clone(),
-                    Process::Command(span, name, noop_cmd(noop_span)),
+                    ProcessHead::Command(ProcessCommand {
+                        span,
+                        target: CommandTarget::Local(name),
+                        command: noop_cmd(noop_span),
+                    }),
                 )
             }
         })
@@ -3404,108 +3670,153 @@ fn command(input: &mut Input) -> Result<(Span, Process<Unresolved>)> {
 }
 
 fn noop_cmd(span: Span) -> Command<Unresolved> {
-    Command::Then(Box::new(Process::Fallthrough(span)))
+    Command {
+        steps: Vec::new(),
+        terminator: CommandTerminator::Then(span),
+    }
+}
+
+fn command_accepts_process_tail(command: &Command<Unresolved>) -> bool {
+    match &command.terminator {
+        CommandTerminator::Then(_) | CommandTerminator::Case(..) => true,
+        CommandTerminator::Begin { body, .. } => command_accepts_process_tail(body),
+        CommandTerminator::Link(..) | CommandTerminator::Break(_) | CommandTerminator::Loop(..) => {
+            false
+        }
+    }
 }
 
 fn cmd(input: &mut Input) -> Result<Option<(Span, Command<Unresolved>)>> {
-    alt((
-        alt((
+    let mut steps = Vec::new();
+    let mut span: Option<Span> = None;
+    loop {
+        let piece = opt(alt((
             cmd_link,
-            cmd_signal,
             cmd_case,
             cmd_break,
-            cmd_continue,
             cmd_begin,
             cmd_unfounded,
             cmd_loop,
+            cmd_signal,
+            cmd_continue,
             cmd_send,
             cmd_receive,
             cmd_generic_receive,
             cmd_try,
             cmd_default,
             cmd_pipe,
-        ))
-        .map(Some),
-        cmd_then,
-    ))
-    .context(StrContext::Label("command"))
-    .parse_next(input)
+        )))
+        .context(StrContext::Label("command"))
+        .parse_next(input)?;
+        match piece {
+            Some(CommandPiece::Steps(piece_span, mut piece_steps)) => {
+                let continues_process =
+                    matches!(piece_steps.last(), Some(CommandStep::Continue(_)));
+                span = Some(match span {
+                    Some(span) => span.join(piece_span),
+                    None => piece_span,
+                });
+                steps.append(&mut piece_steps);
+                if continues_process {
+                    let span = span.expect("command has a span after a parsed step");
+                    let end = span.only_end();
+                    return Ok(Some((
+                        span,
+                        Command {
+                            steps,
+                            terminator: CommandTerminator::Then(end),
+                        },
+                    )));
+                }
+            }
+            Some(CommandPiece::Terminator(piece_span, terminator)) => {
+                let full_span = match span {
+                    Some(span) => span.join(piece_span),
+                    None => piece_span,
+                };
+                return Ok(Some((full_span, Command { steps, terminator })));
+            }
+            None => {
+                return Ok(span.map(|span| {
+                    let end = span.only_end();
+                    (
+                        span,
+                        Command {
+                            steps,
+                            terminator: CommandTerminator::Then(end),
+                        },
+                    )
+                }));
+            }
+        }
+    }
 }
 
-fn cmd_then(input: &mut Input) -> Result<Option<(Span, Command<Unresolved>)>> {
-    (opt(t(TokenKind::Semicolon)), opt(process))
-        .map(|(_, opt)| {
-            opt.map(|(full_span, process)| (full_span, Command::Then(Box::new(process))))
-        })
-        .parse_next(input)
+enum CommandPiece {
+    Steps(Span, Vec<CommandStep<Unresolved>>),
+    Terminator(Span, CommandTerminator<Unresolved>),
 }
 
-fn cmd_link(input: &mut Input) -> Result<(Span, Command<Unresolved>)> {
+fn cmd_link(input: &mut Input) -> Result<CommandPiece> {
     commit_after(t(TokenKind::Link), expression)
         .map(|(token, expression)| {
             let span = token.span.join(expression.span());
-            (span.clone(), Command::Link(span, Box::new(expression)))
+            CommandPiece::Terminator(
+                span.clone(),
+                CommandTerminator::Link(span, Box::new(expression)),
+            )
         })
         .parse_next(input)
 }
 
-fn cmd_send(input: &mut Input) -> Result<(Span, Command<Unresolved>)> {
+fn cmd_send(input: &mut Input) -> Result<CommandPiece> {
     commit_after(
         t(TokenKind::LParen),
         (
             list1(|input: &mut Input| send_prefix_item(TokenKind::RParen, input)),
             t(TokenKind::RParen),
-            cmd,
         ),
     )
-    .map(|(open, (items, close, cmd))| {
-        let (cmd_full_span, cmd) = match cmd {
-            Some((span, cmd)) => (span, cmd),
-            None => {
-                let s = close.span.only_end();
-                (s.clone(), noop_cmd(s))
-            }
-        };
+    .map(|(open, (items, close))| {
         let short_span = open.span.join(close.span());
-        let full_span = open.span.join(cmd_full_span);
-        let cmd = fold_send_prefix(
-            items,
-            cmd,
-            |typ, cmd| Command::SendType(short_span.clone(), typ, Box::new(cmd)),
-            |expression, cmd| Command::Send(short_span.clone(), expression, Box::new(cmd)),
-        );
-        (full_span, cmd)
+        let steps = items
+            .into_iter()
+            .map(|item| match item {
+                SendPrefixItem::Explicit(typ) => CommandStep::SendType(short_span.clone(), typ),
+                SendPrefixItem::Value(expression) => {
+                    CommandStep::Send(short_span.clone(), expression)
+                }
+            })
+            .collect();
+        CommandPiece::Steps(short_span, steps)
     })
     .parse_next(input)
 }
 
-fn cmd_receive(input: &mut Input) -> Result<(Span, Command<Unresolved>)> {
+fn cmd_receive(input: &mut Input) -> Result<CommandPiece> {
     commit_after(
         t(TokenKind::LBrack),
-        (list1(pattern_prefix_item), t(TokenKind::RBrack), cmd),
+        (list1(pattern_prefix_item), t(TokenKind::RBrack)),
     )
-    .map(|(open, (items, close, cmd))| {
-        let (cmd_full_span, cmd) = match cmd {
-            Some((span, cmd)) => (span, cmd),
-            None => {
-                let s = close.span.only_end();
-                (s.clone(), noop_cmd(s))
-            }
-        };
+    .map(|(open, (items, close))| {
         let short_span = open.span.join(close.span());
-        let full_span = open.span.join(cmd_full_span);
-        let cmd = fold_pattern_prefix(
-            items,
-            cmd,
-            |name, cmd| Command::ReceiveType(short_span.clone(), name, Box::new(cmd)),
-            |pattern, cmd| Command::Receive(short_span.clone(), pattern, Box::new(cmd), vec![]),
-        );
-        (full_span, cmd)
+        let steps = items
+            .into_iter()
+            .map(|item| match item {
+                PatternPrefixItem::Explicit(name) => {
+                    CommandStep::ReceiveType(short_span.clone(), name)
+                }
+                PatternPrefixItem::Value(pattern) => {
+                    CommandStep::Receive(short_span.clone(), pattern, vec![])
+                }
+            })
+            .collect();
+        CommandPiece::Steps(short_span, steps)
     })
     .parse_next(input)
 }
 
-fn cmd_generic_receive(input: &mut Input) -> Result<(Span, Command<Unresolved>)> {
+fn cmd_generic_receive(input: &mut Input) -> Result<CommandPiece> {
     commit_after(
         t(TokenKind::Lt),
         (
@@ -3514,100 +3825,67 @@ fn cmd_generic_receive(input: &mut Input) -> Result<(Span, Command<Unresolved>)>
             t(TokenKind::LBrack),
             pattern,
             t(TokenKind::RBrack),
-            cmd,
         ),
     )
     .map(
-        |(vars_open, (vars, _vars_close, _pattern_open, arg, pattern_close, cmd))| {
-            let (cmd_full_span, cmd) = match cmd {
-                Some((span, cmd)) => (span, cmd),
-                None => {
-                    let s = pattern_close.span.only_end();
-                    (s.clone(), noop_cmd(s))
-                }
-            };
+        |(vars_open, (vars, _vars_close, _pattern_open, arg, pattern_close))| {
             let short_span = vars_open.span.join(pattern_close.span());
-            let full_span = vars_open.span.join(cmd_full_span);
-            (
-                full_span,
-                Command::Receive(short_span, arg, Box::new(cmd), vars),
+            CommandPiece::Steps(
+                short_span.clone(),
+                vec![CommandStep::Receive(short_span, arg, vars)],
             )
         },
     )
     .parse_next(input)
 }
 
-fn cmd_signal(input: &mut Input) -> Result<(Span, Command<Unresolved>)> {
-    (t(TokenKind::Dot), (local_name, cmd))
-        .map(|(pre, (name, cmd))| {
-            let (cmd_full_span, cmd) = match cmd {
-                Some((span, cmd)) => (span, cmd),
-                None => {
-                    let s = name.span.only_end();
-                    (s.clone(), noop_cmd(s))
-                }
-            };
+fn cmd_signal(input: &mut Input) -> Result<CommandPiece> {
+    (t(TokenKind::Dot), local_name)
+        .map(|(pre, name)| {
             let short_span = pre.span.join(name.span());
-            let full_span = pre.span.join(cmd_full_span);
-            (full_span, Command::Signal(short_span, name, Box::new(cmd)))
+            CommandPiece::Steps(
+                short_span.clone(),
+                vec![CommandStep::Signal(short_span, name)],
+            )
         })
         .parse_next(input)
 }
 
-fn cmd_case(input: &mut Input) -> Result<(Span, Command<Unresolved>)> {
+fn cmd_case(input: &mut Input) -> Result<CommandPiece> {
     commit_after(
         (t(TokenKind::Dot), t(TokenKind::Case)),
-        (branches_body(cmd_branch), opt(pass_process)),
+        branches_body(cmd_branch),
     )
-    .map(
-        |((pre, case_kw), ((branches_span, branches, else_branch), pass_process))| {
-            let full_span = match &pass_process {
-                Some((ps_full_span, _)) => pre.span.join(ps_full_span.clone()),
-                None => pre.span.join(branches_span),
-            };
-            let short_span = pre.span.join(case_kw.span());
-            (
-                full_span,
-                Command::Case(
-                    short_span,
-                    CommandBranches(branches),
-                    else_branch,
-                    pass_process.map(|(_, p)| Box::new(p)),
-                ),
-            )
-        },
-    )
+    .map(|((pre, case_kw), (branches_span, branches, else_branch))| {
+        let full_span = pre.span.join(branches_span);
+        let short_span = pre.span.join(case_kw.span());
+        CommandPiece::Terminator(
+            full_span,
+            CommandTerminator::Case(short_span, CommandBranches(branches), else_branch),
+        )
+    })
     .parse_next(input)
 }
 
-fn cmd_break(input: &mut Input) -> Result<(Span, Command<Unresolved>)> {
+fn cmd_break(input: &mut Input) -> Result<CommandPiece> {
     t(TokenKind::Bang)
         .map(|token| {
             let span = token.span();
-            (span.clone(), Command::Break(span))
+            CommandPiece::Terminator(span.clone(), CommandTerminator::Break(span))
         })
         .parse_next(input)
 }
 
-fn cmd_continue(input: &mut Input) -> Result<(Span, Command<Unresolved>)> {
-    (t(TokenKind::Quest), opt(process))
-        .map(|(token, process)| match process {
-            Some((full_span, process)) => {
-                let span = token.span.join(full_span);
-                (span.clone(), Command::Continue(span, Box::new(process)))
-            }
-            None => {
-                let span = token.span();
-                (
-                    span.clone(),
-                    Command::Continue(span, Box::new(Process::Fallthrough(token.span.only_end()))),
-                )
-            }
+fn cmd_continue(input: &mut Input) -> Result<CommandPiece> {
+    t(TokenKind::Quest)
+        .map(|token| {
+            let span = token.span();
+            CommandPiece::Steps(span.clone(), vec![CommandStep::Continue(span)])
         })
         .parse_next(input)
 }
 
-fn cmd_begin(input: &mut Input) -> Result<(Span, Command<Unresolved>)> {
+fn cmd_begin(input: &mut Input) -> Result<CommandPiece> {
     commit_after((t(TokenKind::Dot), t(TokenKind::Begin)), (label, cmd))
         .map(|((pre, begin_kw), (label, cmd))| {
             let (cmd_full_span, cmd) = match (&label, cmd) {
@@ -3626,20 +3904,21 @@ fn cmd_begin(input: &mut Input) -> Result<(Span, Command<Unresolved>)> {
                 None => pre.span.join(begin_kw.span()),
             };
             let full_span = pre.span.join(cmd_full_span);
-            (
+            CommandPiece::Terminator(
                 full_span,
-                Command::Begin {
+                CommandTerminator::Begin {
                     span: short_span,
                     unfounded: false,
                     label,
-                    then: Box::new(cmd),
+                    body: Box::new(cmd),
+                    continuation: None,
                 },
             )
         })
         .parse_next(input)
 }
 
-fn cmd_unfounded(input: &mut Input) -> Result<(Span, Command<Unresolved>)> {
+fn cmd_unfounded(input: &mut Input) -> Result<CommandPiece> {
     commit_after((t(TokenKind::Dot), t(TokenKind::Unfounded)), (label, cmd))
         .map(|((pre, unfounded_kw), (label, cmd))| {
             let (cmd_full_span, cmd) = match (&label, cmd) {
@@ -3658,52 +3937,48 @@ fn cmd_unfounded(input: &mut Input) -> Result<(Span, Command<Unresolved>)> {
                 None => pre.span.join(unfounded_kw.span()),
             };
             let full_span = pre.span.join(cmd_full_span);
-            (
+            CommandPiece::Terminator(
                 full_span,
-                Command::Begin {
+                CommandTerminator::Begin {
                     span: short_span,
                     unfounded: true,
                     label,
-                    then: Box::new(cmd),
+                    body: Box::new(cmd),
+                    continuation: None,
                 },
             )
         })
         .parse_next(input)
 }
 
-fn cmd_loop(input: &mut Input) -> Result<(Span, Command<Unresolved>)> {
+fn cmd_loop(input: &mut Input) -> Result<CommandPiece> {
     commit_after((t(TokenKind::Dot), t(TokenKind::Loop)), label)
         .map(|((pre1, pre2), label)| {
             let span = match &label {
                 Some(label) => pre1.span.join(label.span()),
                 None => pre1.span.join(pre2.span()),
             };
-            (span.clone(), Command::Loop(span, label))
+            CommandPiece::Terminator(span.clone(), CommandTerminator::Loop(span, label))
         })
         .parse_next(input)
 }
 
-fn cmd_try(input: &mut Input) -> Result<(Span, Command<Unresolved>)> {
-    (t(TokenKind::Dot), (t(TokenKind::Try), label, cmd))
-        .map(|(dot, (try_kw, label, cmd))| {
-            let (cmd_full_span, cmd) = match cmd {
-                Some((span, cmd)) => (span, cmd),
-                None => {
-                    let s = try_kw.span.only_end();
-                    (s.clone(), noop_cmd(s))
-                }
-            };
+fn cmd_try(input: &mut Input) -> Result<CommandPiece> {
+    (t(TokenKind::Dot), (t(TokenKind::Try), label))
+        .map(|(dot, (try_kw, label))| {
             let short_span = match &label {
                 Some(label) => dot.span.join(label.span()),
                 None => dot.span.join(try_kw.span()),
             };
-            let full_span = dot.span.join(cmd_full_span);
-            (full_span, Command::Try(short_span, label, Box::new(cmd)))
+            CommandPiece::Steps(
+                short_span.clone(),
+                vec![CommandStep::Try(short_span, label)],
+            )
         })
         .parse_next(input)
 }
 
-fn cmd_default(input: &mut Input) -> Result<(Span, Command<Unresolved>)> {
+fn cmd_default(input: &mut Input) -> Result<CommandPiece> {
     (
         t(TokenKind::Dot),
         (
@@ -3711,92 +3986,82 @@ fn cmd_default(input: &mut Input) -> Result<(Span, Command<Unresolved>)> {
             t(TokenKind::LParen),
             expression,
             t(TokenKind::RParen),
-            cmd,
         ),
     )
-        .map(|(dot, (_, _, expr, close, cmd))| {
-            let (cmd_full_span, cmd) = match cmd {
-                Some((span, cmd)) => (span, cmd),
-                None => {
-                    let s = close.span.only_end();
-                    (s.clone(), noop_cmd(s))
-                }
-            };
+        .map(|(dot, (_, _, expr, close))| {
             let short_span = dot.span.join(close.span());
-            let full_span = dot.span.join(cmd_full_span);
-            (
-                full_span,
-                Command::Default(short_span, Box::new(expr), Box::new(cmd)),
+            CommandPiece::Steps(
+                short_span.clone(),
+                vec![CommandStep::Default(short_span, Box::new(expr))],
             )
         })
         .parse_next(input)
 }
 
-fn cmd_pipe(input: &mut Input) -> Result<(Span, Command<Unresolved>)> {
+fn cmd_pipe(input: &mut Input) -> Result<CommandPiece> {
     commit_after(
         t(TokenKind::ThinArrow),
-        (
-            alt((
-                global_name.map(|name| Expression::Global(name.span(), name)),
-                local_name.map(|name| Expression::Variable(name.span(), name)),
-                expr_grouped,
-            )),
-            cmd,
-        ),
+        alt((
+            global_name.map(|name| Expression::Global(name.span(), name)),
+            local_name.map(|name| Expression::Variable(name.span(), name)),
+            expr_grouped,
+        )),
     )
-    .map(|(pre, (function, cmd))| {
-        let (cmd_full_span, cmd) = match cmd {
-            Some((span, cmd)) => (span, cmd),
-            None => {
-                let s = function.span().only_end();
-                (s.clone(), noop_cmd(s))
-            }
-        };
+    .map(|(pre, function)| {
         let short_span = pre.span.join(function.span());
-        let full_span = pre.span.join(cmd_full_span);
-        (
-            full_span,
-            Command::Pipe(short_span, Box::new(function), Box::new(cmd)),
+        CommandPiece::Steps(
+            short_span.clone(),
+            vec![CommandStep::Pipe(short_span, Box::new(function))],
         )
     })
     .parse_next(input)
 }
 
-fn pass_process(input: &mut Input) -> Result<(Span, Process<Unresolved>)> {
-    alt((proc_if, proc_let, global_command, command)).parse_next(input)
-}
-
 fn cmd_branch(input: &mut Input) -> Result<CommandBranch<Unresolved>> {
-    alt((
-        cmd_branch_then,
-        cmd_branch_bind_then,
-        cmd_branch_continue,
-        cmd_branch_receive,
-        cmd_branch_generic_receive,
-        cmd_branch_try,
-        cmd_branch_default,
-    ))
-    .parse_next(input)
+    let mut steps = Vec::new();
+    loop {
+        match alt((
+            cmd_branch_then,
+            cmd_branch_bind_then,
+            cmd_branch_continue,
+            cmd_branch_receive,
+            cmd_branch_generic_receive,
+            cmd_branch_try,
+            cmd_branch_default,
+        ))
+        .parse_next(input)?
+        {
+            CommandBranchPiece::Steps(mut parsed) => steps.append(&mut parsed),
+            CommandBranchPiece::Terminator(terminator) => {
+                return Ok(CommandBranch { steps, terminator });
+            }
+        }
+    }
 }
 
-fn cmd_branch_then(input: &mut Input) -> Result<CommandBranch<Unresolved>> {
+enum CommandBranchPiece {
+    Steps(Vec<CommandBranchStep<Unresolved>>),
+    Terminator(CommandBranchTerminator<Unresolved>),
+}
+
+fn cmd_branch_then(input: &mut Input) -> Result<CommandBranchPiece> {
     commit_after(
         t(TokenKind::FatArrow),
         (t(TokenKind::LCurly), opt(process), t(TokenKind::RCurly)),
     )
     .map(|(pre, (open, process, close))| {
-        CommandBranch::Then(
+        CommandBranchPiece::Terminator(CommandBranchTerminator::Then(
             pre.span.join(close.span()),
             match process {
                 Some((_, process)) => process,
-                None => Process::Fallthrough(open.span.only_end()),
+                None => Process::fallthrough(open.span.only_end()),
             },
-        )
+        ))
     })
     .parse_next(input)
 }
 
-fn cmd_branch_bind_then(input: &mut Input) -> Result<CommandBranch<Unresolved>> {
+fn cmd_branch_bind_then(input: &mut Input) -> Result<CommandBranchPiece> {
     (
         local_name,
         cut_err((
@@ -3805,36 +4070,43 @@ fn cmd_branch_bind_then(input: &mut Input) -> Result<CommandBranch<Unresolved>> 
         )),
     )
         .map(|(name, (pre, (open, process, close)))| {
-            CommandBranch::BindThen(
+            CommandBranchPiece::Terminator(CommandBranchTerminator::BindThen(
                 pre.span.join(close.span()),
                 name,
                 match process {
                     Some((_, process)) => process,
-                    None => Process::Fallthrough(open.span.only_end()),
+                    None => Process::fallthrough(open.span.only_end()),
                 },
-            )
+            ))
         })
         .parse_next(input)
 }
 
-fn cmd_branch_receive(input: &mut Input) -> Result<CommandBranch<Unresolved>> {
+fn cmd_branch_receive(input: &mut Input) -> Result<CommandBranchPiece> {
     commit_after(
         t(TokenKind::LParen),
-        (list1(pattern_prefix_item), t(TokenKind::RParen), cmd_branch),
+        (list1(pattern_prefix_item), t(TokenKind::RParen)),
     )
-    .map(|(open, (items, _close, rest))| {
-        let span = open.span.join(rest.span());
-        fold_pattern_prefix(
-            items,
-            rest,
-            |name, rest| CommandBranch::ReceiveType(span.clone(), name, Box::new(rest)),
-            |pattern, rest| CommandBranch::Receive(span.clone(), pattern, Box::new(rest), vec![]),
+    .map(|(open, (items, close))| {
+        let span = open.span.join(close.span());
+        CommandBranchPiece::Steps(
+            items
+                .into_iter()
+                .map(|item| match item {
+                    PatternPrefixItem::Explicit(name) => {
+                        CommandBranchStep::ReceiveType(span.clone(), name)
+                    }
+                    PatternPrefixItem::Value(pattern) => {
+                        CommandBranchStep::Receive(span.clone(), pattern, vec![])
+                    }
+                })
+                .collect(),
         )
     })
     .parse_next(input)
 }
 
-fn cmd_branch_generic_receive(input: &mut Input) -> Result<CommandBranch<Unresolved>> {
+fn cmd_branch_generic_receive(input: &mut Input) -> Result<CommandBranchPiece> {
     commit_after(
         t(TokenKind::Lt),
         (
@@ -3843,19 +4115,18 @@ fn cmd_branch_generic_receive(input: &mut Input) -> Result<CommandBranch<Unresol
             t(TokenKind::LParen),
             pattern,
             t(TokenKind::RParen),
-            cmd_branch,
         ),
     )
     .map(
-        |(vars_open, (vars, _vars_close, _pattern_open, arg, _pattern_close, rest))| {
-            let span = vars_open.span.join(rest.span());
-            CommandBranch::Receive(span.clone(), arg, Box::new(rest), vars)
+        |(vars_open, (vars, _vars_close, _pattern_open, arg, pattern_close))| {
+            let span = vars_open.span.join(pattern_close.span());
+            CommandBranchPiece::Steps(vec![CommandBranchStep::Receive(span, arg, vars)])
         },
     )
     .parse_next(input)
 }
 
-fn cmd_branch_continue(input: &mut Input) -> Result<CommandBranch<Unresolved>> {
+fn cmd_branch_continue(input: &mut Input) -> Result<CommandBranchPiece> {
     commit_after(
         t(TokenKind::Bang),
         (
@@ -3866,32 +4137,39 @@ fn cmd_branch_continue(input: &mut Input) -> Result<CommandBranch<Unresolved>> {
         ),
     )
     .map(|(token, (_, open, process, close))| {
-        CommandBranch::Continue(
+        CommandBranchPiece::Terminator(CommandBranchTerminator::Continue(
             token.span.join(close.span()),
             match process {
                 Some((_, process)) => process,
-                None => Process::Fallthrough(open.span.only_end()),
+                None => Process::fallthrough(open.span.only_end()),
             },
-        )
+        ))
     })
     .parse_next(input)
 }
 
-fn cmd_branch_try(input: &mut Input) -> Result<CommandBranch<Unresolved>> {
-    commit_after(t(TokenKind::Try), (label, cmd_branch))
-        .map(|(kw, (label, rest))| {
-            CommandBranch::Try(kw.span.join(rest.span()), label, Box::new(rest))
+fn cmd_branch_try(input: &mut Input) -> Result<CommandBranchPiece> {
+    commit_after(t(TokenKind::Try), label)
+        .map(|(kw, label)| {
+            let span = match &label {
+                Some(label) => kw.span.join(label.span()),
+                None => kw.span(),
+            };
+            CommandBranchPiece::Steps(vec![CommandBranchStep::Try(span, label)])
         })
         .parse_next(input)
 }
 
-fn cmd_branch_default(input: &mut Input) -> Result<CommandBranch<Unresolved>> {
+fn cmd_branch_default(input: &mut Input) -> Result<CommandBranchPiece> {
     commit_after(
         (t(TokenKind::Default), t(TokenKind::LParen)),
-        (expression, t(TokenKind::RParen), cmd_branch),
+        (expression, t(TokenKind::RParen)),
     )
-    .map(|((kw, _), (expr, _close, rest))| {
-        CommandBranch::Default(kw.span.join(rest.span()), Box::new(expr), Box::new(rest))
+    .map(|((kw, _), (expr, close))| {
+        CommandBranchPiece::Steps(vec![CommandBranchStep::Default(
+            kw.span.join(close.span()),
+            Box::new(expr),
+        )])
     })
     .parse_next(input)
 }
@@ -3949,6 +4227,58 @@ mod test {
 
         let inline_program = "def IfInline: ! = chan exit { if .true! => { exit! } exit! }";
         assert!(parse_module(inline_program, "if_inline.par".into()).is_ok());
+    }
+
+    #[test]
+    fn test_process_semicolons_are_consistent() {
+        for source in [
+            "def X = do { let x = 1; let y = 2 } in !",
+            "def X = do { value.next; exit!; } in !",
+            "def X = do { exit!; } in !",
+            "def X = do { exit <> !; } in !",
+            "def X = do { value.loop; } in !",
+            "def X = do { submit(); } in !",
+            "def X = do { throw 1; } in !",
+        ] {
+            assert!(
+                parse_module(source, "semicolons.par".into()).is_ok(),
+                "failed to parse: {source}"
+            );
+        }
+
+        assert!(
+            parse_module(
+                "def X = do { exit!; let unreachable = 1 } in !",
+                "terminal.par".into(),
+            )
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn parses_long_flat_process_and_command_sequences() {
+        const STEP_COUNT: usize = 20_000;
+
+        let lets = "let x = 0; ".repeat(STEP_COUNT);
+        let source = format!("def X = do {{ {lets}exit! }} in !");
+        let parsed = parse_source_file(&source, "long_process.par".into()).unwrap();
+        let DefinitionBody::Par(Expression::Do { process, .. }) = &parsed.body.definitions[0].body
+        else {
+            panic!("expected do expression")
+        };
+        assert_eq!(process.steps.len(), STEP_COUNT);
+
+        let signals = ".next".repeat(STEP_COUNT);
+        let source = format!("def X = do {{ value{signals}! }} in !");
+        let parsed = parse_source_file(&source, "long_command.par".into()).unwrap();
+        let DefinitionBody::Par(Expression::Do { process, .. }) = &parsed.body.definitions[0].body
+        else {
+            panic!("expected do expression")
+        };
+        let ProcessTerminator::Command(ProcessCommand { command, .. }) = &process.terminator else {
+            panic!("expected command terminator")
+        };
+        assert_eq!(command.steps.len(), STEP_COUNT);
     }
 
     #[test]
@@ -4134,11 +4464,15 @@ def UseNeg = let neg = 2 in neg
         assert!(matches!(
             &parsed.body.definitions[0].body,
             DefinitionBody::Par(Expression::Let {
-                pattern: Pattern::Name(_, LocalName { string, .. }, _),
+                pattern: Pattern {
+                    steps,
+                    terminal: PatternTerminal::Name(_, LocalName { string, .. }, _),
+                },
                 then,
                 ..
             })
-                if string.as_str() == "not"
+                if steps.is_empty()
+                    && string.as_str() == "not"
                     && matches!(
                         **then,
                         Expression::Variable(_, LocalName { ref string, .. })
@@ -4148,11 +4482,15 @@ def UseNeg = let neg = 2 in neg
         assert!(matches!(
             &parsed.body.definitions[1].body,
             DefinitionBody::Par(Expression::Let {
-                pattern: Pattern::Name(_, LocalName { string, .. }, _),
+                pattern: Pattern {
+                    steps,
+                    terminal: PatternTerminal::Name(_, LocalName { string, .. }, _),
+                },
                 then,
                 ..
             })
-                if string.as_str() == "neg"
+                if steps.is_empty()
+                    && string.as_str() == "neg"
                     && matches!(
                         **then,
                         Expression::Variable(_, LocalName { ref string, .. })

--- a/crates/par-core/src/frontend_impl/process.rs
+++ b/crates/par-core/src/frontend_impl/process.rs
@@ -22,14 +22,24 @@ pub enum PollKind {
 }
 
 #[derive(Clone, Debug)]
-pub enum Process<Typ, S> {
+pub struct Process<Typ, S> {
+    pub steps: Vec<Step<Typ, S>>,
+    pub terminator: Terminator<Typ, S>,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct ProcessBuilder<Typ, S> {
+    steps: Vec<Step<Typ, S>>,
+}
+
+#[derive(Clone, Debug)]
+pub enum Step<Typ, S> {
     Let {
         span: Span,
         name: LocalName,
         annotation: Option<Type<S>>,
         typ: Typ,
         value: Arc<Expression<Typ, S>>,
-        then: Arc<Self>,
     },
     Do {
         span: Span,
@@ -37,6 +47,17 @@ pub enum Process<Typ, S> {
         usage: VariableUsage,
         typ: Typ,
         command: Command<Typ, S>,
+    },
+}
+
+#[derive(Clone, Debug)]
+pub enum Terminator<Typ, S> {
+    Do {
+        span: Span,
+        name: LocalName,
+        usage: VariableUsage,
+        typ: Typ,
+        command: TerminalCommand<Typ, S>,
     },
     Poll {
         span: Span,
@@ -47,8 +68,8 @@ pub enum Process<Typ, S> {
         name: LocalName,
         name_typ: Typ,
         captures: Captures,
-        then: Arc<Self>,
-        else_: Arc<Self>,
+        then: Arc<Process<Typ, S>>,
+        else_: Arc<Process<Typ, S>>,
     },
     Submit {
         span: Span,
@@ -57,31 +78,34 @@ pub enum Process<Typ, S> {
         values: Vec<Arc<Expression<Typ, S>>>,
         captures: Captures,
     },
-    Block(Span, usize, Arc<Self>, Arc<Self>),
+    Block(Span, usize, Arc<Process<Typ, S>>, Arc<Process<Typ, S>>),
     Goto(Span, usize, Captures),
     Unreachable(Span),
 }
 
 #[derive(Clone, Debug)]
 pub enum Command<Typ, S> {
-    Noop(Arc<Process<Typ, S>>),
+    /// Validate and consume a bare command subject before continuing. This has no runtime
+    /// protocol effect, but preserves linearity diagnostics and hover information for source
+    /// command chains of the form `subject; next`.
+    Noop,
+    Send(Arc<Expression<Typ, S>>),
+    Receive(LocalName, Option<Type<S>>, Typ, Vec<TypeParameter>),
+    Signal(LocalName),
+    Continue,
+    SendType(Type<S>),
+    ReceiveType(TypeParameter),
+}
+
+#[derive(Clone, Debug)]
+pub enum TerminalCommand<Typ, S> {
     Link(Arc<Expression<Typ, S>>),
-    Send(Arc<Expression<Typ, S>>, Arc<Process<Typ, S>>),
-    Receive(
-        LocalName,
-        Option<Type<S>>,
-        Typ,
-        Arc<Process<Typ, S>>,
-        Vec<TypeParameter>,
-    ),
-    Signal(LocalName, Arc<Process<Typ, S>>),
     Case(
         Arc<[LocalName]>,
         Box<[Arc<Process<Typ, S>>]>,
         Option<Arc<Process<Typ, S>>>,
     ),
     Break,
-    Continue(Arc<Process<Typ, S>>),
     Begin {
         unfounded: bool,
         label: Option<LocalName>,
@@ -89,8 +113,6 @@ pub enum Command<Typ, S> {
         body: Arc<Process<Typ, S>>,
     },
     Loop(Option<LocalName>, LocalName, Captures),
-    SendType(Type<S>, Arc<Process<Typ, S>>),
-    ReceiveType(TypeParameter, Arc<Process<Typ, S>>),
 }
 
 #[derive(Clone, Debug)]
@@ -113,8 +135,16 @@ pub enum Expression<Typ, S> {
 
 impl<Typ, S> Spanning for Process<Typ, S> {
     fn span(&self) -> Span {
+        match self.steps.first() {
+            Some(Step::Let { span, .. } | Step::Do { span, .. }) => span.clone(),
+            None => self.terminator.span(),
+        }
+    }
+}
+
+impl<Typ, S> Spanning for Terminator<Typ, S> {
+    fn span(&self) -> Span {
         match self {
-            Self::Let { span, .. } => span.clone(),
             Self::Do { span, .. } => span.clone(),
             Self::Poll { span, .. } => span.clone(),
             Self::Submit { span, .. } => span.clone(),
@@ -125,112 +155,247 @@ impl<Typ, S> Spanning for Process<Typ, S> {
     }
 }
 
-impl<S: Clone> Process<(), S> {
-    pub fn optimize(&self) -> Arc<Self> {
-        match self {
-            Self::Let {
+impl<Typ, S> Process<Typ, S> {
+    pub fn new(steps: Vec<Step<Typ, S>>, terminator: Terminator<Typ, S>) -> Self {
+        Self { steps, terminator }
+    }
+
+    pub fn terminal(terminator: Terminator<Typ, S>) -> Arc<Self> {
+        Arc::new(Self::new(Vec::new(), terminator))
+    }
+
+    pub fn prepend(step: Step<Typ, S>, process: Arc<Self>) -> Arc<Self>
+    where
+        Typ: Clone,
+        S: Clone,
+    {
+        let process = Arc::unwrap_or_clone(process);
+        let mut steps = Vec::with_capacity(process.steps.len() + 1);
+        steps.push(step);
+        steps.extend(process.steps);
+        Arc::new(Self::new(steps, process.terminator))
+    }
+
+    pub fn let_step(
+        span: Span,
+        name: LocalName,
+        annotation: Option<Type<S>>,
+        typ: Typ,
+        value: Arc<Expression<Typ, S>>,
+        then: Arc<Self>,
+    ) -> Arc<Self>
+    where
+        Typ: Clone,
+        S: Clone,
+    {
+        Self::prepend(
+            Step::Let {
                 span,
                 name,
                 annotation,
                 typ,
-                value: expression,
-                then: process,
-            } => Arc::new(Self::Let {
-                span: span.clone(),
-                name: name.clone(),
-                annotation: annotation.clone(),
-                typ: typ.clone(),
-                value: expression.optimize(),
-                then: process.optimize(),
-            }),
-            Self::Do {
+                value,
+            },
+            then,
+        )
+    }
+
+    pub fn do_step(
+        span: Span,
+        name: LocalName,
+        usage: VariableUsage,
+        typ: Typ,
+        command: Command<Typ, S>,
+        then: Arc<Self>,
+    ) -> Arc<Self>
+    where
+        Typ: Clone,
+        S: Clone,
+    {
+        Self::prepend(
+            Step::Do {
                 span,
                 name,
                 usage,
                 typ,
                 command,
-            } => Arc::new(Self::Do {
-                span: span.clone(),
-                name: name.clone(),
-                typ: typ.clone(),
-                usage: usage.clone(),
-                command: match command {
-                    Command::Noop(process) => Command::Noop(process.optimize()),
-                    Command::Link(expression) => {
-                        let expression = expression.optimize();
-                        match expression.optimize().as_ref() {
-                            Expression::Chan {
-                                chan_name: channel,
-                                chan_annotation: annotation,
-                                process,
-                                ..
-                            } => {
-                                if name == channel && annotation.is_none() {
-                                    return Arc::clone(process);
-                                } else {
-                                    return Arc::new(Process::Let {
-                                        span: span.clone(),
-                                        name: channel.clone(),
-                                        annotation: annotation.clone(),
-                                        typ: (),
-                                        value: Arc::new(Expression::Variable(
-                                            span.clone(),
-                                            name.clone(),
-                                            (),
-                                            VariableUsage::Unknown,
-                                        )),
-                                        then: Arc::clone(process),
-                                    });
-                                }
-                            }
-                            _ => Command::Link(expression),
-                        }
-                    }
-                    Command::Send(argument, process) => {
-                        Command::Send(argument.optimize(), process.optimize())
-                    }
-                    Command::Receive(parameter, annotation, typ, process, vars) => {
-                        Command::Receive(
+            },
+            then,
+        )
+    }
+
+    pub fn do_terminal(
+        span: Span,
+        name: LocalName,
+        usage: VariableUsage,
+        typ: Typ,
+        command: TerminalCommand<Typ, S>,
+    ) -> Arc<Self> {
+        Self::terminal(Terminator::Do {
+            span,
+            name,
+            usage,
+            typ,
+            command,
+        })
+    }
+}
+
+impl<Typ, S> ProcessBuilder<Typ, S> {
+    pub fn new() -> Self {
+        Self { steps: Vec::new() }
+    }
+
+    pub fn push(&mut self, step: Step<Typ, S>) {
+        self.steps.push(step);
+    }
+
+    pub fn finish(self, terminator: Terminator<Typ, S>) -> Arc<Process<Typ, S>> {
+        Arc::new(Process::new(self.steps, terminator))
+    }
+
+    pub fn finish_with(self, process: Arc<Process<Typ, S>>) -> Arc<Process<Typ, S>>
+    where
+        Typ: Clone,
+        S: Clone,
+    {
+        let process = Arc::unwrap_or_clone(process);
+        let mut steps = self.steps;
+        steps.extend(process.steps);
+        Arc::new(Process::new(steps, process.terminator))
+    }
+}
+
+impl<S: Clone> Process<(), S> {
+    pub fn optimize(&self) -> Arc<Self> {
+        let mut steps = self
+            .steps
+            .iter()
+            .map(|step| match step {
+                Step::Let {
+                    span,
+                    name,
+                    annotation,
+                    typ,
+                    value,
+                } => Step::Let {
+                    span: span.clone(),
+                    name: name.clone(),
+                    annotation: annotation.clone(),
+                    typ: *typ,
+                    value: value.optimize(),
+                },
+                Step::Do {
+                    span,
+                    name,
+                    usage,
+                    typ,
+                    command,
+                } => Step::Do {
+                    span: span.clone(),
+                    name: name.clone(),
+                    usage: usage.clone(),
+                    typ: *typ,
+                    command: match command {
+                        Command::Noop => Command::Noop,
+                        Command::Send(argument) => Command::Send(argument.optimize()),
+                        Command::Receive(parameter, annotation, typ, vars) => Command::Receive(
                             parameter.clone(),
                             annotation.clone(),
-                            typ.clone(),
-                            process.optimize(),
+                            *typ,
                             vars.clone(),
+                        ),
+                        Command::Signal(chosen) => Command::Signal(chosen.clone()),
+                        Command::Continue => Command::Continue,
+                        Command::SendType(argument) => Command::SendType(argument.clone()),
+                        Command::ReceiveType(parameter) => Command::ReceiveType(parameter.clone()),
+                    },
+                },
+            })
+            .collect::<Vec<_>>();
+
+        let terminator = match &self.terminator {
+            Terminator::Do {
+                span,
+                name,
+                usage,
+                typ,
+                command: TerminalCommand::Link(expression),
+            } => {
+                let expression = expression.optimize();
+                if let Expression::Chan {
+                    chan_name: channel,
+                    chan_annotation: annotation,
+                    process,
+                    ..
+                } = expression.as_ref()
+                {
+                    let nested = process.optimize();
+                    if name != channel || annotation.is_some() {
+                        steps.push(Step::Let {
+                            span: span.clone(),
+                            name: channel.clone(),
+                            annotation: annotation.clone(),
+                            typ: (),
+                            value: Arc::new(Expression::Variable(
+                                span.clone(),
+                                name.clone(),
+                                (),
+                                VariableUsage::Unknown,
+                            )),
+                        });
+                    }
+                    let nested = Arc::unwrap_or_clone(nested);
+                    steps.extend(nested.steps);
+                    nested.terminator
+                } else {
+                    Terminator::Do {
+                        span: span.clone(),
+                        name: name.clone(),
+                        usage: usage.clone(),
+                        typ: *typ,
+                        command: TerminalCommand::Link(expression),
+                    }
+                }
+            }
+            Terminator::Do {
+                span,
+                name,
+                usage,
+                typ,
+                command,
+            } => Terminator::Do {
+                span: span.clone(),
+                name: name.clone(),
+                usage: usage.clone(),
+                typ: *typ,
+                command: match command {
+                    TerminalCommand::Link(_) => unreachable!(),
+                    TerminalCommand::Case(branches, processes, else_process) => {
+                        TerminalCommand::Case(
+                            Arc::clone(branches),
+                            processes.iter().map(|p| p.optimize()).collect(),
+                            else_process.as_ref().map(|p| p.optimize()),
                         )
                     }
-                    Command::Signal(chosen, process) => {
-                        Command::Signal(chosen.clone(), process.optimize())
-                    }
-                    Command::Case(branches, processes, else_process) => {
-                        let processes = processes.iter().map(|p| p.optimize()).collect();
-                        let else_process = else_process.clone().map(|p| p.optimize());
-                        Command::Case(Arc::clone(branches), processes, else_process)
-                    }
-                    Command::Break => Command::Break,
-                    Command::Continue(process) => Command::Continue(process.optimize()),
-                    Command::Begin {
+                    TerminalCommand::Break => TerminalCommand::Break,
+                    TerminalCommand::Begin {
                         unfounded,
                         label,
                         captures,
-                        body: process,
-                    } => Command::Begin {
-                        unfounded: unfounded.clone(),
+                        body,
+                    } => TerminalCommand::Begin {
+                        unfounded: *unfounded,
                         label: label.clone(),
                         captures: captures.clone(),
-                        body: process.optimize(),
+                        body: body.optimize(),
                     },
-                    Command::Loop(label, driver, captures) => {
-                        Command::Loop(label.clone(), driver.clone(), captures.clone())
-                    }
-                    Command::SendType(argument, process) => {
-                        Command::SendType(argument.clone(), process.optimize())
-                    }
-                    Command::ReceiveType(parameter, process) => {
-                        Command::ReceiveType(parameter.clone(), process.optimize())
+                    TerminalCommand::Loop(label, driver, captures) => {
+                        TerminalCommand::Loop(label.clone(), driver.clone(), captures.clone())
                     }
                 },
-            }),
-            Self::Poll {
+            },
+            Terminator::Poll {
                 span,
                 kind,
                 driver,
@@ -241,7 +406,7 @@ impl<S: Clone> Process<(), S> {
                 captures,
                 then,
                 else_,
-            } => Arc::new(Self::Poll {
+            } => Terminator::Poll {
                 span: span.clone(),
                 kind: kind.clone(),
                 driver: driver.clone(),
@@ -252,31 +417,30 @@ impl<S: Clone> Process<(), S> {
                 captures: captures.clone(),
                 then: then.optimize(),
                 else_: else_.optimize(),
-            }),
-            Self::Submit {
+            },
+            Terminator::Submit {
                 span,
                 driver,
                 point,
                 values,
                 captures,
-            } => Arc::new(Self::Submit {
+            } => Terminator::Submit {
                 span: span.clone(),
                 driver: driver.clone(),
                 point: point.clone(),
                 values: values.iter().map(|e| e.optimize()).collect(),
                 captures: captures.clone(),
-            }),
-            Self::Block(span, index, body, process) => Arc::new(Self::Block(
-                span.clone(),
-                *index,
-                body.optimize(),
-                process.optimize(),
-            )),
-            Self::Goto(span, index, caps) => {
-                Arc::new(Self::Goto(span.clone(), *index, caps.clone()))
+            },
+            Terminator::Block(span, index, body, process) => {
+                Terminator::Block(span.clone(), *index, body.optimize(), process.optimize())
             }
-            Self::Unreachable(span) => Arc::new(Self::Unreachable(span.clone())),
-        }
+            Terminator::Goto(span, index, caps) => {
+                Terminator::Goto(span.clone(), *index, caps.clone())
+            }
+            Terminator::Unreachable(span) => Terminator::Unreachable(span.clone()),
+        };
+
+        Arc::new(Process::new(steps, terminator))
     }
 }
 
@@ -287,29 +451,11 @@ impl<S: Clone + Eq + std::hash::Hash + std::fmt::Display> Process<Type<S>, S> {
         docs: &Docs<S>,
         consume: &mut impl FnMut(Span, HoverInfo<S>),
     ) {
-        match self {
-            Process::Let {
-                name,
-                annotation,
-                typ,
-                value,
-                then,
-                ..
-            } => {
-                value.types_at_spans(program, docs, consume);
-                consume(name.span(), HoverInfo::named(name, typ.clone()));
-                if let Some(annotation) = annotation {
-                    annotation.types_at_spans(&program.type_defs, docs, consume);
-                }
-                then.types_at_spans(program, docs, consume);
-            }
-            Process::Do {
-                span,
-                name,
-                typ,
-                command,
-                ..
-            } => {
+        let consume_subject =
+            |span: &Span,
+             name: &LocalName,
+             typ: &Type<S>,
+             consume: &mut dyn FnMut(Span, HoverInfo<S>)| {
                 consume(name.span(), HoverInfo::named(name, typ.clone()));
                 if name == &LocalName::result() {
                     consume(
@@ -321,9 +467,48 @@ impl<S: Clone + Eq + std::hash::Hash + std::fmt::Display> Process<Type<S>, S> {
                 } else {
                     consume(span.clone(), HoverInfo::named(name, typ.clone()));
                 }
+            };
+
+        for step in &self.steps {
+            match step {
+                Step::Let {
+                    name,
+                    annotation,
+                    typ,
+                    value,
+                    ..
+                } => {
+                    value.types_at_spans(program, docs, consume);
+                    consume(name.span(), HoverInfo::named(name, typ.clone()));
+                    if let Some(annotation) = annotation {
+                        annotation.types_at_spans(&program.type_defs, docs, consume);
+                    }
+                }
+                Step::Do {
+                    span,
+                    name,
+                    typ,
+                    command,
+                    ..
+                } => {
+                    consume_subject(span, name, typ, consume);
+                    command.types_at_spans(program, docs, consume);
+                }
+            }
+        }
+
+        match &self.terminator {
+            Terminator::Do {
+                span,
+                name,
+                typ,
+                command,
+                ..
+            } => {
+                consume_subject(span, name, typ, consume);
                 command.types_at_spans(program, docs, consume);
             }
-            Process::Poll {
+            Terminator::Poll {
                 clients,
                 name,
                 name_typ,
@@ -338,17 +523,16 @@ impl<S: Clone + Eq + std::hash::Hash + std::fmt::Display> Process<Type<S>, S> {
                 then.types_at_spans(program, docs, consume);
                 else_.types_at_spans(program, docs, consume);
             }
-            Process::Submit { values, .. } => {
+            Terminator::Submit { values, .. } => {
                 for value in values {
                     value.types_at_spans(program, docs, consume);
                 }
             }
-            Process::Block(_, _, body, process) => {
+            Terminator::Block(_, _, body, process) => {
                 body.types_at_spans(program, docs, consume);
                 process.types_at_spans(program, docs, consume);
             }
-            Process::Goto(_, _, _) => {}
-            Process::Unreachable(_) => {}
+            Terminator::Goto(_, _, _) | Terminator::Unreachable(_) => {}
         }
     }
 }
@@ -356,20 +540,22 @@ impl<S: Clone + Eq + std::hash::Hash + std::fmt::Display> Process<Type<S>, S> {
 impl<Typ, S> Command<Typ, S> {
     pub fn free_variables(&self) -> IndexSet<LocalName> {
         match self {
-            Command::Noop(process) => process.free_variables(),
-            Command::Link(expression) => expression.free_variables(),
-            Command::Send(argument, process) => {
-                let mut vars = argument.free_variables();
-                vars.extend(process.free_variables());
-                vars
-            }
-            Command::Receive(parameter, _annot, _typ, process, _vars) => {
-                let mut vars = process.free_variables();
-                vars.shift_remove(parameter);
-                vars
-            }
-            Command::Signal(_, process) => process.free_variables(),
-            Command::Case(_, processes, else_process) => {
+            Command::Noop => IndexSet::new(),
+            Command::Send(argument) => argument.free_variables(),
+            Command::Receive(..)
+            | Command::Signal(_)
+            | Command::Continue
+            | Command::SendType(_)
+            | Command::ReceiveType(_) => IndexSet::new(),
+        }
+    }
+}
+
+impl<Typ, S> TerminalCommand<Typ, S> {
+    pub fn free_variables(&self) -> IndexSet<LocalName> {
+        match self {
+            TerminalCommand::Link(expression) => expression.free_variables(),
+            TerminalCommand::Case(_, processes, else_process) => {
                 let mut vars: IndexSet<LocalName> =
                     processes.iter().flat_map(|p| p.free_variables()).collect();
                 if let Some(p) = else_process {
@@ -377,16 +563,13 @@ impl<Typ, S> Command<Typ, S> {
                 }
                 vars
             }
-            Command::Break => IndexSet::new(),
-            Command::Continue(process) => process.free_variables(),
-            Command::Begin { captures, body, .. } => {
+            TerminalCommand::Break => IndexSet::new(),
+            TerminalCommand::Begin { captures, body, .. } => {
                 let mut vars: IndexSet<LocalName> = captures.names.keys().cloned().collect();
                 vars.extend(body.free_variables());
                 vars
             }
-            Command::Loop(_, _, captures) => captures.names.keys().cloned().collect(),
-            Command::SendType(_, process) => process.free_variables(),
-            Command::ReceiveType(_, process) => process.free_variables(),
+            TerminalCommand::Loop(_, _, captures) => captures.names.keys().cloned().collect(),
         }
     }
 }
@@ -399,26 +582,33 @@ impl<S: Clone + Eq + std::hash::Hash + std::fmt::Display> Command<Type<S>, S> {
         consume: &mut impl FnMut(Span, HoverInfo<S>),
     ) {
         match self {
-            Self::Noop(process) => {
-                process.types_at_spans(program, docs, consume);
-            }
-            Self::Link(expression) => {
-                expression.types_at_spans(program, docs, consume);
-            }
-            Self::Send(argument, process) => {
+            Self::Noop => {}
+            Self::Send(argument) => {
                 argument.types_at_spans(program, docs, consume);
-                process.types_at_spans(program, docs, consume);
             }
-            Self::Receive(param, annotation, param_type, process, _) => {
+            Self::Receive(param, annotation, param_type, _) => {
                 consume(param.span(), HoverInfo::named(param, param_type.clone()));
                 if let Some(annotation) = annotation {
                     annotation.types_at_spans(&program.type_defs, docs, consume);
                 }
-                process.types_at_spans(program, docs, consume);
             }
-            Self::Signal(_, process) => {
-                process.types_at_spans(program, docs, consume);
+            Self::Signal(_) | Self::Continue | Self::ReceiveType(_) => {}
+            Self::SendType(typ) => {
+                typ.types_at_spans(&program.type_defs, docs, consume);
             }
+        }
+    }
+}
+
+impl<S: Clone + Eq + std::hash::Hash + std::fmt::Display> TerminalCommand<Type<S>, S> {
+    pub fn types_at_spans(
+        &self,
+        program: &CheckedModule<S>,
+        docs: &Docs<S>,
+        consume: &mut impl FnMut(Span, HoverInfo<S>),
+    ) {
+        match self {
+            Self::Link(expression) => expression.types_at_spans(program, docs, consume),
             Self::Case(_, branches, else_process) => {
                 for process in branches {
                     process.types_at_spans(program, docs, consume);
@@ -427,21 +617,8 @@ impl<S: Clone + Eq + std::hash::Hash + std::fmt::Display> Command<Type<S>, S> {
                     process.types_at_spans(program, docs, consume);
                 }
             }
-            Self::Break => {}
-            Self::Continue(process) => {
-                process.types_at_spans(program, docs, consume);
-            }
-            Self::Begin { body, .. } => {
-                body.types_at_spans(program, docs, consume);
-            }
-            Self::Loop(_, _, _) => {}
-            Self::SendType(typ, process) => {
-                typ.types_at_spans(&program.type_defs, docs, consume);
-                process.types_at_spans(program, docs, consume);
-            }
-            Self::ReceiveType(_, process) => {
-                process.types_at_spans(program, docs, consume);
-            }
+            Self::Break | Self::Loop(..) => {}
+            Self::Begin { body, .. } => body.types_at_spans(program, docs, consume),
         }
     }
 }
@@ -800,36 +977,53 @@ impl<Typ: Clone, S> Expression<Typ, S> {
 
 impl<S: Clone> Process<Type<S>, S> {
     pub fn map_types(&self, f: &mut impl FnMut(Type<S>) -> Type<S>) -> Arc<Self> {
-        match self {
-            Process::Let {
-                span,
-                name,
-                annotation,
-                typ,
-                value,
-                then,
-            } => Arc::new(Process::Let {
-                span: span.clone(),
-                name: name.clone(),
-                annotation: annotation.clone().map(&mut *f),
-                typ: f(typ.clone()),
-                value: value.map_types(f),
-                then: then.map_types(f),
-            }),
-            Process::Do {
+        let steps = self
+            .steps
+            .iter()
+            .map(|step| match step {
+                Step::Let {
+                    span,
+                    name,
+                    annotation,
+                    typ,
+                    value,
+                } => Step::Let {
+                    span: span.clone(),
+                    name: name.clone(),
+                    annotation: annotation.clone().map(&mut *f),
+                    typ: f(typ.clone()),
+                    value: value.map_types(f),
+                },
+                Step::Do {
+                    span,
+                    name,
+                    usage,
+                    typ,
+                    command,
+                } => Step::Do {
+                    span: span.clone(),
+                    name: name.clone(),
+                    usage: usage.clone(),
+                    typ: f(typ.clone()),
+                    command: command.map_types(f),
+                },
+            })
+            .collect();
+        let terminator = match &self.terminator {
+            Terminator::Do {
                 span,
                 name,
                 usage,
                 typ,
                 command,
-            } => Arc::new(Process::Do {
+            } => Terminator::Do {
                 span: span.clone(),
                 name: name.clone(),
                 usage: usage.clone(),
                 typ: f(typ.clone()),
                 command: command.map_types(f),
-            }),
-            Process::Poll {
+            },
+            Terminator::Poll {
                 span,
                 kind,
                 driver,
@@ -840,7 +1034,7 @@ impl<S: Clone> Process<Type<S>, S> {
                 captures,
                 then,
                 else_,
-            } => Arc::new(Process::Poll {
+            } => Terminator::Poll {
                 span: span.clone(),
                 kind: kind.clone(),
                 driver: driver.clone(),
@@ -851,78 +1045,74 @@ impl<S: Clone> Process<Type<S>, S> {
                 captures: captures.clone(),
                 then: then.map_types(f),
                 else_: else_.map_types(f),
-            }),
-            Process::Submit {
+            },
+            Terminator::Submit {
                 span,
                 driver,
                 point,
                 values,
                 captures,
-            } => Arc::new(Process::Submit {
+            } => Terminator::Submit {
                 span: span.clone(),
                 driver: driver.clone(),
                 point: point.clone(),
                 values: map_expression_types_vec(values, f),
                 captures: captures.clone(),
-            }),
-            Process::Block(span, index, body, then) => Arc::new(Process::Block(
-                span.clone(),
-                *index,
-                body.map_types(f),
-                then.map_types(f),
-            )),
-            Process::Goto(span, index, captures) => {
-                Arc::new(Process::Goto(span.clone(), *index, captures.clone()))
+            },
+            Terminator::Block(span, index, body, then) => {
+                Terminator::Block(span.clone(), *index, body.map_types(f), then.map_types(f))
             }
-            Process::Unreachable(span) => Arc::new(Process::Unreachable(span.clone())),
-        }
+            Terminator::Goto(span, index, captures) => {
+                Terminator::Goto(span.clone(), *index, captures.clone())
+            }
+            Terminator::Unreachable(span) => Terminator::Unreachable(span.clone()),
+        };
+        Arc::new(Process::new(steps, terminator))
     }
 }
 
 impl<S: Clone> Command<Type<S>, S> {
     pub fn map_types(&self, f: &mut impl FnMut(Type<S>) -> Type<S>) -> Self {
         match self {
-            Command::Noop(process) => Command::Noop(process.map_types(f)),
-            Command::Link(expression) => Command::Link(expression.map_types(f)),
-            Command::Send(argument, process) => {
-                Command::Send(argument.map_types(f), process.map_types(f))
-            }
-            Command::Receive(parameter, annotation, typ, process, vars) => Command::Receive(
+            Command::Noop => Command::Noop,
+            Command::Send(argument) => Command::Send(argument.map_types(f)),
+            Command::Receive(parameter, annotation, typ, vars) => Command::Receive(
                 parameter.clone(),
                 annotation.clone().map(&mut *f),
                 f(typ.clone()),
-                process.map_types(f),
                 vars.clone(),
             ),
-            Command::Signal(chosen, process) => {
-                Command::Signal(chosen.clone(), process.map_types(f))
-            }
-            Command::Case(branches, processes, else_process) => Command::Case(
+            Command::Signal(chosen) => Command::Signal(chosen.clone()),
+            Command::Continue => Command::Continue,
+            Command::SendType(argument) => Command::SendType(f(argument.clone())),
+            Command::ReceiveType(parameter) => Command::ReceiveType(parameter.clone()),
+        }
+    }
+}
+
+impl<S: Clone> TerminalCommand<Type<S>, S> {
+    pub fn map_types(&self, f: &mut impl FnMut(Type<S>) -> Type<S>) -> Self {
+        match self {
+            TerminalCommand::Link(expression) => TerminalCommand::Link(expression.map_types(f)),
+            TerminalCommand::Case(branches, processes, else_process) => TerminalCommand::Case(
                 Arc::clone(branches),
                 map_process_types_boxed_slice(processes, f),
                 else_process.as_ref().map(|process| process.map_types(f)),
             ),
-            Command::Break => Command::Break,
-            Command::Continue(process) => Command::Continue(process.map_types(f)),
-            Command::Begin {
+            TerminalCommand::Break => TerminalCommand::Break,
+            TerminalCommand::Begin {
                 unfounded,
                 label,
                 captures,
                 body,
-            } => Command::Begin {
+            } => TerminalCommand::Begin {
                 unfounded: *unfounded,
                 label: label.clone(),
                 captures: captures.clone(),
                 body: body.map_types(f),
             },
-            Command::Loop(label, driver, captures) => {
-                Command::Loop(label.clone(), driver.clone(), captures.clone())
-            }
-            Command::SendType(argument, process) => {
-                Command::SendType(f(argument.clone()), process.map_types(f))
-            }
-            Command::ReceiveType(parameter, process) => {
-                Command::ReceiveType(parameter.clone(), process.map_types(f))
+            TerminalCommand::Loop(label, driver, captures) => {
+                TerminalCommand::Loop(label.clone(), driver.clone(), captures.clone())
             }
         }
     }
@@ -1003,23 +1193,53 @@ impl<S: Clone> Process<(), S> {
         self,
         f: &mut impl FnMut(GlobalName<S>) -> Result<GlobalName<T>, E>,
     ) -> Result<Process<(), T>, E> {
-        match self {
-            Process::Let {
-                span,
-                name,
-                annotation,
-                typ: (),
-                value,
-                then,
-            } => Self::map_global_names_let(span, name, annotation, value, then, f),
-            Process::Do {
+        let mut steps = Vec::with_capacity(self.steps.len());
+        for step in self.steps {
+            steps.push(match step {
+                Step::Let {
+                    span,
+                    name,
+                    annotation,
+                    typ: (),
+                    value,
+                } => Step::Let {
+                    span,
+                    name,
+                    annotation: annotation.map(|typ| typ.map_global_names(f)).transpose()?,
+                    typ: (),
+                    value: map_arc_expression(value, f)?,
+                },
+                Step::Do {
+                    span,
+                    name,
+                    usage,
+                    typ: (),
+                    command,
+                } => Step::Do {
+                    span,
+                    name,
+                    usage,
+                    typ: (),
+                    command: command.map_global_names(f)?,
+                },
+            });
+        }
+
+        let terminator = match self.terminator {
+            Terminator::Do {
                 span,
                 name,
                 usage,
                 typ: (),
                 command,
-            } => Self::map_global_names_do(span, name, usage, command, f),
-            Process::Poll {
+            } => Terminator::Do {
+                span,
+                name,
+                usage,
+                typ: (),
+                command: command.map_global_names(f)?,
+            },
+            Terminator::Poll {
                 span,
                 kind,
                 driver,
@@ -1030,114 +1250,41 @@ impl<S: Clone> Process<(), S> {
                 captures,
                 then,
                 else_,
-            } => Self::map_global_names_poll(
-                span, kind, driver, point, clients, name, captures, then, else_, f,
-            ),
-            Process::Submit {
+            } => Terminator::Poll {
+                span,
+                kind,
+                driver,
+                point,
+                clients: map_expression_vec(clients, f)?,
+                name,
+                name_typ: (),
+                captures,
+                then: map_arc_process(then, f)?,
+                else_: map_arc_process(else_, f)?,
+            },
+            Terminator::Submit {
                 span,
                 driver,
                 point,
                 values,
                 captures,
-            } => Self::map_global_names_submit(span, driver, point, values, captures, f),
-            Process::Block(span, index, body, then) => {
-                Self::map_global_names_block(span, index, body, then, f)
-            }
-            Process::Goto(span, index, captures) => Ok(Process::Goto(span, index, captures)),
-            Process::Unreachable(span) => Ok(Process::Unreachable(span)),
-        }
-    }
-
-    fn map_global_names_let<T, E>(
-        span: Span,
-        name: LocalName,
-        annotation: Option<Type<S>>,
-        value: Arc<Expression<(), S>>,
-        then: Arc<Process<(), S>>,
-        f: &mut impl FnMut(GlobalName<S>) -> Result<GlobalName<T>, E>,
-    ) -> Result<Process<(), T>, E> {
-        Ok(Process::Let {
-            span,
-            name,
-            annotation: annotation.map(|typ| typ.map_global_names(f)).transpose()?,
-            typ: (),
-            value: map_arc_expression(value, f)?,
-            then: map_arc_process(then, f)?,
-        })
-    }
-
-    fn map_global_names_do<T, E>(
-        span: Span,
-        name: LocalName,
-        usage: VariableUsage,
-        command: Command<(), S>,
-        f: &mut impl FnMut(GlobalName<S>) -> Result<GlobalName<T>, E>,
-    ) -> Result<Process<(), T>, E> {
-        Ok(Process::Do {
-            span,
-            name,
-            usage,
-            typ: (),
-            command: command.map_global_names(f)?,
-        })
-    }
-
-    fn map_global_names_poll<T, E>(
-        span: Span,
-        kind: PollKind,
-        driver: LocalName,
-        point: LocalName,
-        clients: Vec<Arc<Expression<(), S>>>,
-        name: LocalName,
-        captures: Captures,
-        then: Arc<Process<(), S>>,
-        else_: Arc<Process<(), S>>,
-        f: &mut impl FnMut(GlobalName<S>) -> Result<GlobalName<T>, E>,
-    ) -> Result<Process<(), T>, E> {
-        Ok(Process::Poll {
-            span,
-            kind,
-            driver,
-            point,
-            clients: map_expression_vec(clients, f)?,
-            name,
-            name_typ: (),
-            captures,
-            then: map_arc_process(then, f)?,
-            else_: map_arc_process(else_, f)?,
-        })
-    }
-
-    fn map_global_names_submit<T, E>(
-        span: Span,
-        driver: LocalName,
-        point: LocalName,
-        values: Vec<Arc<Expression<(), S>>>,
-        captures: Captures,
-        f: &mut impl FnMut(GlobalName<S>) -> Result<GlobalName<T>, E>,
-    ) -> Result<Process<(), T>, E> {
-        Ok(Process::Submit {
-            span,
-            driver,
-            point,
-            values: map_expression_vec(values, f)?,
-            captures,
-        })
-    }
-
-    fn map_global_names_block<T, E>(
-        span: Span,
-        index: usize,
-        body: Arc<Process<(), S>>,
-        then: Arc<Process<(), S>>,
-        f: &mut impl FnMut(GlobalName<S>) -> Result<GlobalName<T>, E>,
-    ) -> Result<Process<(), T>, E> {
-        Ok(Process::Block(
-            span,
-            index,
-            map_arc_process(body, f)?,
-            map_arc_process(then, f)?,
-        ))
+            } => Terminator::Submit {
+                span,
+                driver,
+                point,
+                values: map_expression_vec(values, f)?,
+                captures,
+            },
+            Terminator::Block(span, index, body, then) => Terminator::Block(
+                span,
+                index,
+                map_arc_process(body, f)?,
+                map_arc_process(then, f)?,
+            ),
+            Terminator::Goto(span, index, captures) => Terminator::Goto(span, index, captures),
+            Terminator::Unreachable(span) => Terminator::Unreachable(span),
+        };
+        Ok(Process::new(steps, terminator))
     }
 }
 
@@ -1147,140 +1294,54 @@ impl<S: Clone> Command<(), S> {
         f: &mut impl FnMut(GlobalName<S>) -> Result<GlobalName<T>, E>,
     ) -> Result<Command<(), T>, E> {
         match self {
-            Command::Noop(process) => Self::map_global_names_noop(process, f),
-            Command::Link(expression) => Self::map_global_names_link(expression, f),
-            Command::Send(argument, process) => Self::map_global_names_send(argument, process, f),
-            Command::Receive(parameter, annotation, (), process, vars) => {
-                Self::map_global_names_receive(parameter, annotation, process, vars, f)
+            Command::Noop => Ok(Command::Noop),
+            Command::Send(argument) => Ok(Command::Send(map_arc_expression(argument, f)?)),
+            Command::Receive(parameter, annotation, (), vars) => Ok(Command::Receive(
+                parameter,
+                annotation.map(|typ| typ.map_global_names(f)).transpose()?,
+                (),
+                vars,
+            )),
+            Command::Signal(chosen) => Ok(Command::Signal(chosen)),
+            Command::Continue => Ok(Command::Continue),
+            Command::SendType(argument) => Ok(Command::SendType(argument.map_global_names(f)?)),
+            Command::ReceiveType(parameter) => Ok(Command::ReceiveType(parameter)),
+        }
+    }
+}
+
+impl<S: Clone> TerminalCommand<(), S> {
+    pub fn map_global_names<T, E>(
+        self,
+        f: &mut impl FnMut(GlobalName<S>) -> Result<GlobalName<T>, E>,
+    ) -> Result<TerminalCommand<(), T>, E> {
+        match self {
+            TerminalCommand::Link(expression) => {
+                Ok(TerminalCommand::Link(map_arc_expression(expression, f)?))
             }
-            Command::Signal(chosen, process) => Self::map_global_names_signal(chosen, process, f),
-            Command::Case(branches, processes, else_process) => {
-                Self::map_global_names_case(branches, processes, else_process, f)
-            }
-            Command::Break => Ok(Command::Break),
-            Command::Continue(process) => Self::map_global_names_continue(process, f),
-            Command::Begin {
+            TerminalCommand::Case(branches, processes, else_process) => Ok(TerminalCommand::Case(
+                branches,
+                map_process_boxed_slice(processes, f)?,
+                else_process
+                    .map(|process| map_arc_process(process, f))
+                    .transpose()?,
+            )),
+            TerminalCommand::Break => Ok(TerminalCommand::Break),
+            TerminalCommand::Begin {
                 unfounded,
                 label,
                 captures,
                 body,
-            } => Self::map_global_names_begin(unfounded, label, captures, body, f),
-            Command::Loop(label, driver, captures) => Ok(Command::Loop(label, driver, captures)),
-            Command::SendType(argument, process) => {
-                Self::map_global_names_send_type(argument, process, f)
-            }
-            Command::ReceiveType(parameter, process) => {
-                Self::map_global_names_receive_type(parameter, process, f)
+            } => Ok(TerminalCommand::Begin {
+                unfounded,
+                label,
+                captures,
+                body: map_arc_process(body, f)?,
+            }),
+            TerminalCommand::Loop(label, driver, captures) => {
+                Ok(TerminalCommand::Loop(label, driver, captures))
             }
         }
-    }
-
-    fn map_global_names_noop<T, E>(
-        process: Arc<Process<(), S>>,
-        f: &mut impl FnMut(GlobalName<S>) -> Result<GlobalName<T>, E>,
-    ) -> Result<Command<(), T>, E> {
-        Ok(Command::Noop(map_arc_process(process, f)?))
-    }
-
-    fn map_global_names_link<T, E>(
-        expression: Arc<Expression<(), S>>,
-        f: &mut impl FnMut(GlobalName<S>) -> Result<GlobalName<T>, E>,
-    ) -> Result<Command<(), T>, E> {
-        Ok(Command::Link(map_arc_expression(expression, f)?))
-    }
-
-    fn map_global_names_send<T, E>(
-        argument: Arc<Expression<(), S>>,
-        process: Arc<Process<(), S>>,
-        f: &mut impl FnMut(GlobalName<S>) -> Result<GlobalName<T>, E>,
-    ) -> Result<Command<(), T>, E> {
-        Ok(Command::Send(
-            map_arc_expression(argument, f)?,
-            map_arc_process(process, f)?,
-        ))
-    }
-
-    fn map_global_names_receive<T, E>(
-        parameter: LocalName,
-        annotation: Option<Type<S>>,
-        process: Arc<Process<(), S>>,
-        vars: Vec<TypeParameter>,
-        f: &mut impl FnMut(GlobalName<S>) -> Result<GlobalName<T>, E>,
-    ) -> Result<Command<(), T>, E> {
-        Ok(Command::Receive(
-            parameter,
-            annotation.map(|typ| typ.map_global_names(f)).transpose()?,
-            (),
-            map_arc_process(process, f)?,
-            vars,
-        ))
-    }
-
-    fn map_global_names_signal<T, E>(
-        chosen: LocalName,
-        process: Arc<Process<(), S>>,
-        f: &mut impl FnMut(GlobalName<S>) -> Result<GlobalName<T>, E>,
-    ) -> Result<Command<(), T>, E> {
-        Ok(Command::Signal(chosen, map_arc_process(process, f)?))
-    }
-
-    fn map_global_names_case<T, E>(
-        branches: Arc<[LocalName]>,
-        processes: Box<[Arc<Process<(), S>>]>,
-        else_process: Option<Arc<Process<(), S>>>,
-        f: &mut impl FnMut(GlobalName<S>) -> Result<GlobalName<T>, E>,
-    ) -> Result<Command<(), T>, E> {
-        Ok(Command::Case(
-            branches,
-            map_process_boxed_slice(processes, f)?,
-            else_process
-                .map(|process| map_arc_process(process, f))
-                .transpose()?,
-        ))
-    }
-
-    fn map_global_names_continue<T, E>(
-        process: Arc<Process<(), S>>,
-        f: &mut impl FnMut(GlobalName<S>) -> Result<GlobalName<T>, E>,
-    ) -> Result<Command<(), T>, E> {
-        Ok(Command::Continue(map_arc_process(process, f)?))
-    }
-
-    fn map_global_names_begin<T, E>(
-        unfounded: bool,
-        label: Option<LocalName>,
-        captures: Captures,
-        body: Arc<Process<(), S>>,
-        f: &mut impl FnMut(GlobalName<S>) -> Result<GlobalName<T>, E>,
-    ) -> Result<Command<(), T>, E> {
-        Ok(Command::Begin {
-            unfounded,
-            label,
-            captures,
-            body: map_arc_process(body, f)?,
-        })
-    }
-
-    fn map_global_names_send_type<T, E>(
-        argument: Type<S>,
-        process: Arc<Process<(), S>>,
-        f: &mut impl FnMut(GlobalName<S>) -> Result<GlobalName<T>, E>,
-    ) -> Result<Command<(), T>, E> {
-        Ok(Command::SendType(
-            argument.map_global_names(f)?,
-            map_arc_process(process, f)?,
-        ))
-    }
-
-    fn map_global_names_receive_type<T, E>(
-        parameter: TypeParameter,
-        process: Arc<Process<(), S>>,
-        f: &mut impl FnMut(GlobalName<S>) -> Result<GlobalName<T>, E>,
-    ) -> Result<Command<(), T>, E> {
-        Ok(Command::ReceiveType(
-            parameter,
-            map_arc_process(process, f)?,
-        ))
     }
 }
 
@@ -1398,21 +1459,13 @@ fn map_expression_vec<S: Clone, T, E>(
 
 impl<Typ, S> Process<Typ, S> {
     pub fn free_variables(&self) -> IndexSet<LocalName> {
-        match self {
-            Process::Let {
-                name, value, then, ..
-            } => {
-                let mut vars = then.free_variables();
-                vars.shift_remove(name);
-                vars.extend(value.free_variables());
-                vars
-            }
-            Process::Do { name, command, .. } => {
+        let mut vars = match &self.terminator {
+            Terminator::Do { name, command, .. } => {
                 let mut vars = command.free_variables();
                 vars.insert(name.clone());
                 vars
             }
-            Process::Poll {
+            Terminator::Poll {
                 driver,
                 clients,
                 name,
@@ -1433,7 +1486,7 @@ impl<Typ, S> Process<Typ, S> {
                 vars.extend(else_vars);
                 vars
             }
-            Process::Submit {
+            Terminator::Submit {
                 driver,
                 values,
                 captures,
@@ -1446,36 +1499,53 @@ impl<Typ, S> Process<Typ, S> {
                 }
                 vars
             }
-            Process::Block(_, _, _body, process) => process.free_variables(),
-            Process::Goto(_, _, caps) => caps.names.keys().cloned().collect(),
-            Process::Unreachable(_) => IndexSet::new(),
+            Terminator::Block(_, _, _body, process) => process.free_variables(),
+            Terminator::Goto(_, _, caps) => caps.names.keys().cloned().collect(),
+            Terminator::Unreachable(_) => IndexSet::new(),
+        };
+
+        for step in self.steps.iter().rev() {
+            match step {
+                Step::Let { name, value, .. } => {
+                    vars.shift_remove(name);
+                    vars.extend(value.free_variables());
+                }
+                Step::Do { name, command, .. } => {
+                    if let Command::Receive(parameter, ..) = command {
+                        vars.shift_remove(parameter);
+                    }
+                    vars.extend(command.free_variables());
+                    vars.insert(name.clone());
+                }
+            }
         }
+        vars
     }
 }
 
 impl<Typ, S: Clone + std::fmt::Display> Process<Typ, S> {
     pub fn pretty(&self, f: &mut impl Write, indent: usize) -> fmt::Result {
-        match self {
-            Self::Let {
-                span: _,
-                name,
-                annotation: _,
-                typ: _,
-                value: expression,
-                then: process,
-            } => {
-                indentation(f, indent)?;
-                write!(f, "let {} = ", name)?;
-                expression.pretty(f, indent)?;
-                process.pretty(f, indent)
+        for step in &self.steps {
+            indentation(f, indent)?;
+            match step {
+                Step::Let { name, value, .. } => {
+                    write!(f, "let {} = ", name)?;
+                    value.pretty(f, indent)?;
+                }
+                Step::Do { name, command, .. } => {
+                    write!(f, "{}", name)?;
+                    command.pretty(f, indent)?;
+                }
             }
+        }
 
-            Self::Unreachable(_) => {
-                indentation(f, indent)?;
+        indentation(f, indent)?;
+        match &self.terminator {
+            Terminator::Unreachable(_) => {
                 write!(f, "unreachable")
             }
 
-            Self::Poll {
+            Terminator::Poll {
                 kind,
                 driver,
                 point,
@@ -1485,7 +1555,6 @@ impl<Typ, S: Clone + std::fmt::Display> Process<Typ, S> {
                 else_,
                 ..
             } => {
-                indentation(f, indent)?;
                 match kind {
                     PollKind::Poll => write!(f, "poll")?,
                     PollKind::Repoll => write!(f, "repoll")?,
@@ -1514,13 +1583,12 @@ impl<Typ, S: Clone + std::fmt::Display> Process<Typ, S> {
                 Ok(())
             }
 
-            Self::Submit {
+            Terminator::Submit {
                 driver,
                 point,
                 values,
                 ..
             } => {
-                indentation(f, indent)?;
                 write!(f, "submit[{} -> {}](", driver, point)?;
                 if let Some(first) = values.first() {
                     first.pretty(f, indent)?;
@@ -1533,49 +1601,14 @@ impl<Typ, S: Clone + std::fmt::Display> Process<Typ, S> {
                 Ok(())
             }
 
-            Self::Do {
-                span: _,
-                name: subject,
-                usage: _,
-                typ: _,
-                command,
-            } => {
-                indentation(f, indent)?;
-                write!(f, "{}", subject)?;
-
+            Terminator::Do { name, command, .. } => {
+                write!(f, "{}", name)?;
                 match command {
-                    Command::Noop(process) => process.pretty(f, indent),
-                    Command::Link(expression) => {
+                    TerminalCommand::Link(expression) => {
                         write!(f, " <> ")?;
                         expression.pretty(f, indent)
                     }
-
-                    Command::Send(argument, process) => {
-                        write!(f, "(")?;
-                        argument.pretty(f, indent)?;
-                        write!(f, ")")?;
-                        process.pretty(f, indent)
-                    }
-
-                    Command::Receive(parameter, _, _, process, vars) => {
-                        if !vars.is_empty() {
-                            write!(f, "<")?;
-                            write!(f, "{}", vars[0])?;
-                            for var in &vars[1..] {
-                                write!(f, ", {}", var)?;
-                            }
-                            write!(f, ">")?;
-                        }
-                        write!(f, "[{}]", parameter)?;
-                        process.pretty(f, indent)
-                    }
-
-                    Command::Signal(chosen, process) => {
-                        write!(f, ".{}", chosen)?;
-                        process.pretty(f, indent)
-                    }
-
-                    Command::Case(choices, branches, else_process) => {
+                    TerminalCommand::Case(choices, branches, else_process) => {
                         write!(f, ".case {{")?;
                         for (choice, process) in choices.iter().zip(branches.iter()) {
                             indentation(f, indent + 1)?;
@@ -1594,17 +1627,8 @@ impl<Typ, S: Clone + std::fmt::Display> Process<Typ, S> {
                         indentation(f, indent)?;
                         write!(f, "}}")
                     }
-
-                    Command::Break => {
-                        write!(f, "!")
-                    }
-
-                    Command::Continue(process) => {
-                        write!(f, "?")?;
-                        process.pretty(f, indent)
-                    }
-
-                    Command::Begin {
+                    TerminalCommand::Break => write!(f, "!"),
+                    TerminalCommand::Begin {
                         unfounded,
                         label,
                         body: process,
@@ -1620,8 +1644,7 @@ impl<Typ, S: Clone + std::fmt::Display> Process<Typ, S> {
                         }
                         process.pretty(f, indent)
                     }
-
-                    Command::Loop(label, driver, caps) => {
+                    TerminalCommand::Loop(label, driver, caps) => {
                         write!(f, ".loop")?;
                         if let Some(label) = label {
                             write!(f, "@{} ", label)?;
@@ -1633,23 +1656,10 @@ impl<Typ, S: Clone + std::fmt::Display> Process<Typ, S> {
                         write!(f, "}}")?;
                         Ok(())
                     }
-
-                    Command::SendType(argument, process) => {
-                        write!(f, "(type ")?;
-                        argument.pretty(f, &CanonicalGlobalNameWriter, indent)?;
-                        write!(f, ")")?;
-                        process.pretty(f, indent)
-                    }
-
-                    Command::ReceiveType(parameter, process) => {
-                        write!(f, "[type {}]", parameter)?;
-                        process.pretty(f, indent)
-                    }
                 }
             }
 
-            Self::Block(_, index, body, process) => {
-                indentation(f, indent)?;
+            Terminator::Block(_, index, body, process) => {
                 write!(f, "block@{} {{", index)?;
                 body.pretty(f, indent + 1)?;
                 indentation(f, indent)?;
@@ -1657,10 +1667,40 @@ impl<Typ, S: Clone + std::fmt::Display> Process<Typ, S> {
                 process.pretty(f, indent)
             }
 
-            Self::Goto(_, index, _) => {
-                indentation(f, indent)?;
+            Terminator::Goto(_, index, _) => {
                 write!(f, "goto@{}", index)
             }
+        }
+    }
+}
+
+impl<Typ, S: Clone + std::fmt::Display> Command<Typ, S> {
+    fn pretty(&self, f: &mut impl Write, indent: usize) -> fmt::Result {
+        match self {
+            Command::Noop => Ok(()),
+            Command::Send(argument) => {
+                write!(f, "(")?;
+                argument.pretty(f, indent)?;
+                write!(f, ")")
+            }
+            Command::Receive(parameter, _, _, vars) => {
+                if !vars.is_empty() {
+                    write!(f, "<{}", vars[0])?;
+                    for var in &vars[1..] {
+                        write!(f, ", {}", var)?;
+                    }
+                    write!(f, ">")?;
+                }
+                write!(f, "[{}]", parameter)
+            }
+            Command::Signal(chosen) => write!(f, ".{}", chosen),
+            Command::Continue => write!(f, "?"),
+            Command::SendType(argument) => {
+                write!(f, "(type ")?;
+                argument.pretty(f, &CanonicalGlobalNameWriter, indent)?;
+                write!(f, ")")
+            }
+            Command::ReceiveType(parameter) => write!(f, "[type {}]", parameter),
         }
     }
 }

--- a/crates/par-core/src/frontend_impl/types/checking.rs
+++ b/crates/par-core/src/frontend_impl/types/checking.rs
@@ -1,11 +1,13 @@
 use super::super::language::{LocalName, TypeConstraint, TypeParameter};
-use super::super::process::{Captures, Command, Expression, PollKind, Process, VariableUsage};
+use super::super::process::{
+    Captures, Command, Expression, PollKind, Process, Step, TerminalCommand, Terminator,
+    VariableUsage,
+};
 use super::context::{BlockPathContext, BlockScope, PollPointScope, PollScope};
 use super::core::{LoopId, Operation, Type, get_primitive_type};
 use super::error::TypeError;
 use super::lattice::union_types;
 use super::{Context, TypeDefs};
-use crate::frontend::TypeError::TypeMustBeKnownAtThisPoint;
 use crate::frontend_impl::types::implicit::{resolve_holes, substitute_holes};
 use crate::frontend_impl::types::lattice::intersect_types;
 use crate::location::Span;
@@ -19,6 +21,69 @@ use std::sync::Arc;
 enum ProcessAnalyzerMode {
     Check,
     Infer(LocalName),
+}
+
+/// A deferred step whose type depends on the type inferred for the process suffix.
+///
+/// Inference walks the process forward, recording these frames until it can infer the subject's
+/// type from the terminator. It then replays the frames in reverse to build the type outward and
+/// fill in the typed steps, using this explicit stack instead of recursive calls for each step.
+enum InferenceFrame<S> {
+    Alias {
+        index: usize,
+        span: Span,
+        name: LocalName,
+        annotation: Option<Type<S>>,
+        variable_span: Span,
+        variable: LocalName,
+        usage: VariableUsage,
+    },
+    Noop {
+        index: usize,
+        span: Span,
+        name: LocalName,
+        usage: VariableUsage,
+    },
+    Send {
+        index: usize,
+        span: Span,
+        name: LocalName,
+        usage: VariableUsage,
+        argument: Arc<Expression<Type<S>, S>>,
+        argument_type: Type<S>,
+    },
+    Receive {
+        index: usize,
+        span: Span,
+        name: LocalName,
+        usage: VariableUsage,
+        parameter: LocalName,
+        annotation: Option<Type<S>>,
+        parameter_type: Type<S>,
+        type_parameters: Vec<TypeParameter>,
+        failed: bool,
+    },
+    Signal {
+        index: usize,
+        span: Span,
+        name: LocalName,
+        usage: VariableUsage,
+        chosen: LocalName,
+    },
+    ReceiveType {
+        index: usize,
+        span: Span,
+        name: LocalName,
+        usage: VariableUsage,
+        parameter: TypeParameter,
+    },
+    SendTypeFailure {
+        index: usize,
+        span: Span,
+        name: LocalName,
+        usage: VariableUsage,
+        argument: Type<S>,
+    },
 }
 impl<S: Clone + Eq + std::hash::Hash> Context<S> {
     fn analyze_process(
@@ -96,37 +161,126 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
         process: &Process<(), S>,
         emit: &mut impl FnMut(TypeError<S>),
     ) -> Arc<Process<Type<S>, S>> {
-        match process {
-            Process::Let {
-                span,
-                name,
-                annotation,
-                typ: (),
-                value: expression,
-                then: process,
-            } => match annotation {
-                Some(annotated_type) => self.check_process_let_annotated(
+        let mut steps = Vec::with_capacity(process.steps.len());
+        for (index, step) in process.steps.iter().enumerate() {
+            match step {
+                Step::Let {
                     span,
                     name,
                     annotation,
-                    annotated_type,
-                    expression,
-                    process,
-                    emit,
-                ),
-                None => self
-                    .check_process_let_inferred(span, name, annotation, expression, process, emit),
-            },
+                    typ: (),
+                    value,
+                } => {
+                    let (value, typ) = match annotation {
+                        Some(typ) => {
+                            if let Err(error) = self.type_defs.validate_type(typ) {
+                                emit(error);
+                            }
+                            (self.check_expression(None, value, typ, emit), typ.clone())
+                        }
+                        None => self.infer_expression(None, value, emit),
+                    };
+                    if let Err(error) = self.put(span, name.clone(), typ.clone()) {
+                        emit(error);
+                    }
+                    steps.push(Step::Let {
+                        span: span.clone(),
+                        name: name.clone(),
+                        annotation: annotation.clone(),
+                        typ,
+                        value,
+                    });
+                }
+                Step::Do {
+                    span,
+                    name,
+                    usage,
+                    typ: (),
+                    command,
+                } => {
+                    let typ = self
+                        .get_variable_or_error(span, name)
+                        .unwrap_or_else(|error| {
+                            emit(error);
+                            Type::Fail(span.clone())
+                        });
+                    if let Type::Hole(_, _, hole) | Type::DualHole(_, _, hole) = &typ {
+                        let is_dual = matches!(typ, Type::DualHole(..));
+                        let suffix = Process::new(
+                            process.steps[index..].to_vec(),
+                            process.terminator.clone(),
+                        );
+                        let (typed_suffix, inferred) = self.infer_process(&suffix, name, emit);
+                        if is_dual {
+                            hole.add_lower_bound(inferred.dual(Span::None));
+                        } else {
+                            hole.add_upper_bound(inferred);
+                        }
+                        let typed_suffix = Arc::unwrap_or_clone(typed_suffix);
+                        steps.extend(typed_suffix.steps);
+                        return Arc::new(Process::new(steps, typed_suffix.terminator));
+                    }
+                    let command = self.check_step_command(span, name, &typ, command, emit);
+                    steps.push(Step::Do {
+                        span: span.clone(),
+                        name: name.clone(),
+                        usage: usage.clone(),
+                        typ,
+                        command,
+                    });
+                }
+            }
+        }
 
-            Process::Do {
+        let terminator = match &process.terminator {
+            Terminator::Do {
                 span,
-                name: object,
+                name,
                 usage,
                 typ: (),
                 command,
-            } => self.check_process_do(span, object, usage, command, emit),
-
-            Process::Poll {
+            } => {
+                let typ = self
+                    .get_variable_or_error(span, name)
+                    .unwrap_or_else(|error| {
+                        emit(error);
+                        Type::Fail(span.clone())
+                    });
+                let command = match &typ {
+                    Type::Hole(_, _, hole) => {
+                        let (command, inferred) =
+                            self.infer_terminal_command(span, name, command, emit);
+                        hole.add_upper_bound(inferred);
+                        command
+                    }
+                    Type::DualHole(_, _, hole) => {
+                        let (command, inferred) =
+                            self.infer_terminal_command(span, name, command, emit);
+                        hole.add_lower_bound(inferred.dual(Span::None));
+                        command
+                    }
+                    _ => {
+                        self.check_terminal_command(
+                            None,
+                            span,
+                            name,
+                            &typ,
+                            command,
+                            &ProcessAnalyzerMode::Check,
+                            emit,
+                        )
+                        .0
+                    }
+                };
+                Terminator::Do {
+                    span: span.clone(),
+                    name: name.clone(),
+                    usage: usage.clone(),
+                    typ,
+                    command,
+                }
+            }
+            Terminator::Poll {
                 span,
                 kind,
                 driver,
@@ -140,109 +294,22 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
             } => self.check_process_poll(
                 span, kind, driver, point, clients, name, captures, then, else_, emit,
             ),
-
-            Process::Submit {
+            Terminator::Submit {
                 span,
                 driver,
                 point,
                 values,
                 captures,
             } => self.check_process_submit(span, driver, point, values, captures, emit),
-
-            Process::Unreachable(span) => self.check_process_unreachable(span, emit),
-
-            Process::Block(span, index, body, then) => {
+            Terminator::Unreachable(span) => self.check_process_unreachable(span, emit),
+            Terminator::Block(span, index, body, then) => {
                 self.check_process_block(span, *index, body, then, emit)
             }
-
-            Process::Goto(span, index, caps) => self.check_process_goto(span, *index, caps, emit),
-        }
-    }
-
-    fn check_process_let_annotated(
-        &mut self,
-        span: &Span,
-        name: &LocalName,
-        annotation: &Option<Type<S>>,
-        annotated_type: &Type<S>,
-        expression: &Expression<(), S>,
-        process: &Process<(), S>,
-        emit: &mut impl FnMut(TypeError<S>),
-    ) -> Arc<Process<Type<S>, S>> {
-        if let Err(e) = self.type_defs.validate_type(annotated_type) {
-            emit(e);
-        }
-        let expression = self.check_expression(None, expression, annotated_type, emit);
-        let typ = annotated_type.clone();
-        if let Err(e) = self.put(span, name.clone(), typ.clone()) {
-            emit(e);
-        }
-        let process = self.check_process(process, emit);
-        Arc::new(Process::Let {
-            span: span.clone(),
-            name: name.clone(),
-            annotation: annotation.clone(),
-            typ,
-            value: expression,
-            then: process,
-        })
-    }
-
-    fn check_process_let_inferred(
-        &mut self,
-        span: &Span,
-        name: &LocalName,
-        annotation: &Option<Type<S>>,
-        expression: &Expression<(), S>,
-        process: &Process<(), S>,
-        emit: &mut impl FnMut(TypeError<S>),
-    ) -> Arc<Process<Type<S>, S>> {
-        let (expression, typ) = self.infer_expression(None, expression, emit);
-        if let Err(e) = self.put(span, name.clone(), typ.clone()) {
-            emit(e);
-        }
-        let process = self.check_process(process, emit);
-        Arc::new(Process::Let {
-            span: span.clone(),
-            name: name.clone(),
-            annotation: annotation.clone(),
-            typ,
-            value: expression,
-            then: process,
-        })
-    }
-
-    fn check_process_do(
-        &mut self,
-        span: &Span,
-        object: &LocalName,
-        usage: &VariableUsage,
-        command: &Command<(), S>,
-        emit: &mut impl FnMut(TypeError<S>),
-    ) -> Arc<Process<Type<S>, S>> {
-        let typ = self
-            .get_variable_or_error(span, object)
-            .unwrap_or_else(|e| {
-                emit(e);
-                Type::Fail(span.clone())
-            });
-        let (command, _) = self.check_command(
-            None,
-            span,
-            object,
-            &typ,
-            command,
-            &ProcessAnalyzerMode::Check,
-            emit,
-        );
-
-        Arc::new(Process::Do {
-            span: span.clone(),
-            name: object.clone(),
-            usage: usage.clone(),
-            typ,
-            command,
-        })
+            Terminator::Goto(span, index, caps) => {
+                self.check_process_goto(span, *index, caps, emit)
+            }
+        };
+        Arc::new(Process::new(steps, terminator))
     }
 
     fn check_process_poll(
@@ -257,7 +324,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
         then: &Process<(), S>,
         else_: &Process<(), S>,
         emit: &mut impl FnMut(TypeError<S>),
-    ) -> Arc<Process<Type<S>, S>> {
+    ) -> Terminator<Type<S>, S> {
         let is_repoll = matches!(kind, PollKind::Repoll);
 
         let preserved_vars: IndexMap<_, _> = self
@@ -284,16 +351,16 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
                     ),
                     None => {
                         emit(TypeError::RepollOutsidePoll(span.clone()));
-                        return Arc::new(Process::Unreachable(span.clone()));
+                        return Terminator::Unreachable(span.clone());
                     }
                 };
             if poll_driver != *driver {
                 emit(TypeError::RepollOutsidePoll(span.clone()));
-                return Arc::new(Process::Unreachable(span.clone()));
+                return Terminator::Unreachable(span.clone());
             }
             if self.get_variable(driver).is_none() {
                 emit(TypeError::RepollOutsidePoll(span.clone()));
-                return Arc::new(Process::Unreachable(span.clone()));
+                return Terminator::Unreachable(span.clone());
             }
 
             let mut point_client_type = poll_points
@@ -385,7 +452,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
         } else {
             if clients.is_empty() {
                 emit(TypeError::PollMustHaveAtLeastOneClient(span.clone()));
-                return Arc::new(Process::Unreachable(span.clone()));
+                return Terminator::Unreachable(span.clone());
             }
 
             let mut client_type = None;
@@ -431,7 +498,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
                     span.clone(),
                     client_type,
                 ));
-                return Arc::new(Process::Unreachable(span.clone()));
+                return Terminator::Unreachable(span.clone());
             };
 
             let pool_type = client_type.clone();
@@ -511,7 +578,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
 
         self.variables.clear();
 
-        Arc::new(Process::Poll {
+        Terminator::Poll {
             span: span.clone(),
             kind: kind.clone(),
             driver: driver.clone(),
@@ -522,7 +589,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
             captures: captures.clone(),
             then: typed_then,
             else_: typed_else,
-        })
+        }
     }
 
     fn check_process_submit(
@@ -533,7 +600,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
         values: &[Arc<Expression<(), S>>],
         captures: &Captures,
         emit: &mut impl FnMut(TypeError<S>),
-    ) -> Arc<Process<Type<S>, S>> {
+    ) -> Terminator<Type<S>, S> {
         let (poll_pool_type, current_point_client_type, poll_point_client_type, preserved_vars) =
             match self.poll.as_ref() {
                 Some(poll) => {
@@ -560,7 +627,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
                 }
                 None => {
                     emit(TypeError::SubmitOutsidePoll(span.clone()));
-                    return Arc::new(Process::Unreachable(span.clone()));
+                    return Terminator::Unreachable(span.clone());
                 }
             };
 
@@ -638,20 +705,20 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
         }
         self.variables.clear();
 
-        Arc::new(Process::Submit {
+        Terminator::Submit {
             span: span.clone(),
             driver: driver.clone(),
             point: point.clone(),
             values: typed_values,
             captures: captures.clone(),
-        })
+        }
     }
 
     fn check_process_unreachable(
         &mut self,
         span: &Span,
         emit: &mut impl FnMut(TypeError<S>),
-    ) -> Arc<Process<Type<S>, S>> {
+    ) -> Terminator<Type<S>, S> {
         let impossible = Type::either(vec![]);
         let mut exhaustive = false;
         for typ in self.variables.values() {
@@ -670,7 +737,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
             emit(TypeError::NonExhaustiveIf(span.clone()));
         }
         self.variables.clear();
-        Arc::new(Process::Unreachable(span.clone()))
+        Terminator::Unreachable(span.clone())
     }
 
     fn check_process_block(
@@ -680,7 +747,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
         body: &Process<(), S>,
         then: &Process<(), S>,
         emit: &mut impl FnMut(TypeError<S>),
-    ) -> Arc<Process<Type<S>, S>> {
+    ) -> Terminator<Type<S>, S> {
         let target_type_vars = self.type_defs.vars.clone();
         if self
             .blocks
@@ -705,12 +772,12 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
         if scope.paths.is_empty() {
             self.type_defs = target_type_defs;
             // Ill-typed synthesized condition blocks can become unreachable during recovery.
-            return Arc::new(Process::Block(
+            return Terminator::Block(
                 span.clone(),
                 index,
-                Arc::new(Process::Unreachable(span.clone())),
+                Process::terminal(Terminator::Unreachable(span.clone())),
                 typed_then,
-            ));
+            );
         }
         let free = body.free_variables();
         let contexts = filter_block_path_contexts(&target_type_defs, span, scope.paths, emit);
@@ -723,7 +790,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
         self.variables = saved;
         self.type_defs = target_type_defs;
 
-        Arc::new(Process::Block(span.clone(), index, typed_body, typed_then))
+        Terminator::Block(span.clone(), index, typed_body, typed_then)
     }
 
     fn check_process_goto(
@@ -732,675 +799,382 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
         index: usize,
         caps: &Captures,
         _emit: &mut impl FnMut(TypeError<S>),
-    ) -> Arc<Process<Type<S>, S>> {
+    ) -> Terminator<Type<S>, S> {
         let entry = self.blocks.get_mut(&index).unwrap();
         entry.paths.push(BlockPathContext {
             variables: self.variables.clone(),
             type_vars: self.type_defs.vars.clone(),
         });
         self.variables.clear();
-        Arc::new(Process::Goto(span.clone(), index, caps.clone()))
+        Terminator::Goto(span.clone(), index, caps.clone())
     }
 
-    fn check_command(
-        &mut self,
-        inference_subject: Option<&LocalName>,
+    fn normalize_command_type(
+        &self,
         span: &Span,
-        object: &LocalName,
         typ: &Type<S>,
-        command: &Command<(), S>,
-        mode: &ProcessAnalyzerMode,
+        expand_iterative: bool,
+        expand_recursive: bool,
         emit: &mut impl FnMut(TypeError<S>),
-    ) -> (Command<Type<S>, S>, Option<Type<S>>) {
-        if let Type::Name(_, name, args) = typ {
-            let expanded = self.type_defs.get(span, name, args).unwrap_or_else(|e| {
-                emit(e);
+    ) -> Type<S> {
+        let mut typ = typ.clone();
+        loop {
+            let next = match &typ {
+                Type::Name(_, name, args) => self.type_defs.get(span, name, args),
+                Type::DualName(_, name, args) => self.type_defs.get_dual(span, name, args),
+                Type::Box(_, inner) => Ok((**inner).clone()),
+                Type::DualBox(_, inner)
+                    if inner
+                        .satisfies_constraint(TypeConstraint::Box, &self.type_defs)
+                        .unwrap_or(false) =>
+                {
+                    Ok(inner.clone().dual(Span::None))
+                }
+                Type::Iterative {
+                    asc,
+                    label,
+                    body,
+                    display_hint,
+                    ..
+                } if expand_iterative => {
+                    Type::expand_iterative(span, asc, label, body, display_hint.0.as_ref())
+                }
+                Type::Recursive {
+                    asc,
+                    label,
+                    body,
+                    display_hint,
+                    ..
+                } if expand_recursive => {
+                    Type::expand_recursive(asc, label, body, display_hint.0.as_ref())
+                }
+                _ => break,
+            }
+            .unwrap_or_else(|error| {
+                emit(error);
                 Type::Fail(span.clone())
             });
-            return self.check_command(
-                inference_subject,
-                span,
-                object,
-                &expanded,
-                command,
-                mode,
-                emit,
-            );
-        }
-        if let Type::DualName(_, name, args) = typ {
-            let expanded = self
-                .type_defs
-                .get_dual(span, name, args)
-                .unwrap_or_else(|e| {
-                    emit(e);
-                    Type::Fail(span.clone())
-                });
-            return self.check_command(
-                inference_subject,
-                span,
-                object,
-                &expanded,
-                command,
-                mode,
-                emit,
-            );
-        }
-        if let Type::Box(_, inner) = typ {
-            return self.check_command(inference_subject, span, object, inner, command, mode, emit);
-        }
-        if let Type::DualBox(_, inner) = typ {
-            if inner
-                .satisfies_constraint(TypeConstraint::Box, &self.type_defs)
-                .unwrap_or(false)
-            {
-                return self.check_command(
-                    inference_subject,
-                    span,
-                    object,
-                    &inner.clone().dual(Span::None),
-                    command,
-                    mode,
-                    emit,
-                );
+            if next == typ {
+                break;
             }
+            typ = next;
         }
-        if !matches!(command, Command::Link(_)) {
-            if let Type::Iterative {
-                asc: top_asc,
-                label: top_label,
-                body,
-                display_hint,
-                ..
-            } = typ
-            {
-                let expanded =
-                    Type::expand_iterative(span, top_asc, top_label, body, display_hint.0.as_ref())
-                        .unwrap_or_else(|e| {
-                            emit(e);
-                            Type::Fail(span.clone())
-                        });
-                return self.check_command(
-                    inference_subject,
-                    span,
-                    object,
-                    &expanded,
-                    command,
-                    mode,
-                    emit,
-                );
-            }
-        }
-        if !matches!(command, Command::Begin { .. } | Command::Loop(_, _, _)) {
-            if let Type::Recursive {
-                asc: top_asc,
-                label: top_label,
-                body,
-                display_hint,
-                ..
-            } = typ
-            {
-                let expanded =
-                    Type::expand_recursive(top_asc, top_label, body, display_hint.0.as_ref())
-                        .unwrap_or_else(|e| {
-                            emit(e);
-                            Type::Fail(span.clone())
-                        });
-                return self.check_command(
-                    inference_subject,
-                    span,
-                    object,
-                    &expanded,
-                    command,
-                    mode,
-                    emit,
-                );
-            }
-        }
-
-        self.check_command_normalized(inference_subject, span, object, typ, command, mode, emit)
+        typ
     }
 
-    fn check_command_normalized(
+    fn check_step_command(
+        &mut self,
+        span: &Span,
+        object: &LocalName,
+        typ: &Type<S>,
+        command: &Command<(), S>,
+        emit: &mut impl FnMut(TypeError<S>),
+    ) -> Command<Type<S>, S> {
+        let typ = self.normalize_command_type(span, typ, true, true, emit);
+        match command {
+            Command::Noop => {
+                self.put(span, object.clone(), typ).ok();
+                Command::Noop
+            }
+            Command::Send(argument) => {
+                let (argument_type, then_type, vars) = match &typ {
+                    Type::Function(_, argument_type, then_type, vars) => (
+                        (**argument_type).clone(),
+                        (**then_type).clone(),
+                        vars.as_slice(),
+                    ),
+                    _ => {
+                        if !matches!(typ, Type::Fail(_)) {
+                            emit(TypeError::InvalidOperation(
+                                span.clone(),
+                                Operation::Send,
+                                typ.clone(),
+                            ));
+                        }
+                        let fail = Type::Fail(span.clone());
+                        (fail.clone(), fail, &[] as &[TypeParameter])
+                    }
+                };
+                let (argument, then_type) = if vars.is_empty() {
+                    (
+                        self.check_expression(None, argument, &argument_type, emit),
+                        then_type,
+                    )
+                } else {
+                    let (argument_type, holes) = substitute_holes(&argument_type, vars)
+                        .unwrap_or_else(|error| {
+                            emit(error);
+                            (Type::Fail(span.clone()), HashMap::new())
+                        });
+                    let argument = self.check_expression(None, argument, &argument_type, emit);
+                    let inferred = resolve_holes(span, vars, &self.type_defs, holes)
+                        .unwrap_or_else(|error| {
+                            emit(error);
+                            vars.iter()
+                                .map(|var| (var.name.clone(), Type::Fail(span.clone())))
+                                .collect()
+                        });
+                    let argument =
+                        argument.map_types(&mut |typ| typ.substitute_inferred_holes(&inferred));
+                    let then_type = then_type
+                        .substitute(inferred.iter().map(|(name, typ)| (name, typ)).collect())
+                        .unwrap_or_else(|error| {
+                            emit(error);
+                            Type::Fail(span.clone())
+                        });
+                    (argument, then_type)
+                };
+                self.put(span, object.clone(), then_type).ok();
+                Command::Send(argument)
+            }
+            Command::Receive(parameter, annotation, (), type_parameters) => {
+                let (param_type, then_type, expected_parameters) = match &typ {
+                    Type::Pair(_, param_type, then_type, parameters)
+                        if parameters.len() == type_parameters.len() =>
+                    {
+                        (
+                            (**param_type).clone(),
+                            (**then_type).clone(),
+                            parameters.clone(),
+                        )
+                    }
+                    _ => {
+                        if !matches!(typ, Type::Fail(_)) {
+                            emit(TypeError::InvalidOperation(
+                                span.clone(),
+                                Operation::Receive {
+                                    generics: type_parameters.len(),
+                                },
+                                typ.clone(),
+                            ));
+                        }
+                        let fail = Type::Fail(span.clone());
+                        (fail.clone(), fail, type_parameters.clone())
+                    }
+                };
+                let type_parameters =
+                    self.resolve_type_parameters(type_parameters, &expected_parameters, emit);
+                let substitutions: BTreeMap<_, _> = expected_parameters
+                    .iter()
+                    .map(|parameter| &parameter.name)
+                    .zip(
+                        type_parameters
+                            .iter()
+                            .map(|parameter| Type::Var(Span::None, parameter.name.clone())),
+                    )
+                    .collect();
+                let param_type = param_type
+                    .substitute(substitutions.iter().map(|(k, v)| (*k, v)).collect())
+                    .unwrap_or_else(|error| {
+                        emit(error);
+                        Type::Fail(span.clone())
+                    });
+                let then_type = then_type
+                    .substitute(substitutions.iter().map(|(k, v)| (*k, v)).collect())
+                    .unwrap_or_else(|error| {
+                        emit(error);
+                        Type::Fail(span.clone())
+                    });
+                self.type_defs.extend_vars(type_parameters.iter().cloned());
+                if let Some(annotation) = annotation {
+                    if let Err(error) = self.type_defs.validate_type(annotation) {
+                        emit(error);
+                    }
+                    if let Err(error) =
+                        param_type.check_assignable(span, annotation, &self.type_defs)
+                    {
+                        emit(error);
+                    }
+                }
+                self.put(span, parameter.clone(), param_type.clone()).ok();
+                self.put(span, object.clone(), then_type).ok();
+                Command::Receive(
+                    parameter.clone(),
+                    annotation.clone(),
+                    param_type,
+                    type_parameters,
+                )
+            }
+            Command::Signal(chosen) => {
+                let branch_type = match &typ {
+                    Type::Choice(_, branches) => {
+                        branches.get(chosen).cloned().unwrap_or_else(|| {
+                            emit(TypeError::InvalidBranch(
+                                span.clone(),
+                                chosen.clone(),
+                                typ.clone(),
+                            ));
+                            Type::Fail(span.clone())
+                        })
+                    }
+                    _ => {
+                        if !matches!(typ, Type::Fail(_)) {
+                            emit(TypeError::InvalidOperation(
+                                span.clone(),
+                                Operation::Signal,
+                                typ.clone(),
+                            ));
+                        }
+                        Type::Fail(span.clone())
+                    }
+                };
+                self.put(span, object.clone(), branch_type).ok();
+                Command::Signal(chosen.clone())
+            }
+            Command::Continue => {
+                if !matches!(typ, Type::Break(_) | Type::Fail(_)) {
+                    emit(TypeError::InvalidOperation(
+                        span.clone(),
+                        Operation::Continue,
+                        typ,
+                    ));
+                }
+                Command::Continue
+            }
+            Command::SendType(argument) => {
+                let then_type = match &typ {
+                    Type::Forall(_, parameter, then_type) => {
+                        self.check_type_constraint(span, parameter, argument, emit);
+                        then_type
+                            .clone()
+                            .substitute(BTreeMap::from([(&parameter.name, argument)]))
+                            .unwrap_or_else(|error| {
+                                emit(error);
+                                Type::Fail(span.clone())
+                            })
+                    }
+                    _ => {
+                        if !matches!(typ, Type::Fail(_)) {
+                            emit(TypeError::InvalidOperation(
+                                span.clone(),
+                                Operation::SendType,
+                                typ,
+                            ));
+                        }
+                        Type::Fail(span.clone())
+                    }
+                };
+                self.put(span, object.clone(), then_type).ok();
+                Command::SendType(argument.clone())
+            }
+            Command::ReceiveType(parameter) => {
+                let (parameter, then_type) = match &typ {
+                    Type::Exists(_, expected, then_type) => {
+                        let parameter = self.resolve_type_parameter(parameter, expected, emit);
+                        let then_type = then_type
+                            .clone()
+                            .substitute(BTreeMap::from([(
+                                &expected.name,
+                                &Type::Var(span.clone(), parameter.name.clone()),
+                            )]))
+                            .unwrap_or_else(|error| {
+                                emit(error);
+                                Type::Fail(span.clone())
+                            });
+                        (parameter, then_type)
+                    }
+                    _ => {
+                        if !matches!(typ, Type::Fail(_)) {
+                            emit(TypeError::InvalidOperation(
+                                span.clone(),
+                                Operation::ReceiveType,
+                                typ,
+                            ));
+                        }
+                        (parameter.clone(), Type::Fail(span.clone()))
+                    }
+                };
+                self.type_defs.insert_var(parameter.clone());
+                self.put(span, object.clone(), then_type).ok();
+                Command::ReceiveType(parameter)
+            }
+        }
+    }
+
+    fn check_terminal_command(
         &mut self,
         inference_subject: Option<&LocalName>,
         span: &Span,
         object: &LocalName,
         typ: &Type<S>,
-        command: &Command<(), S>,
+        command: &TerminalCommand<(), S>,
         mode: &ProcessAnalyzerMode,
         emit: &mut impl FnMut(TypeError<S>),
-    ) -> (Command<Type<S>, S>, Option<Type<S>>) {
-        match typ {
-            Type::Hole(_span, _name, hole) => {
-                if let Some(inference_subject) = inference_subject {
-                    emit(TypeMustBeKnownAtThisPoint(
-                        span.clone(),
-                        inference_subject.clone(),
-                    ));
-                    let fail = Type::Fail(span.clone());
-                    self.put(span, object.clone(), fail.clone()).ok();
-                    let (cmd, typ) = self.infer_command(span, object, command, emit);
-                    hole.add_upper_bound(typ);
-                    return (cmd, Some(fail));
-                }
-                let (cmd, typ) = self.infer_command(span, object, command, emit);
-                hole.add_upper_bound(typ);
-                return (cmd, None);
-            }
-            Type::DualHole(_span, _name, hole) => {
-                if let Some(inference_subject) = inference_subject {
-                    emit(TypeMustBeKnownAtThisPoint(
-                        span.clone(),
-                        inference_subject.clone(),
-                    ));
-                    let fail = Type::Fail(span.clone());
-                    self.put(span, object.clone(), fail.clone()).ok();
-                    let (cmd, typ) = self.infer_command(span, object, command, emit);
-                    hole.add_lower_bound(typ.dual(Span::None));
-                    return (cmd, None);
-                }
-                let (cmd, typ) = self.infer_command(span, object, command, emit);
-                hole.add_lower_bound(typ.dual(Span::None));
-                return (cmd, None);
-            }
-            _ => {}
-        };
+    ) -> (TerminalCommand<Type<S>, S>, Option<Type<S>>) {
+        let typ = self.normalize_command_type(
+            span,
+            typ,
+            !matches!(command, TerminalCommand::Link(_)),
+            !matches!(
+                command,
+                TerminalCommand::Begin { .. } | TerminalCommand::Loop(..)
+            ),
+            emit,
+        );
         match command {
-            Command::Noop(process) => {
-                self.put(span, object.clone(), typ.clone()).ok();
-                let (process, inferred) = self.analyze_process(process, mode, emit);
-                (Command::Noop(process), inferred)
-            }
-            Command::Link(expression) => self.check_command_link(span, typ, expression, emit),
-            Command::Send(argument, process) => {
-                self.check_command_send(span, object, typ, argument, process, mode, emit)
-            }
-            Command::Receive(parameter, annotation, (), process, type_parameters) => self
-                .check_command_receive(
-                    span,
-                    object,
-                    typ,
-                    parameter,
-                    annotation,
-                    process,
-                    type_parameters,
-                    mode,
+            TerminalCommand::Link(expression) => {
+                let expression = self.check_expression(
+                    inference_subject,
+                    expression,
+                    &typ.clone().dual(Span::None),
                     emit,
-                ),
-            Command::Signal(chosen, process) => {
-                self.check_command_signal(span, object, typ, chosen, process, mode, emit)
+                );
+                if let Err(error) = self.cannot_have_obligations(span) {
+                    emit(error);
+                }
+                (TerminalCommand::Link(expression), None)
             }
-            Command::Case(branches, processes, else_process) => self.check_command_case(
+            TerminalCommand::Case(branches, processes, else_process) => self.check_command_case(
                 span,
                 object,
-                typ,
+                &typ,
                 branches,
                 processes,
                 else_process,
                 mode,
                 emit,
             ),
-            Command::Break => {
-                let Type::Continue(_) = typ else {
-                    if !matches!(typ, Type::Fail(_)) {
-                        emit(TypeError::InvalidOperation(
-                            span.clone(),
-                            Operation::Break,
-                            typ.clone(),
-                        ));
-                    }
-                    return (Command::Break, None);
-                };
-                if let Err(e) = self.cannot_have_obligations(span) {
-                    emit(e);
+            TerminalCommand::Break => {
+                if !matches!(typ, Type::Continue(_) | Type::Fail(_)) {
+                    emit(TypeError::InvalidOperation(
+                        span.clone(),
+                        Operation::Break,
+                        typ,
+                    ));
                 }
-                (Command::Break, None)
+                if let Err(error) = self.cannot_have_obligations(span) {
+                    emit(error);
+                }
+                (TerminalCommand::Break, None)
             }
-            Command::Continue(process) => {
-                self.check_command_continue(span, typ, process, mode, emit)
-            }
-            Command::Begin {
+            TerminalCommand::Begin {
                 unfounded,
                 label,
                 captures,
-                body: process,
+                body,
             } => self.check_command_begin(
                 inference_subject,
                 span,
                 object,
-                typ,
+                &typ,
                 *unfounded,
                 label,
                 captures,
-                process,
+                body,
                 mode,
                 emit,
             ),
-            Command::Loop(label, driver, captures) => self.check_command_loop(
+            TerminalCommand::Loop(label, driver, captures) => self.check_command_loop(
                 inference_subject,
                 span,
                 object,
-                typ,
+                &typ,
                 label,
                 driver,
                 captures,
                 emit,
             ),
-            Command::SendType(argument, process) => {
-                self.check_command_send_type(span, object, typ, argument, process, mode, emit)
-            }
-            Command::ReceiveType(parameter, process) => {
-                self.check_command_receive_type(span, object, typ, parameter, process, mode, emit)
-            }
         }
-    }
-
-    fn check_command_link(
-        &mut self,
-        span: &Span,
-        typ: &Type<S>,
-        expression: &Arc<Expression<(), S>>,
-        emit: &mut impl FnMut(TypeError<S>),
-    ) -> (Command<Type<S>, S>, Option<Type<S>>) {
-        let expression =
-            self.check_expression(None, expression, &typ.clone().dual(Span::None), emit);
-        if let Err(e) = self.cannot_have_obligations(span) {
-            emit(e);
-        }
-        (Command::Link(expression), None)
-    }
-
-    fn check_command_send(
-        &mut self,
-        span: &Span,
-        object: &LocalName,
-        typ: &Type<S>,
-        argument: &Arc<Expression<(), S>>,
-        process: &Arc<Process<(), S>>,
-        mode: &ProcessAnalyzerMode,
-        emit: &mut impl FnMut(TypeError<S>),
-    ) -> (Command<Type<S>, S>, Option<Type<S>>) {
-        let Type::Function(_, argument_type, then_type, vars) = typ else {
-            if !matches!(typ, Type::Fail(_)) {
-                emit(TypeError::InvalidOperation(
-                    span.clone(),
-                    Operation::Send,
-                    typ.clone(),
-                ));
-            }
-            let fail = Type::Fail(span.clone());
-            let argument = self.check_expression(None, argument, &fail, emit);
-            self.put(span, object.clone(), fail.clone()).ok();
-            let (process, inferred) = self.analyze_process(process, mode, emit);
-            return (Command::Send(argument, process), inferred);
-        };
-        if vars.is_empty() {
-            self.check_command_send_plain(
-                span,
-                object,
-                argument,
-                process,
-                argument_type,
-                then_type,
-                mode,
-                emit,
-            )
-        } else {
-            self.check_command_send_generic(
-                span,
-                object,
-                argument,
-                process,
-                argument_type,
-                then_type,
-                vars,
-                mode,
-                emit,
-            )
-        }
-    }
-
-    fn check_command_send_generic(
-        &mut self,
-        span: &Span,
-        object: &LocalName,
-        argument: &Arc<Expression<(), S>>,
-        process: &Arc<Process<(), S>>,
-        argument_type: &Type<S>,
-        then_type: &Type<S>,
-        vars: &[TypeParameter],
-        mode: &ProcessAnalyzerMode,
-        emit: &mut impl FnMut(TypeError<S>),
-    ) -> (Command<Type<S>, S>, Option<Type<S>>) {
-        let (argument_type, holes_map) =
-            substitute_holes(argument_type, vars).unwrap_or_else(|e| {
-                emit(e);
-                (Type::Fail(span.clone()), HashMap::new())
-            });
-        let argument = self.check_expression(None, argument, &argument_type, emit);
-        let inferred_holes =
-            resolve_holes(span, vars, &self.type_defs, holes_map).unwrap_or_else(|e| {
-                emit(e);
-                vars.iter()
-                    .map(|var| (var.name.clone(), Type::Fail(span.clone())))
-                    .collect()
-            });
-        let argument =
-            argument.map_types(&mut |typ| typ.substitute_inferred_holes(&inferred_holes));
-        let then_type = then_type
-            .clone()
-            .substitute(inferred_holes.iter().map(|(k, v)| (k, v)).collect())
-            .unwrap_or_else(|e: TypeError<S>| {
-                emit(e);
-                Type::Fail(span.clone())
-            });
-        self.finish_check_command_send(span, object, argument, process, then_type, mode, emit)
-    }
-
-    fn check_command_send_plain(
-        &mut self,
-        span: &Span,
-        object: &LocalName,
-        argument: &Arc<Expression<(), S>>,
-        process: &Arc<Process<(), S>>,
-        argument_type: &Type<S>,
-        then_type: &Type<S>,
-        mode: &ProcessAnalyzerMode,
-        emit: &mut impl FnMut(TypeError<S>),
-    ) -> (Command<Type<S>, S>, Option<Type<S>>) {
-        let argument = self.check_expression(None, argument, argument_type, emit);
-        self.finish_check_command_send(
-            span,
-            object,
-            argument,
-            process,
-            then_type.clone(),
-            mode,
-            emit,
-        )
-    }
-
-    fn finish_check_command_send(
-        &mut self,
-        span: &Span,
-        object: &LocalName,
-        argument: Arc<Expression<Type<S>, S>>,
-        process: &Arc<Process<(), S>>,
-        then_type: Type<S>,
-        mode: &ProcessAnalyzerMode,
-        emit: &mut impl FnMut(TypeError<S>),
-    ) -> (Command<Type<S>, S>, Option<Type<S>>) {
-        if let Err(e) = self.put(span, object.clone(), then_type) {
-            emit(e);
-        }
-        let (process, inferred_types) = self.analyze_process(process, mode, emit);
-        (Command::Send(argument, process), inferred_types)
-    }
-
-    fn check_command_receive(
-        &mut self,
-        span: &Span,
-        object: &LocalName,
-        typ: &Type<S>,
-        parameter: &LocalName,
-        annotation: &Option<Type<S>>,
-        process: &Arc<Process<(), S>>,
-        type_parameters: &[TypeParameter],
-        mode: &ProcessAnalyzerMode,
-        emit: &mut impl FnMut(TypeError<S>),
-    ) -> (Command<Type<S>, S>, Option<Type<S>>) {
-        let Type::Pair(_, param_type, then_type, type_names) = typ else {
-            if !matches!(typ, Type::Fail(_)) {
-                emit(TypeError::InvalidOperation(
-                    span.clone(),
-                    Operation::Receive {
-                        generics: type_parameters.len(),
-                    },
-                    typ.clone(),
-                ));
-            }
-            let fail = Type::Fail(span.clone());
-            self.put(span, object.clone(), fail.clone()).ok();
-            self.put(span, parameter.clone(), fail.clone()).ok();
-            let (process, inferred) = self.analyze_process(process, mode, emit);
-            return (
-                Command::Receive(
-                    parameter.clone(),
-                    annotation.clone(),
-                    fail,
-                    process,
-                    type_parameters.to_vec(),
-                ),
-                inferred,
-            );
-        };
-
-        if type_parameters.len() != type_names.len() {
-            emit(TypeError::InvalidOperation(
-                span.clone(),
-                Operation::Receive {
-                    generics: type_parameters.len(),
-                },
-                typ.clone(),
-            ));
-            let fail = Type::Fail(span.clone());
-            self.put(span, object.clone(), fail.clone()).ok();
-            self.put(span, parameter.clone(), fail.clone()).ok();
-            let (process, inferred) = self.analyze_process(process, mode, emit);
-            return (
-                Command::Receive(
-                    parameter.clone(),
-                    annotation.clone(),
-                    fail,
-                    process,
-                    type_parameters.to_vec(),
-                ),
-                inferred,
-            );
-        }
-
-        if type_names.is_empty() {
-            self.check_command_receive_plain(
-                span,
-                object,
-                parameter,
-                annotation,
-                process,
-                type_names,
-                param_type,
-                then_type,
-                type_parameters,
-                mode,
-                emit,
-            )
-        } else {
-            self.check_command_receive_generic(
-                span,
-                object,
-                parameter,
-                annotation,
-                process,
-                type_names,
-                param_type,
-                then_type,
-                type_parameters,
-                mode,
-                emit,
-            )
-        }
-    }
-
-    fn check_command_receive_generic(
-        &mut self,
-        span: &Span,
-        object: &LocalName,
-        parameter: &LocalName,
-        annotation: &Option<Type<S>>,
-        process: &Arc<Process<(), S>>,
-        type_names: &[TypeParameter],
-        param_type: &Type<S>,
-        then_type: &Type<S>,
-        type_parameters: &[TypeParameter],
-        mode: &ProcessAnalyzerMode,
-        emit: &mut impl FnMut(TypeError<S>),
-    ) -> (Command<Type<S>, S>, Option<Type<S>>) {
-        let type_parameters = self.resolve_type_parameters(type_parameters, type_names, emit);
-        let type_vars: Vec<Type<S>> = type_parameters
-            .iter()
-            .map(|v| Type::Var(Span::None, v.name.clone()))
-            .collect();
-        let then_type = then_type
-            .clone()
-            .substitute(
-                type_names
-                    .iter()
-                    .map(|name| &name.name)
-                    .zip(type_vars.iter())
-                    .collect(),
-            )
-            .unwrap_or_else(|e| {
-                emit(e);
-                Type::Fail(span.clone())
-            });
-        let param_type = param_type
-            .clone()
-            .substitute(
-                type_names
-                    .iter()
-                    .map(|name| &name.name)
-                    .zip(type_vars.iter())
-                    .collect(),
-            )
-            .unwrap_or_else(|e| {
-                emit(e);
-                Type::Fail(span.clone())
-            });
-        self.finish_check_command_receive(
-            span,
-            object,
-            parameter,
-            annotation,
-            process,
-            &type_parameters,
-            param_type,
-            then_type,
-            mode,
-            emit,
-        )
-    }
-
-    fn check_command_receive_plain(
-        &mut self,
-        span: &Span,
-        object: &LocalName,
-        parameter: &LocalName,
-        annotation: &Option<Type<S>>,
-        process: &Arc<Process<(), S>>,
-        type_names: &[TypeParameter],
-        param_type: &Type<S>,
-        then_type: &Type<S>,
-        type_parameters: &[TypeParameter],
-        mode: &ProcessAnalyzerMode,
-        emit: &mut impl FnMut(TypeError<S>),
-    ) -> (Command<Type<S>, S>, Option<Type<S>>) {
-        let type_parameters = self.resolve_type_parameters(type_parameters, type_names, emit);
-        self.finish_check_command_receive(
-            span,
-            object,
-            parameter,
-            annotation,
-            process,
-            &type_parameters,
-            param_type.clone(),
-            then_type.clone(),
-            mode,
-            emit,
-        )
-    }
-
-    fn finish_check_command_receive(
-        &mut self,
-        span: &Span,
-        object: &LocalName,
-        parameter: &LocalName,
-        annotation: &Option<Type<S>>,
-        process: &Arc<Process<(), S>>,
-        type_parameters: &[TypeParameter],
-        param_type: Type<S>,
-        then_type: Type<S>,
-        mode: &ProcessAnalyzerMode,
-        emit: &mut impl FnMut(TypeError<S>),
-    ) -> (Command<Type<S>, S>, Option<Type<S>>) {
-        self.type_defs.extend_vars(type_parameters.iter().cloned());
-
-        if let Some(annotated_type) = annotation {
-            if let Err(e) = self.type_defs.validate_type(annotated_type) {
-                emit(e);
-            }
-            if let Err(e) = param_type.check_assignable(span, annotated_type, &self.type_defs) {
-                emit(e);
-            }
-        }
-        if let Err(e) = self.put(span, parameter.clone(), param_type.clone()) {
-            emit(e);
-        }
-        if let Err(e) = self.put(span, object.clone(), then_type) {
-            emit(e);
-        }
-        let (process, inferred_types) = self.analyze_process(process, mode, emit);
-        (
-            Command::Receive(
-                parameter.clone(),
-                annotation.clone(),
-                param_type,
-                process,
-                type_parameters.to_vec(),
-            ),
-            inferred_types,
-        )
-    }
-
-    fn check_command_signal(
-        &mut self,
-        span: &Span,
-        object: &LocalName,
-        typ: &Type<S>,
-        chosen: &LocalName,
-        process: &Arc<Process<(), S>>,
-        mode: &ProcessAnalyzerMode,
-        emit: &mut impl FnMut(TypeError<S>),
-    ) -> (Command<Type<S>, S>, Option<Type<S>>) {
-        let Type::Choice(_, branches) = typ else {
-            if !matches!(typ, Type::Fail(_)) {
-                emit(TypeError::InvalidOperation(
-                    span.clone(),
-                    Operation::Signal,
-                    typ.clone(),
-                ));
-            }
-            let fail = Type::Fail(span.clone());
-            self.put(span, object.clone(), fail.clone()).ok();
-            let (process, inferred) = self.analyze_process(process, mode, emit);
-            return (Command::Signal(chosen.clone(), process), inferred);
-        };
-        let Some(branch_type) = branches.get(chosen) else {
-            if !matches!(typ, Type::Fail(_)) {
-                emit(TypeError::InvalidBranch(
-                    span.clone(),
-                    chosen.clone(),
-                    typ.clone(),
-                ));
-            }
-            let fail = Type::Fail(span.clone());
-            self.put(span, object.clone(), fail.clone()).ok();
-            let (process, inferred) = self.analyze_process(process, mode, emit);
-            return (Command::Signal(chosen.clone(), process), inferred);
-        };
-        if let Err(e) = self.put(span, object.clone(), branch_type.clone()) {
-            emit(e);
-        }
-        let (process, inferred_types) = self.analyze_process(process, mode, emit);
-        (Command::Signal(chosen.clone(), process), inferred_types)
     }
 
     fn check_command_case(
@@ -1413,7 +1187,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
         else_process: &Option<Arc<Process<(), S>>>,
         mode: &ProcessAnalyzerMode,
         emit: &mut impl FnMut(TypeError<S>),
-    ) -> (Command<Type<S>, S>, Option<Type<S>>) {
+    ) -> (TerminalCommand<Type<S>, S>, Option<Type<S>>) {
         let Type::Either(_, branch_types) = typ else {
             if !matches!(typ, Type::Fail(_)) {
                 emit(TypeError::InvalidOperation(
@@ -1439,7 +1213,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
                 typed
             });
             return (
-                Command::Case(
+                TerminalCommand::Case(
                     branches.clone(),
                     typed_processes.into_boxed_slice(),
                     typed_else,
@@ -1493,7 +1267,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
         }
 
         (
-            Command::Case(
+            TerminalCommand::Case(
                 Arc::clone(branches),
                 Box::from(typed_processes),
                 typed_else_process,
@@ -1575,29 +1349,6 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
         };
     }
 
-    fn check_command_continue(
-        &mut self,
-        span: &Span,
-        typ: &Type<S>,
-        process: &Arc<Process<(), S>>,
-        mode: &ProcessAnalyzerMode,
-        emit: &mut impl FnMut(TypeError<S>),
-    ) -> (Command<Type<S>, S>, Option<Type<S>>) {
-        let Type::Break(_) = typ else {
-            if !matches!(typ, Type::Fail(_)) {
-                emit(TypeError::InvalidOperation(
-                    span.clone(),
-                    Operation::Continue,
-                    typ.clone(),
-                ));
-            }
-            let (process, inferred) = self.analyze_process(process, mode, emit);
-            return (Command::Continue(process), inferred);
-        };
-        let (process, inferred_types) = self.analyze_process(process, mode, emit);
-        (Command::Continue(process), inferred_types)
-    }
-
     fn check_command_begin(
         &mut self,
         inference_subject: Option<&LocalName>,
@@ -1610,7 +1361,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
         process: &Arc<Process<(), S>>,
         mode: &ProcessAnalyzerMode,
         emit: &mut impl FnMut(TypeError<S>),
-    ) -> (Command<Type<S>, S>, Option<Type<S>>) {
+    ) -> (TerminalCommand<Type<S>, S>, Option<Type<S>>) {
         if let Some(inference_subject) = inference_subject {
             emit(TypeError::TypeMustBeKnownAtThisPoint(
                 span.clone(),
@@ -1620,7 +1371,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
             self.put(span, object.clone(), fail.clone()).ok();
             let (process, inferred) = self.analyze_process(process, mode, emit);
             return (
-                Command::Begin {
+                TerminalCommand::Begin {
                     unfounded,
                     label: label.clone(),
                     captures: captures.clone(),
@@ -1648,7 +1399,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
             self.put(span, object.clone(), fail.clone()).ok();
             let (process, inferred) = self.analyze_process(process, mode, emit);
             return (
-                Command::Begin {
+                TerminalCommand::Begin {
                     unfounded,
                     label: label.clone(),
                     captures: captures.clone(),
@@ -1695,7 +1446,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
         }
         let (process, _inferred_type) = self.analyze_process(process, mode, emit);
         (
-            Command::Begin {
+            TerminalCommand::Begin {
                 unfounded,
                 label: label.clone(),
                 captures: captures.clone(),
@@ -1715,7 +1466,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
         driver: &LocalName,
         captures: &Captures,
         emit: &mut impl FnMut(TypeError<S>),
-    ) -> (Command<Type<S>, S>, Option<Type<S>>) {
+    ) -> (TerminalCommand<Type<S>, S>, Option<Type<S>>) {
         if !matches!(typ, Type::Recursive { .. }) {
             if !matches!(typ, Type::Fail(_)) {
                 emit(TypeError::InvalidOperation(
@@ -1725,13 +1476,13 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
                 ));
             }
             return (
-                Command::Loop(label.clone(), driver.clone(), captures.clone()),
+                TerminalCommand::Loop(label.clone(), driver.clone(), captures.clone()),
                 None,
             );
         }
         let Some((driver_type, variables)) = self.loop_points.get(label).cloned() else {
             emit(TypeError::NoSuchLoopPoint(span.clone(), label.clone()));
-            return (Command::Break, None);
+            return (TerminalCommand::Break, None);
         };
         if let Err(e) = self.put(span, driver.clone(), typ.clone()) {
             emit(e);
@@ -1781,91 +1532,8 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
         }
 
         (
-            Command::Loop(label.clone(), driver.clone(), captures.clone()),
+            TerminalCommand::Loop(label.clone(), driver.clone(), captures.clone()),
             inferred_loop.or(Some(Type::Self_(span.clone(), label.clone()))),
-        )
-    }
-
-    fn check_command_send_type(
-        &mut self,
-        span: &Span,
-        object: &LocalName,
-        typ: &Type<S>,
-        argument: &Type<S>,
-        process: &Arc<Process<(), S>>,
-        mode: &ProcessAnalyzerMode,
-        emit: &mut impl FnMut(TypeError<S>),
-    ) -> (Command<Type<S>, S>, Option<Type<S>>) {
-        let Type::Forall(_, type_name, then_type) = typ else {
-            if !matches!(typ, Type::Fail(_)) {
-                emit(TypeError::InvalidOperation(
-                    span.clone(),
-                    Operation::SendType,
-                    typ.clone(),
-                ));
-            }
-            let fail = Type::Fail(span.clone());
-            self.put(span, object.clone(), fail.clone()).ok();
-            let (process, inferred) = self.analyze_process(process, mode, emit);
-            return (Command::SendType(argument.clone(), process), inferred);
-        };
-        self.check_type_constraint(span, type_name, argument, emit);
-        let then_type = then_type
-            .clone()
-            .substitute(BTreeMap::from([(&type_name.name, argument)]))
-            .unwrap_or_else(|e| {
-                emit(e);
-                Type::Fail(span.clone())
-            });
-        if let Err(e) = self.put(span, object.clone(), then_type) {
-            emit(e);
-        }
-        let (process, inferred_types) = self.analyze_process(process, mode, emit);
-        (Command::SendType(argument.clone(), process), inferred_types)
-    }
-
-    fn check_command_receive_type(
-        &mut self,
-        span: &Span,
-        object: &LocalName,
-        typ: &Type<S>,
-        parameter: &TypeParameter,
-        process: &Arc<Process<(), S>>,
-        mode: &ProcessAnalyzerMode,
-        emit: &mut impl FnMut(TypeError<S>),
-    ) -> (Command<Type<S>, S>, Option<Type<S>>) {
-        let Type::Exists(_, type_name, then_type) = typ else {
-            if !matches!(typ, Type::Fail(_)) {
-                emit(TypeError::InvalidOperation(
-                    span.clone(),
-                    Operation::ReceiveType,
-                    typ.clone(),
-                ));
-            }
-            let fail = Type::Fail(span.clone());
-            self.put(span, object.clone(), fail.clone()).ok();
-            let (process, inferred) = self.analyze_process(process, mode, emit);
-            return (Command::ReceiveType(parameter.clone(), process), inferred);
-        };
-        let parameter = self.resolve_type_parameter(parameter, type_name, emit);
-        let then_type = then_type
-            .clone()
-            .substitute(BTreeMap::from([(
-                &type_name.name,
-                &Type::Var(span.clone(), parameter.name.clone()),
-            )]))
-            .unwrap_or_else(|e| {
-                emit(e);
-                Type::Fail(span.clone())
-            });
-        self.type_defs.insert_var(parameter.clone());
-        if let Err(e) = self.put(span, object.clone(), then_type) {
-            emit(e);
-        }
-        let (process, inferred_types) = self.analyze_process(process, mode, emit);
-        (
-            Command::ReceiveType(parameter.clone(), process),
-            inferred_types,
         )
     }
 
@@ -1875,45 +1543,418 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
         inference_subject: &LocalName,
         emit: &mut impl FnMut(TypeError<S>),
     ) -> (Arc<Process<Type<S>, S>>, Type<S>) {
-        match process {
-            Process::Let {
+        let mut subject = inference_subject.clone();
+        let mut typed_steps = vec![None; process.steps.len()];
+        let mut frames = Vec::new();
+        let mut completed_suffix = None;
+
+        for (index, step) in process.steps.iter().enumerate() {
+            match step {
+                Step::Let {
+                    span,
+                    name,
+                    annotation,
+                    typ: (),
+                    value,
+                } => {
+                    if annotation.is_none()
+                        && let Expression::Variable(variable_span, variable, (), usage) =
+                            value.as_ref()
+                        && *variable == subject
+                        && matches!(usage, VariableUsage::Move)
+                    {
+                        frames.push(InferenceFrame::Alias {
+                            index,
+                            span: span.clone(),
+                            name: name.clone(),
+                            annotation: annotation.clone(),
+                            variable_span: variable_span.clone(),
+                            variable: variable.clone(),
+                            usage: usage.clone(),
+                        });
+                        subject = name.clone();
+                        continue;
+                    }
+
+                    let (value, typ) = match annotation {
+                        Some(typ) => (
+                            self.check_expression(Some(&subject), value, typ, emit),
+                            typ.clone(),
+                        ),
+                        None => self.infer_expression(Some(&subject), value, emit),
+                    };
+                    if let Err(error) = self.put(span, name.clone(), typ.clone()) {
+                        emit(error);
+                    }
+                    typed_steps[index] = Some(Step::Let {
+                        span: span.clone(),
+                        name: name.clone(),
+                        annotation: annotation.clone(),
+                        typ,
+                        value,
+                    });
+                }
+                Step::Do {
+                    span,
+                    name,
+                    usage,
+                    typ: (),
+                    command,
+                } if *name == subject => match command {
+                    Command::Noop => frames.push(InferenceFrame::Noop {
+                        index,
+                        span: span.clone(),
+                        name: name.clone(),
+                        usage: usage.clone(),
+                    }),
+                    Command::Send(argument) => {
+                        let (argument, argument_type) =
+                            self.infer_expression(Some(&subject), argument, emit);
+                        frames.push(InferenceFrame::Send {
+                            index,
+                            span: span.clone(),
+                            name: name.clone(),
+                            usage: usage.clone(),
+                            argument,
+                            argument_type,
+                        });
+                    }
+                    Command::Receive(parameter, annotation, (), type_parameters) => {
+                        self.type_defs.extend_vars(type_parameters.iter().cloned());
+                        let (parameter_type, failed) = match annotation {
+                            Some(typ) => (typ.clone(), false),
+                            None => {
+                                emit(TypeError::ParameterTypeMustBeKnown(
+                                    span.clone(),
+                                    parameter.clone(),
+                                ));
+                                (Type::Fail(span.clone()), true)
+                            }
+                        };
+                        if let Err(error) =
+                            self.put(span, parameter.clone(), parameter_type.clone())
+                        {
+                            emit(error);
+                        }
+                        frames.push(InferenceFrame::Receive {
+                            index,
+                            span: span.clone(),
+                            name: name.clone(),
+                            usage: usage.clone(),
+                            parameter: parameter.clone(),
+                            annotation: annotation.clone(),
+                            parameter_type,
+                            type_parameters: type_parameters.clone(),
+                            failed,
+                        });
+                    }
+                    Command::Signal(chosen) => frames.push(InferenceFrame::Signal {
+                        index,
+                        span: span.clone(),
+                        name: name.clone(),
+                        usage: usage.clone(),
+                        chosen: chosen.clone(),
+                    }),
+                    Command::Continue => {
+                        typed_steps[index] = Some(Step::Do {
+                            span: span.clone(),
+                            name: name.clone(),
+                            usage: usage.clone(),
+                            typ: Type::Break(span.clone()),
+                            command: Command::Continue,
+                        });
+                        let suffix = Process::new(
+                            process.steps[index + 1..].to_vec(),
+                            process.terminator.clone(),
+                        );
+                        let suffix = Arc::unwrap_or_clone(self.check_process(&suffix, emit));
+                        for (offset, step) in suffix.steps.into_iter().enumerate() {
+                            typed_steps[index + 1 + offset] = Some(step);
+                        }
+                        completed_suffix = Some((suffix.terminator, Type::Break(span.clone())));
+                        break;
+                    }
+                    Command::SendType(argument) => {
+                        emit(TypeError::TypeMustBeKnownAtThisPoint(
+                            span.clone(),
+                            subject.clone(),
+                        ));
+                        frames.push(InferenceFrame::SendTypeFailure {
+                            index,
+                            span: span.clone(),
+                            name: name.clone(),
+                            usage: usage.clone(),
+                            argument: argument.clone(),
+                        });
+                    }
+                    Command::ReceiveType(parameter) => {
+                        self.type_defs.insert_var(parameter.clone());
+                        frames.push(InferenceFrame::ReceiveType {
+                            index,
+                            span: span.clone(),
+                            name: name.clone(),
+                            usage: usage.clone(),
+                            parameter: parameter.clone(),
+                        });
+                    }
+                },
+                Step::Do {
+                    span,
+                    name,
+                    usage,
+                    typ: (),
+                    command,
+                } => {
+                    let typ = self
+                        .get_variable_or_error(span, name)
+                        .unwrap_or_else(|error| {
+                            emit(error);
+                            Type::Fail(span.clone())
+                        });
+                    let command = self.check_step_command(span, name, &typ, command, emit);
+                    typed_steps[index] = Some(Step::Do {
+                        span: span.clone(),
+                        name: name.clone(),
+                        usage: usage.clone(),
+                        typ,
+                        command,
+                    });
+                }
+            }
+        }
+
+        let (terminator, mut inferred_type) = match completed_suffix {
+            Some(completed) => completed,
+            None => self.infer_terminator(&process.terminator, &subject, emit),
+        };
+
+        for frame in frames.into_iter().rev() {
+            match frame {
+                InferenceFrame::Alias {
+                    index,
+                    span,
+                    name,
+                    annotation,
+                    variable_span,
+                    variable,
+                    usage,
+                } => {
+                    typed_steps[index] = Some(Step::Let {
+                        span,
+                        name,
+                        annotation,
+                        typ: inferred_type.clone(),
+                        value: Arc::new(Expression::Variable(
+                            variable_span,
+                            variable,
+                            inferred_type.clone(),
+                            usage,
+                        )),
+                    });
+                }
+                InferenceFrame::Noop {
+                    index,
+                    span,
+                    name,
+                    usage,
+                } => {
+                    typed_steps[index] = Some(Step::Do {
+                        span,
+                        name,
+                        usage,
+                        typ: inferred_type.clone(),
+                        command: Command::Noop,
+                    });
+                }
+                InferenceFrame::Send {
+                    index,
+                    span,
+                    name,
+                    usage,
+                    argument,
+                    argument_type,
+                } => {
+                    inferred_type = Type::Function(
+                        span.clone(),
+                        Box::new(argument_type),
+                        Box::new(inferred_type),
+                        vec![],
+                    );
+                    typed_steps[index] = Some(Step::Do {
+                        span,
+                        name,
+                        usage,
+                        typ: inferred_type.clone(),
+                        command: Command::Send(argument),
+                    });
+                }
+                InferenceFrame::Receive {
+                    index,
+                    span,
+                    name,
+                    usage,
+                    parameter,
+                    annotation,
+                    parameter_type,
+                    type_parameters,
+                    failed,
+                } => {
+                    inferred_type = if failed {
+                        Type::Fail(span.clone())
+                    } else {
+                        Type::Pair(
+                            span.clone(),
+                            Box::new(parameter_type.clone()),
+                            Box::new(inferred_type),
+                            type_parameters.clone(),
+                        )
+                    };
+                    typed_steps[index] = Some(Step::Do {
+                        span,
+                        name,
+                        usage,
+                        typ: inferred_type.clone(),
+                        command: Command::Receive(
+                            parameter,
+                            annotation,
+                            parameter_type,
+                            type_parameters,
+                        ),
+                    });
+                }
+                InferenceFrame::Signal {
+                    index,
+                    span,
+                    name,
+                    usage,
+                    chosen,
+                } => {
+                    inferred_type = Type::Choice(
+                        span.clone(),
+                        BTreeMap::from([(chosen.clone(), inferred_type)]),
+                    );
+                    typed_steps[index] = Some(Step::Do {
+                        span,
+                        name,
+                        usage,
+                        typ: inferred_type.clone(),
+                        command: Command::Signal(chosen),
+                    });
+                }
+                InferenceFrame::ReceiveType {
+                    index,
+                    span,
+                    name,
+                    usage,
+                    parameter,
+                } => {
+                    inferred_type =
+                        Type::Exists(span.clone(), parameter.clone(), Box::new(inferred_type));
+                    typed_steps[index] = Some(Step::Do {
+                        span,
+                        name,
+                        usage,
+                        typ: inferred_type.clone(),
+                        command: Command::ReceiveType(parameter),
+                    });
+                }
+                InferenceFrame::SendTypeFailure {
+                    index,
+                    span,
+                    name,
+                    usage,
+                    argument,
+                } => {
+                    inferred_type = Type::Fail(span.clone());
+                    typed_steps[index] = Some(Step::Do {
+                        span,
+                        name,
+                        usage,
+                        typ: inferred_type.clone(),
+                        command: Command::SendType(argument),
+                    });
+                }
+            }
+        }
+
+        let typed_steps = typed_steps
+            .into_iter()
+            .map(|step| step.expect("inference should type every process step"))
+            .collect();
+        (
+            Arc::new(Process::new(typed_steps, terminator)),
+            inferred_type,
+        )
+    }
+
+    fn infer_terminator(
+        &mut self,
+        terminator: &Terminator<(), S>,
+        inference_subject: &LocalName,
+        emit: &mut impl FnMut(TypeError<S>),
+    ) -> (Terminator<Type<S>, S>, Type<S>) {
+        match terminator {
+            Terminator::Do {
                 span,
                 name,
-                annotation,
-                typ: (),
-                value: expression,
-                then: process,
-            } => match annotation {
-                Some(annotated_type) => self.infer_process_let_annotated(
-                    span,
-                    name,
-                    annotation,
-                    annotated_type,
-                    expression,
-                    process,
-                    inference_subject,
-                    emit,
-                ),
-                None => self.infer_process_let_inferred(
-                    span,
-                    name,
-                    annotation,
-                    expression,
-                    process,
-                    inference_subject,
-                    emit,
-                ),
-            },
-
-            Process::Do {
-                span,
-                name: object,
                 usage,
                 typ: (),
                 command,
-            } => self.infer_process_do(span, object, usage, command, inference_subject, emit),
-
-            Process::Poll {
+            } if name == inference_subject => {
+                let (command, typ) =
+                    self.infer_terminal_command(span, inference_subject, command, emit);
+                (
+                    Terminator::Do {
+                        span: span.clone(),
+                        name: name.clone(),
+                        usage: usage.clone(),
+                        typ: typ.clone(),
+                        command,
+                    },
+                    typ,
+                )
+            }
+            Terminator::Do {
+                span,
+                name,
+                usage,
+                typ: (),
+                command,
+            } => {
+                let typ = self
+                    .get_variable_or_error(span, name)
+                    .unwrap_or_else(|error| {
+                        emit(error);
+                        Type::Fail(span.clone())
+                    });
+                let (command, inferred) = self.check_terminal_command(
+                    Some(inference_subject),
+                    span,
+                    name,
+                    &typ,
+                    command,
+                    &ProcessAnalyzerMode::Infer(inference_subject.clone()),
+                    emit,
+                );
+                let inferred = inferred.unwrap_or_else(|| {
+                    emit(TypeError::TypeMustBeKnownAtThisPoint(
+                        span.clone(),
+                        inference_subject.clone(),
+                    ));
+                    Type::Fail(span.clone())
+                });
+                (
+                    Terminator::Do {
+                        span: span.clone(),
+                        name: name.clone(),
+                        usage: usage.clone(),
+                        typ,
+                        command,
+                    },
+                    inferred,
+                )
+            }
+            Terminator::Poll {
                 span,
                 kind,
                 driver,
@@ -1937,8 +1978,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
                 inference_subject,
                 emit,
             ),
-
-            Process::Submit {
+            Terminator::Submit {
                 span,
                 driver,
                 point,
@@ -1953,181 +1993,51 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
                 inference_subject,
                 emit,
             ),
-
-            Process::Unreachable(span) => self.infer_process_unreachable(span, emit),
-
-            Process::Block(span, index, body, then) => {
+            Terminator::Unreachable(span) => self.infer_process_unreachable(span, emit),
+            Terminator::Block(span, index, body, then) => {
                 self.infer_process_block(span, *index, body, then, inference_subject, emit)
             }
-
-            Process::Goto(span, index, caps) => self.infer_process_goto(span, *index, caps, emit),
+            Terminator::Goto(span, index, captures) => {
+                self.infer_process_goto(span, *index, captures, emit)
+            }
         }
     }
 
-    fn infer_process_let_annotated(
+    fn infer_terminal_command(
         &mut self,
         span: &Span,
-        name: &LocalName,
-        annotation: &Option<Type<S>>,
-        annotated_type: &Type<S>,
-        expression: &Arc<Expression<(), S>>,
-        process: &Arc<Process<(), S>>,
-        inference_subject: &LocalName,
+        subject: &LocalName,
+        command: &TerminalCommand<(), S>,
         emit: &mut impl FnMut(TypeError<S>),
-    ) -> (Arc<Process<Type<S>, S>>, Type<S>) {
-        let expression =
-            self.check_expression(Some(inference_subject), expression, annotated_type, emit);
-        self.finish_infer_process_let(
-            span,
-            name,
-            annotation,
-            annotated_type.clone(),
-            expression,
-            process,
-            inference_subject,
-            emit,
-        )
-    }
-
-    fn infer_process_let_inferred(
-        &mut self,
-        span: &Span,
-        name: &LocalName,
-        annotation: &Option<Type<S>>,
-        expression: &Arc<Expression<(), S>>,
-        process: &Arc<Process<(), S>>,
-        inference_subject: &LocalName,
-        emit: &mut impl FnMut(TypeError<S>),
-    ) -> (Arc<Process<Type<S>, S>>, Type<S>) {
-        if let Expression::Variable(variable_span, variable, (), usage) = expression.as_ref()
-            && variable == inference_subject
-            && matches!(usage, VariableUsage::Move)
-        {
-            let (process, typ) = self.infer_process(process, name, emit);
-            return (
-                Arc::new(Process::Let {
-                    span: span.clone(),
-                    name: name.clone(),
-                    annotation: annotation.clone(),
-                    typ: typ.clone(),
-                    value: Arc::new(Expression::Variable(
-                        variable_span.clone(),
-                        variable.clone(),
-                        typ.clone(),
-                        usage.clone(),
-                    )),
-                    then: process,
-                }),
-                typ,
-            );
+    ) -> (TerminalCommand<Type<S>, S>, Type<S>) {
+        match command {
+            TerminalCommand::Link(expression) => {
+                let (expression, typ) = self.infer_expression(Some(subject), expression, emit);
+                if let Err(error) = self.cannot_have_obligations(span) {
+                    emit(error);
+                }
+                (TerminalCommand::Link(expression), typ.dual(Span::None))
+            }
+            TerminalCommand::Case(branches, processes, else_process) => {
+                self.infer_command_case(span, subject, branches, processes, else_process, emit)
+            }
+            TerminalCommand::Break => {
+                if let Err(error) = self.cannot_have_obligations(span) {
+                    emit(error);
+                }
+                (TerminalCommand::Break, Type::Continue(span.clone()))
+            }
+            TerminalCommand::Begin { .. } => {
+                emit(TypeError::TypeMustBeKnownAtThisPoint(
+                    span.clone(),
+                    subject.clone(),
+                ));
+                (TerminalCommand::Break, Type::Fail(span.clone()))
+            }
+            TerminalCommand::Loop(label, driver, captures) => {
+                self.infer_command_loop(span, label, driver, captures, emit)
+            }
         }
-        let (expression, typ) = self.infer_expression(Some(inference_subject), expression, emit);
-        self.finish_infer_process_let(
-            span,
-            name,
-            annotation,
-            typ,
-            expression,
-            process,
-            inference_subject,
-            emit,
-        )
-    }
-
-    fn finish_infer_process_let(
-        &mut self,
-        span: &Span,
-        name: &LocalName,
-        annotation: &Option<Type<S>>,
-        typ: Type<S>,
-        expression: Arc<Expression<Type<S>, S>>,
-        process: &Arc<Process<(), S>>,
-        inference_subject: &LocalName,
-        emit: &mut impl FnMut(TypeError<S>),
-    ) -> (Arc<Process<Type<S>, S>>, Type<S>) {
-        if let Err(e) = self.put(span, name.clone(), typ.clone()) {
-            emit(e);
-        }
-        let (process, subject_type) = self.infer_process(process, inference_subject, emit);
-        (
-            Arc::new(Process::Let {
-                span: span.clone(),
-                name: name.clone(),
-                annotation: annotation.clone(),
-                typ,
-                value: expression,
-                then: process,
-            }),
-            subject_type,
-        )
-    }
-
-    fn infer_process_do(
-        &mut self,
-        span: &Span,
-        object: &LocalName,
-        usage: &VariableUsage,
-        command: &Command<(), S>,
-        inference_subject: &LocalName,
-        emit: &mut impl FnMut(TypeError<S>),
-    ) -> (Arc<Process<Type<S>, S>>, Type<S>) {
-        if object == inference_subject {
-            let (command, typ) = self.infer_command(span, inference_subject, command, emit);
-            return (
-                Arc::new(Process::Do {
-                    span: span.clone(),
-                    name: object.clone(),
-                    usage: usage.clone(),
-                    typ: typ.clone(),
-                    command,
-                }),
-                typ,
-            );
-        }
-        let typ = self
-            .get_variable_or_error(span, object)
-            .unwrap_or_else(|e| {
-                emit(e);
-                Type::Fail(span.clone())
-            });
-
-        let (command, inferred_type) = self.check_command(
-            Some(inference_subject),
-            span,
-            object,
-            &typ,
-            command,
-            &ProcessAnalyzerMode::Infer(inference_subject.clone()),
-            emit,
-        );
-
-        let Some(inferred_type) = inferred_type else {
-            emit(TypeError::TypeMustBeKnownAtThisPoint(
-                span.clone(),
-                inference_subject.clone(),
-            ));
-            return (
-                Arc::new(Process::Do {
-                    span: span.clone(),
-                    name: object.clone(),
-                    usage: usage.clone(),
-                    typ,
-                    command,
-                }),
-                Type::Fail(span.clone()),
-            );
-        };
-
-        (
-            Arc::new(Process::Do {
-                span: span.clone(),
-                name: object.clone(),
-                usage: usage.clone(),
-                typ,
-                command,
-            }),
-            inferred_type,
-        )
     }
 
     fn infer_process_poll(
@@ -2143,7 +2053,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
         else_: &Arc<Process<(), S>>,
         inference_subject: &LocalName,
         emit: &mut impl FnMut(TypeError<S>),
-    ) -> (Arc<Process<Type<S>, S>>, Type<S>) {
+    ) -> (Terminator<Type<S>, S>, Type<S>) {
         let is_repoll = matches!(kind, PollKind::Repoll);
 
         let preserved_vars: IndexMap<_, _> = self
@@ -2171,7 +2081,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
                     None => {
                         emit(TypeError::RepollOutsidePoll(span.clone()));
                         return (
-                            Arc::new(Process::Unreachable(span.clone())),
+                            Terminator::Unreachable(span.clone()),
                             Type::Fail(span.clone()),
                         );
                     }
@@ -2179,7 +2089,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
             if poll_driver != *driver {
                 emit(TypeError::RepollOutsidePoll(span.clone()));
                 return (
-                    Arc::new(Process::Unreachable(span.clone())),
+                    Terminator::Unreachable(span.clone()),
                     Type::Fail(span.clone()),
                 );
             }
@@ -2187,7 +2097,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
             if self.get_variable(driver).is_none() {
                 emit(TypeError::RepollOutsidePoll(span.clone()));
                 return (
-                    Arc::new(Process::Unreachable(span.clone())),
+                    Terminator::Unreachable(span.clone()),
                     Type::Fail(span.clone()),
                 );
             }
@@ -2282,7 +2192,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
             if clients.is_empty() {
                 emit(TypeError::PollMustHaveAtLeastOneClient(span.clone()));
                 return (
-                    Arc::new(Process::Unreachable(span.clone())),
+                    Terminator::Unreachable(span.clone()),
                     Type::Fail(span.clone()),
                 );
             }
@@ -2332,7 +2242,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
                     client_type,
                 ));
                 return (
-                    Arc::new(Process::Unreachable(span.clone())),
+                    Terminator::Unreachable(span.clone()),
                     Type::Fail(span.clone()),
                 );
             };
@@ -2415,7 +2325,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
         self.variables.clear();
 
         (
-            Arc::new(Process::Poll {
+            Terminator::Poll {
                 span: span.clone(),
                 kind: kind.clone(),
                 driver: driver.clone(),
@@ -2426,7 +2336,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
                 captures: captures.clone(),
                 then: typed_then,
                 else_: typed_else,
-            }),
+            },
             intersect_types(&self.type_defs, span, &then_type, &else_type).unwrap_or_else(|e| {
                 emit(e);
                 Type::Fail(span.clone())
@@ -2443,7 +2353,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
         captures: &Captures,
         inference_subject: &LocalName,
         emit: &mut impl FnMut(TypeError<S>),
-    ) -> (Arc<Process<Type<S>, S>>, Type<S>) {
+    ) -> (Terminator<Type<S>, S>, Type<S>) {
         let (poll_pool_type, current_point_client_type, poll_point_client_type, preserved_vars) =
             match self.poll.as_ref() {
                 Some(poll) => {
@@ -2471,7 +2381,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
                 None => {
                     emit(TypeError::SubmitOutsidePoll(span.clone()));
                     return (
-                        Arc::new(Process::Unreachable(span.clone())),
+                        Terminator::Unreachable(span.clone()),
                         Type::Fail(span.clone()),
                     );
                 }
@@ -2552,13 +2462,13 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
         self.variables.clear();
 
         (
-            Arc::new(Process::Submit {
+            Terminator::Submit {
                 span: span.clone(),
                 driver: driver.clone(),
                 point: point.clone(),
                 values: typed_values,
                 captures: captures.clone(),
-            }),
+            },
             Type::choice(vec![]),
         )
     }
@@ -2567,7 +2477,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
         &mut self,
         span: &Span,
         emit: &mut impl FnMut(TypeError<S>),
-    ) -> (Arc<Process<Type<S>, S>>, Type<S>) {
+    ) -> (Terminator<Type<S>, S>, Type<S>) {
         let impossible = Type::either(vec![]);
         let mut exhaustive = false;
         for typ in self.variables.values() {
@@ -2586,10 +2496,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
             emit(TypeError::NonExhaustiveIf(span.clone()));
         }
         self.variables.clear();
-        (
-            Arc::new(Process::Unreachable(span.clone())),
-            Type::choice(vec![]),
-        )
+        (Terminator::Unreachable(span.clone()), Type::choice(vec![]))
     }
 
     fn infer_process_block(
@@ -2600,7 +2507,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
         then: &Arc<Process<(), S>>,
         inference_subject: &LocalName,
         emit: &mut impl FnMut(TypeError<S>),
-    ) -> (Arc<Process<Type<S>, S>>, Type<S>) {
+    ) -> (Terminator<Type<S>, S>, Type<S>) {
         let target_type_vars = self.type_defs.vars.clone();
         if self
             .blocks
@@ -2626,12 +2533,12 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
             self.type_defs = target_type_defs;
             // Ill-typed synthesized condition blocks can become unreachable during recovery.
             return (
-                Arc::new(Process::Block(
+                Terminator::Block(
                     span.clone(),
                     index,
-                    Arc::new(Process::Unreachable(span.clone())),
+                    Process::terminal(Terminator::Unreachable(span.clone())),
                     typed_then,
-                )),
+                ),
                 then_type,
             );
         }
@@ -2659,7 +2566,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
             });
 
         (
-            Arc::new(Process::Block(span.clone(), index, typed_body, typed_then)),
+            Terminator::Block(span.clone(), index, typed_body, typed_then),
             final_type,
         )
     }
@@ -2670,7 +2577,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
         index: usize,
         caps: &Captures,
         _emit: &mut impl FnMut(TypeError<S>),
-    ) -> (Arc<Process<Type<S>, S>>, Type<S>) {
+    ) -> (Terminator<Type<S>, S>, Type<S>) {
         let entry = self.blocks.get_mut(&index).unwrap();
         entry.paths.push(BlockPathContext {
             variables: self.variables.clone(),
@@ -2678,165 +2585,8 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
         });
         self.variables.clear();
         (
-            Arc::new(Process::Goto(span.clone(), index, caps.clone())),
+            Terminator::Goto(span.clone(), index, caps.clone()),
             Type::choice(vec![]),
-        )
-    }
-
-    pub(crate) fn infer_command(
-        &mut self,
-        span: &Span,
-        subject: &LocalName,
-        command: &Command<(), S>,
-        emit: &mut impl FnMut(TypeError<S>),
-    ) -> (Command<Type<S>, S>, Type<S>) {
-        match command {
-            Command::Noop(process) => {
-                let (process, typ) = self.infer_process(process, subject, emit);
-                (Command::Noop(process), typ)
-            }
-            Command::Link(expression) => self.infer_command_link(span, subject, expression, emit),
-            Command::Send(argument, process) => {
-                self.infer_command_send(span, subject, argument, process, emit)
-            }
-            Command::Receive(parameter, annotation, (), process, vars) => self
-                .infer_command_receive(span, subject, parameter, annotation, process, vars, emit),
-            Command::Signal(chosen, process) => {
-                self.infer_command_signal(span, subject, chosen, process, emit)
-            }
-            Command::Case(branches, processes, else_process) => {
-                self.infer_command_case(span, subject, branches, processes, else_process, emit)
-            }
-            Command::Break => {
-                if let Err(e) = self.cannot_have_obligations(span) {
-                    emit(e);
-                }
-                (Command::Break, Type::Continue(span.clone()))
-            }
-            Command::Continue(process) => self.infer_command_continue(span, process, emit),
-            Command::Begin { .. } => {
-                emit(TypeError::TypeMustBeKnownAtThisPoint(
-                    span.clone(),
-                    subject.clone(),
-                ));
-                (Command::Break, Type::Fail(span.clone()))
-            }
-            Command::Loop(label, driver, captures) => {
-                self.infer_command_loop(span, label, driver, captures, emit)
-            }
-            Command::SendType(_, _) => {
-                emit(TypeError::TypeMustBeKnownAtThisPoint(
-                    span.clone(),
-                    subject.clone(),
-                ));
-                (Command::Break, Type::Fail(span.clone()))
-            }
-            Command::ReceiveType(parameter, process) => {
-                self.infer_command_receive_type(span, subject, parameter, process, emit)
-            }
-        }
-    }
-
-    fn infer_command_link(
-        &mut self,
-        span: &Span,
-        subject: &LocalName,
-        expression: &Arc<Expression<(), S>>,
-        emit: &mut impl FnMut(TypeError<S>),
-    ) -> (Command<Type<S>, S>, Type<S>) {
-        let (expression, typ) = self.infer_expression(Some(subject), expression, emit);
-        if let Err(e) = self.cannot_have_obligations(span) {
-            emit(e);
-        }
-        (Command::Link(expression), typ.dual(Span::None))
-    }
-
-    fn infer_command_send(
-        &mut self,
-        span: &Span,
-        subject: &LocalName,
-        argument: &Arc<Expression<(), S>>,
-        process: &Arc<Process<(), S>>,
-        emit: &mut impl FnMut(TypeError<S>),
-    ) -> (Command<Type<S>, S>, Type<S>) {
-        let (argument, arg_type) = self.infer_expression(Some(subject), argument, emit);
-        let (process, then_type) = self.infer_process(process, subject, emit);
-        (
-            Command::Send(argument, process),
-            Type::Function(
-                span.clone(),
-                Box::new(arg_type),
-                Box::new(then_type),
-                vec![],
-            ),
-        )
-    }
-
-    fn infer_command_receive(
-        &mut self,
-        span: &Span,
-        subject: &LocalName,
-        parameter: &LocalName,
-        annotation: &Option<Type<S>>,
-        process: &Arc<Process<(), S>>,
-        vars: &[TypeParameter],
-        emit: &mut impl FnMut(TypeError<S>),
-    ) -> (Command<Type<S>, S>, Type<S>) {
-        self.type_defs.extend_vars(vars.iter().cloned());
-        let Some(param_type) = annotation else {
-            emit(TypeError::ParameterTypeMustBeKnown(
-                span.clone(),
-                parameter.clone(),
-            ));
-            let fail = Type::Fail(span.clone());
-            if let Err(e) = self.put(span, parameter.clone(), fail.clone()) {
-                emit(e);
-            }
-            let (process, _then_type) = self.infer_process(process, subject, emit);
-            return (
-                Command::Receive(
-                    parameter.clone(),
-                    annotation.clone(),
-                    fail,
-                    process,
-                    vars.to_vec(),
-                ),
-                Type::Fail(span.clone()),
-            );
-        };
-        if let Err(e) = self.put(span, parameter.clone(), param_type.clone()) {
-            emit(e);
-        }
-        let (process, then_type) = self.infer_process(process, subject, emit);
-        (
-            Command::Receive(
-                parameter.clone(),
-                annotation.clone(),
-                param_type.clone(),
-                process,
-                vars.to_vec(),
-            ),
-            Type::Pair(
-                span.clone(),
-                Box::new(param_type.clone()),
-                Box::new(then_type),
-                vars.to_vec(),
-            ),
-        )
-    }
-
-    fn infer_command_signal(
-        &mut self,
-        span: &Span,
-        subject: &LocalName,
-        chosen: &LocalName,
-        process: &Arc<Process<(), S>>,
-        emit: &mut impl FnMut(TypeError<S>),
-    ) -> (Command<Type<S>, S>, Type<S>) {
-        let (process, then_type) = self.infer_process(process, subject, emit);
-        (
-            Command::Signal(chosen.clone(), process),
-            Type::Choice(span.clone(), BTreeMap::from([(chosen.clone(), then_type)])),
         )
     }
 
@@ -2848,7 +2598,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
         processes: &Box<[Arc<Process<(), S>>]>,
         else_process: &Option<Arc<Process<(), S>>>,
         emit: &mut impl FnMut(TypeError<S>),
-    ) -> (Command<Type<S>, S>, Type<S>) {
+    ) -> (TerminalCommand<Type<S>, S>, Type<S>) {
         if else_process.is_some() {
             emit(TypeError::TypeMustBeKnownAtThisPoint(
                 span.clone(),
@@ -2868,7 +2618,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
                 process
             });
             return (
-                Command::Case(Arc::clone(branches), Box::from(typed_processes), typed_else),
+                TerminalCommand::Case(Arc::clone(branches), Box::from(typed_processes), typed_else),
                 Type::Fail(span.clone()),
             );
         }
@@ -2886,19 +2636,9 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
         }
 
         (
-            Command::Case(Arc::clone(branches), Box::from(typed_processes), None),
+            TerminalCommand::Case(Arc::clone(branches), Box::from(typed_processes), None),
             Type::Either(span.clone(), branch_types),
         )
-    }
-
-    fn infer_command_continue(
-        &mut self,
-        span: &Span,
-        process: &Arc<Process<(), S>>,
-        emit: &mut impl FnMut(TypeError<S>),
-    ) -> (Command<Type<S>, S>, Type<S>) {
-        let process = self.check_process(process, emit);
-        (Command::Continue(process), Type::Break(span.clone()))
     }
 
     fn infer_command_loop(
@@ -2908,10 +2648,10 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
         driver: &LocalName,
         captures: &Captures,
         emit: &mut impl FnMut(TypeError<S>),
-    ) -> (Command<Type<S>, S>, Type<S>) {
+    ) -> (TerminalCommand<Type<S>, S>, Type<S>) {
         let Some((driver_type, variables)) = self.loop_points.get(label).cloned() else {
             emit(TypeError::NoSuchLoopPoint(span.clone(), label.clone()));
-            return (Command::Break, Type::Fail(span.clone()));
+            return (TerminalCommand::Break, Type::Fail(span.clone()));
         };
 
         for (var, type_at_begin) in variables.as_ref() {
@@ -2939,24 +2679,8 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
         }
 
         (
-            Command::Loop(label.clone(), driver.clone(), captures.clone()),
+            TerminalCommand::Loop(label.clone(), driver.clone(), captures.clone()),
             driver_type,
-        )
-    }
-
-    fn infer_command_receive_type(
-        &mut self,
-        span: &Span,
-        subject: &LocalName,
-        parameter: &TypeParameter,
-        process: &Arc<Process<(), S>>,
-        emit: &mut impl FnMut(TypeError<S>),
-    ) -> (Command<Type<S>, S>, Type<S>) {
-        self.type_defs.insert_var(parameter.clone());
-        let (process, then_type) = self.infer_process(process, subject, emit);
-        (
-            Command::ReceiveType(parameter.clone(), process),
-            Type::Exists(span.clone(), parameter.clone(), Box::new(then_type)),
         )
     }
 
@@ -3598,4 +3322,81 @@ fn merge_path_contexts<S: Clone + Eq + std::hash::Hash>(
         merged_variables.insert(name.clone(), acc);
     }
     merged_variables
+}
+
+#[cfg(test)]
+mod flat_ir_tests {
+    use super::*;
+    use crate::frontend_impl::language::Unresolved;
+
+    #[test]
+    fn checks_long_flat_process_with_a_loop() {
+        const STEP_COUNT: usize = 20_000;
+        let subject = LocalName::from(arcstr::literal!("subject"));
+        let mut builder = crate::frontend_impl::process::ProcessBuilder::new();
+        for _ in 0..STEP_COUNT {
+            builder.push(Step::Do {
+                span: Span::None,
+                name: subject.clone(),
+                usage: VariableUsage::Unknown,
+                typ: (),
+                command: Command::Noop,
+            });
+        }
+        let process = builder.finish(Terminator::Do {
+            span: Span::None,
+            name: subject.clone(),
+            usage: VariableUsage::Unknown,
+            typ: (),
+            command: TerminalCommand::Break,
+        });
+
+        let mut context =
+            Context::<Unresolved>::new(TypeDefs::default(), IndexMap::new(), IndexMap::new());
+        context
+            .put(&Span::None, subject, Type::Continue(Span::None))
+            .unwrap();
+        let mut errors = Vec::new();
+        let checked = context.check_process(&process, &mut |error| errors.push(error));
+        assert!(errors.is_empty(), "{errors:#?}");
+        assert_eq!(checked.steps.len(), STEP_COUNT);
+    }
+
+    #[test]
+    fn inferred_continue_checks_the_remaining_suffix() {
+        let subject = LocalName::from(arcstr::literal!("subject"));
+        let other = LocalName::from(arcstr::literal!("other"));
+        let process = Process::do_step(
+            Span::None,
+            subject.clone(),
+            VariableUsage::Unknown,
+            (),
+            Command::Continue,
+            Process::do_terminal(
+                Span::None,
+                other.clone(),
+                VariableUsage::Unknown,
+                (),
+                TerminalCommand::Break,
+            ),
+        );
+        let mut context =
+            Context::<Unresolved>::new(TypeDefs::default(), IndexMap::new(), IndexMap::new());
+        context
+            .put(&Span::None, other, Type::Continue(Span::None))
+            .unwrap();
+        let mut errors = Vec::new();
+        let (checked, inferred) =
+            context.infer_process(&process, &subject, &mut |error| errors.push(error));
+        assert!(errors.is_empty(), "{errors:#?}");
+        assert!(matches!(inferred, Type::Break(_)));
+        assert!(matches!(
+            &checked.steps[0],
+            Step::Do {
+                typ: Type::Break(_),
+                command: Command::Continue,
+                ..
+            }
+        ));
+    }
 }

--- a/crates/par-core/src/frontend_impl/types/visibility.rs
+++ b/crates/par-core/src/frontend_impl/types/visibility.rs
@@ -340,23 +340,32 @@ fn validate_process_visibility(
     visibility: &VisibilityIndex,
     errors: &mut IndexSet<TypeError<Universal>>,
 ) {
-    match process.as_ref() {
-        process::Process::Let {
-            annotation,
-            value,
-            then,
-            ..
-        } => {
-            if let Some(annotation) = annotation {
-                validate_type_visibility_in_type(current_module, annotation, visibility, errors);
+    for step in &process.steps {
+        match step {
+            process::Step::Let {
+                annotation, value, ..
+            } => {
+                if let Some(annotation) = annotation {
+                    validate_type_visibility_in_type(
+                        current_module,
+                        annotation,
+                        visibility,
+                        errors,
+                    );
+                }
+                validate_expression_visibility(current_module, value, visibility, errors);
             }
-            validate_expression_visibility(current_module, value, visibility, errors);
-            validate_process_visibility(current_module, then, visibility, errors);
+            process::Step::Do { command, .. } => {
+                validate_command_visibility(current_module, command, visibility, errors);
+            }
         }
-        process::Process::Do { command, .. } => {
-            validate_command_visibility(current_module, command, visibility, errors);
+    }
+
+    match &process.terminator {
+        process::Terminator::Do { command, .. } => {
+            validate_terminal_command_visibility(current_module, command, visibility, errors);
         }
-        process::Process::Poll {
+        process::Terminator::Poll {
             clients,
             then,
             else_,
@@ -368,16 +377,16 @@ fn validate_process_visibility(
             validate_process_visibility(current_module, then, visibility, errors);
             validate_process_visibility(current_module, else_, visibility, errors);
         }
-        process::Process::Submit { values, .. } => {
+        process::Terminator::Submit { values, .. } => {
             for value in values {
                 validate_expression_visibility(current_module, value, visibility, errors);
             }
         }
-        process::Process::Block(_, _, body, then) => {
+        process::Terminator::Block(_, _, body, then) => {
             validate_process_visibility(current_module, body, visibility, errors);
             validate_process_visibility(current_module, then, visibility, errors);
         }
-        process::Process::Goto(..) | process::Process::Unreachable(..) => {}
+        process::Terminator::Goto(..) | process::Terminator::Unreachable(..) => {}
     }
 }
 
@@ -388,26 +397,33 @@ fn validate_command_visibility(
     errors: &mut IndexSet<TypeError<Universal>>,
 ) {
     match command {
-        process::Command::Noop(process) => {
-            validate_process_visibility(current_module, process, visibility, errors);
-        }
-        process::Command::Link(expression) => {
-            validate_expression_visibility(current_module, expression, visibility, errors);
-        }
-        process::Command::Send(argument, process) => {
+        process::Command::Noop | process::Command::Continue => {}
+        process::Command::Send(argument) => {
             validate_expression_visibility(current_module, argument, visibility, errors);
-            validate_process_visibility(current_module, process, visibility, errors);
         }
-        process::Command::Receive(_, annotation, _, process, _) => {
+        process::Command::Receive(_, annotation, _, _) => {
             if let Some(annotation) = annotation {
                 validate_type_visibility_in_type(current_module, annotation, visibility, errors);
             }
-            validate_process_visibility(current_module, process, visibility, errors);
         }
-        process::Command::Signal(_, process) => {
-            validate_process_visibility(current_module, process, visibility, errors);
+        process::Command::Signal(_) | process::Command::ReceiveType(_) => {}
+        process::Command::SendType(argument) => {
+            validate_type_visibility_in_type(current_module, argument, visibility, errors);
         }
-        process::Command::Case(_, processes, else_process) => {
+    }
+}
+
+fn validate_terminal_command_visibility(
+    current_module: &Universal,
+    command: &process::TerminalCommand<(), Universal>,
+    visibility: &VisibilityIndex,
+    errors: &mut IndexSet<TypeError<Universal>>,
+) {
+    match command {
+        process::TerminalCommand::Link(expression) => {
+            validate_expression_visibility(current_module, expression, visibility, errors);
+        }
+        process::TerminalCommand::Case(_, processes, else_process) => {
             for process in processes {
                 validate_process_visibility(current_module, process, visibility, errors);
             }
@@ -415,20 +431,9 @@ fn validate_command_visibility(
                 validate_process_visibility(current_module, process, visibility, errors);
             }
         }
-        process::Command::Break => {}
-        process::Command::Continue(process) => {
-            validate_process_visibility(current_module, process, visibility, errors);
-        }
-        process::Command::Begin { body, .. } => {
+        process::TerminalCommand::Break | process::TerminalCommand::Loop(..) => {}
+        process::TerminalCommand::Begin { body, .. } => {
             validate_process_visibility(current_module, body, visibility, errors);
-        }
-        process::Command::Loop(..) => {}
-        process::Command::SendType(argument, process) => {
-            validate_type_visibility_in_type(current_module, argument, visibility, errors);
-            validate_process_visibility(current_module, process, visibility, errors);
-        }
-        process::Command::ReceiveType(_, process) => {
-            validate_process_visibility(current_module, process, visibility, errors);
         }
     }
 }


### PR DESCRIPTION
A lot of recursion turned into loops.

Additionally, fixed the bug where `;` was not allowed after some commands because it was natural to fix in the flat representation.