### PR TITLE
Implement typed holes (todo)

### DIFF
--- a/crates/par-core/src/api.rs
+++ b/crates/par-core/src/api.rs
@@ -101,6 +101,7 @@ pub mod frontend {
 }
 
 pub mod runtime {
+    pub use crate::backend::flat::transpiler::{Transpiled, TranspiledGlobal};
     pub use crate::runtime_impl::{Compiled, RuntimeCompilerError};
     pub use crate::typed_readback::{TypedHandle, TypedReadback, type_supports_readback};
     pub use par_runtime::data::Data;

--- a/crates/par-core/src/backend/flat/transpiler.rs
+++ b/crates/par-core/src/backend/flat/transpiler.rs
@@ -6,7 +6,7 @@ use crate::frontend_impl::types::{Type, TypeDefs, TypeError, visit};
 
 use std::sync::OnceLock;
 
-use crate::backend::tree::compiler::IcCompiled;
+use crate::backend::tree::compiler::{CompiledGlobal, IcCompiled};
 use crate::frontend_impl::language::{GlobalName, Universal};
 use crate::runtime_impl::tree;
 use arcstr::ArcStr;
@@ -18,7 +18,7 @@ use par_runtime::flat::runtime::{
 
 use crate::runtime_impl::tree::Net;
 use par_runtime::flat::runtime::Global;
-use par_runtime::linker::{Artifact, LinkError, Linked, Unlinked, link_arena, link_package_ptr};
+use par_runtime::linker::{Artifact, ArtifactGlobal, LinkError, Linked, Unlinked, link_arena, link_package_ptr};
 use par_runtime::pkgid::PackageId;
 
 #[derive(Default)]
@@ -36,10 +36,16 @@ pub(crate) struct ProgramTranspiler {
     id_to_package: Arc<IndexMap<usize, Net<Unlinked>>>,
 }
 
+#[derive(Clone, Debug)]
+pub enum TranspiledGlobal<Ext: Clone> {
+    Package(PackagePtr<Ext>),
+    Unimplemented,
+}
+
 #[derive(Clone)]
 pub struct Transpiled<Ext: Clone> {
     pub arena: Arc<Arena<Ext>>,
-    pub name_to_package: HashMap<GlobalName<Universal>, PackagePtr<Ext>>,
+    pub name_to_package: HashMap<GlobalName<Universal>, TranspiledGlobal<Ext>>,
     pub type_defs: TypeDefs<Universal>,
 }
 
@@ -54,7 +60,12 @@ impl Transpiled<Unlinked> {
                 .map(|(k, v)| {
                     let mut path = k.module.directories.clone();
                     path.push(k.module.module.clone());
-                    (format!("{}.{}", path.join("/"), k.primary), v.clone())
+                    let key = format!("{}.{}", path.join("/"), k.primary);
+                    let val = match v {
+                        TranspiledGlobal::Package(pkg) => ArtifactGlobal::Package(pkg.clone()),
+                        TranspiledGlobal::Unimplemented => ArtifactGlobal::Unimplemented,
+                    };
+                    (key, val)
                 })
                 .collect(),
         }
@@ -99,7 +110,17 @@ impl Transpiled<Unlinked> {
             name_to_package: ic_compiled
                 .name_to_id
                 .iter()
-                .map(|(a, b)| (a.clone(), this.packages_in_nodes.get(b).unwrap().clone()))
+                .map(|(a, b)| match b {
+                    CompiledGlobal::Package(id) => (
+                        a.clone(),
+                        TranspiledGlobal::Package(
+                            this.packages_in_nodes.get(id).unwrap().clone(),
+                        ),
+                    ),
+                    CompiledGlobal::Unimplemented => {
+                        (a.clone(), TranspiledGlobal::Unimplemented)
+                    }
+                })
                 .collect(),
         }
     }
@@ -116,12 +137,6 @@ impl Transpiled<Unlinked> {
     }
 }
 
-impl<Ext: Clone> Transpiled<Ext> {
-    pub fn get_with_name(&self, name: &GlobalName<Universal>) -> Option<PackagePtr<Ext>> {
-        Some(self.name_to_package.get(name).cloned()?)
-    }
-}
-
 pub(crate) fn link_transpiled(
     transpiled: Transpiled<Unlinked>,
 ) -> Result<Transpiled<Linked>, LinkError> {
@@ -131,7 +146,12 @@ pub(crate) fn link_transpiled(
         name_to_package: transpiled
             .name_to_package
             .iter()
-            .map(|(k, v)| (k.clone(), link_package_ptr(v)))
+            .map(|(k, v)| match v {
+                TranspiledGlobal::Package(pkg) => {
+                    (k.clone(), TranspiledGlobal::Package(link_package_ptr(pkg)))
+                }
+                TranspiledGlobal::Unimplemented => (k.clone(), TranspiledGlobal::Unimplemented),
+            })
             .collect(),
     })
 }

--- a/crates/par-core/src/backend/flat/transpiler.rs
+++ b/crates/par-core/src/backend/flat/transpiler.rs
@@ -18,7 +18,9 @@ use par_runtime::flat::runtime::{
 
 use crate::runtime_impl::tree::Net;
 use par_runtime::flat::runtime::Global;
-use par_runtime::linker::{Artifact, ArtifactGlobal, LinkError, Linked, Unlinked, link_arena, link_package_ptr};
+use par_runtime::linker::{
+    Artifact, ArtifactGlobal, LinkError, Linked, Unlinked, link_arena, link_package_ptr,
+};
 use par_runtime::pkgid::PackageId;
 
 #[derive(Default)]
@@ -113,13 +115,9 @@ impl Transpiled<Unlinked> {
                 .map(|(a, b)| match b {
                     CompiledGlobal::Package(id) => (
                         a.clone(),
-                        TranspiledGlobal::Package(
-                            this.packages_in_nodes.get(id).unwrap().clone(),
-                        ),
+                        TranspiledGlobal::Package(this.packages_in_nodes.get(id).unwrap().clone()),
                     ),
-                    CompiledGlobal::Unimplemented => {
-                        (a.clone(), TranspiledGlobal::Unimplemented)
-                    }
+                    CompiledGlobal::Unimplemented => (a.clone(), TranspiledGlobal::Unimplemented),
                 })
                 .collect(),
         }

--- a/crates/par-core/src/backend/tree/compiler.rs
+++ b/crates/par-core/src/backend/tree/compiler.rs
@@ -41,6 +41,7 @@ pub enum Error {
         dependents: IndexSet<GlobalName<Universal>>,
     },
     UnguardedLoop(Span, #[allow(unused)] Option<LocalName>),
+    Unimplemented(Span),
 }
 
 impl Error {
@@ -73,7 +74,8 @@ impl Error {
         match self {
             Error::UnboundVar(span, _)
             | Error::UnknownVariableUsage(span)
-            | Error::UnguardedLoop(span, _) => (span.clone(), vec![]),
+            | Error::UnguardedLoop(span, _)
+            | Error::Unimplemented(span) => (span.clone(), vec![]),
 
             Error::GlobalNotFound(name) => (name.span(), vec![]),
 
@@ -309,11 +311,18 @@ impl Compiler {
     }
 
     fn compile_global(&mut self, name: &GlobalName<Universal>) -> Result<TypedTree> {
-        if let Some(CompiledGlobal::Package(id)) = self.global_name_to_id.get(name) {
-            return Ok(TypedTree {
-                tree: Tree::Package(*id, Box::new(Tree::Break), FanBehavior::Expand),
-                ty: Type::Break(Span::None),
-            });
+        if let Some(global) = self.global_name_to_id.get(name) {
+            match global {
+                CompiledGlobal::Package(id) => {
+                    return Ok(TypedTree {
+                        tree: Tree::Package(*id, Box::new(Tree::Break), FanBehavior::Expand),
+                        ty: Type::Break(Span::None),
+                    });
+                }
+                CompiledGlobal::Unimplemented => {
+                    return Err(Error::Unimplemented(Span::None));
+                }
+            }
         }
         if !self.compile_global_stack.insert(name.clone()) {
             return Err(Error::DependencyCycle {
@@ -337,18 +346,31 @@ impl Compiler {
             _ => return Err(Error::GlobalNotFound(name.clone())),
         };
 
-        let (id, typ) = self.in_package(name.to_string(), |this, _| {
+        let result = self.in_package(name.to_string(), |this, _| {
             let mut s = String::new();
             global.pretty(&mut s, 0).unwrap();
             Ok((
                 this.compile_expression(global.as_ref())?,
                 (Tree::Continue).with_type(Type::Continue(Span::None)),
             ))
-        })?;
-        self.global_name_to_id
-            .insert(name.clone(), CompiledGlobal::Package(id));
-        self.compile_global_stack.shift_remove(name);
-        Ok(Tree::Package(id, Box::new(Tree::Break), FanBehavior::Expand).with_type(typ))
+        });
+
+        match result {
+            Ok((id, typ)) => {
+                self.global_name_to_id
+                    .insert(name.clone(), CompiledGlobal::Package(id));
+                self.compile_global_stack.shift_remove(name);
+                Ok(Tree::Package(id, Box::new(Tree::Break), FanBehavior::Expand).with_type(typ))
+            }
+            Err(err) => {
+                if matches!(err, Error::Unimplemented(_)) {
+                    self.global_name_to_id
+                        .insert(name.clone(), CompiledGlobal::Unimplemented);
+                }
+                self.compile_global_stack.shift_remove(name);
+                Err(err)
+            }
+        }
     }
 
     /// Optimize away erasure underneath auxiliary ports of DUP and CON nodes where it is safe to do so.
@@ -411,7 +433,15 @@ impl Compiler {
         let old_lazy_redexes = core::mem::take(&mut self.lazy_redexes);
         // Allocate package
         self.id_to_package.push(Default::default());
-        let (mut root, captures) = self.with_captures(&Captures::default(), |this| f(this, id))?;
+        let (mut root, captures) = match self.with_captures(&Captures::default(), |this| f(this, id)) {
+            Ok(val) => val,
+            Err(err) => {
+                self.id_to_package.pop();
+                self.lazy_redexes = old_lazy_redexes;
+                self.net = old_net;
+                return Err(err);
+            }
+        };
 
         // Non-principal interaction optimization pass
         root.tree = self.non_principal_interactions(root.tree);
@@ -701,7 +731,7 @@ impl Compiler {
             Terminator::Goto(_, index, _) => self.compile_process_goto(*index)?,
 
             Terminator::Unreachable(_) => self.compile_process_unreachable()?,
-            Terminator::ToDo(_) => todo!(),
+            Terminator::ToDo(span) => return Err(Error::Unimplemented(span.clone())),
         }
 
         for (parameter, was_empty_before) in received_parameters.into_iter().rev() {
@@ -1229,7 +1259,6 @@ impl Compiler {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum CompiledGlobal {
     Package(usize),
-    #[allow(dead_code)]
     Unimplemented,
 }
 
@@ -1290,7 +1319,10 @@ impl IcCompiled {
         };
 
         for name in compiler.definitions.keys().cloned().collect::<Vec<_>>() {
-            compiler.compile_global(&name)?;
+            match compiler.compile_global(&name) {
+                Ok(_) | Err(Error::Unimplemented(_)) => {}
+                Err(err) => return Err(err),
+            }
         }
 
         Ok(IcCompiled {

--- a/crates/par-core/src/backend/tree/compiler.rs
+++ b/crates/par-core/src/backend/tree/compiler.rs
@@ -433,15 +433,16 @@ impl Compiler {
         let old_lazy_redexes = core::mem::take(&mut self.lazy_redexes);
         // Allocate package
         self.id_to_package.push(Default::default());
-        let (mut root, captures) = match self.with_captures(&Captures::default(), |this| f(this, id)) {
-            Ok(val) => val,
-            Err(err) => {
-                self.id_to_package.pop();
-                self.lazy_redexes = old_lazy_redexes;
-                self.net = old_net;
-                return Err(err);
-            }
-        };
+        let (mut root, captures) =
+            match self.with_captures(&Captures::default(), |this| f(this, id)) {
+                Ok(val) => val,
+                Err(err) => {
+                    self.id_to_package.pop();
+                    self.lazy_redexes = old_lazy_redexes;
+                    self.net = old_net;
+                    return Err(err);
+                }
+            };
 
         // Non-principal interaction optimization pass
         root.tree = self.non_principal_interactions(root.tree);

--- a/crates/par-core/src/backend/tree/compiler.rs
+++ b/crates/par-core/src/backend/tree/compiler.rs
@@ -242,7 +242,7 @@ pub(crate) struct Compiler {
             Type<Universal>,
         ),
     >,
-    global_name_to_id: IndexMap<GlobalName<Universal>, usize>,
+    global_name_to_id: IndexMap<GlobalName<Universal>, CompiledGlobal>,
     id_to_package: Vec<Net<Unlinked>>,
     lazy_redexes: Vec<(Tree<Unlinked>, Tree<Unlinked>)>,
     compile_global_stack: IndexSet<GlobalName<Universal>>,
@@ -309,12 +309,12 @@ impl Compiler {
     }
 
     fn compile_global(&mut self, name: &GlobalName<Universal>) -> Result<TypedTree> {
-        if let Some(id) = self.global_name_to_id.get(name) {
+        if let Some(CompiledGlobal::Package(id)) = self.global_name_to_id.get(name) {
             return Ok(TypedTree {
                 tree: Tree::Package(*id, Box::new(Tree::Break), FanBehavior::Expand),
                 ty: Type::Break(Span::None),
             });
-        };
+        }
         if !self.compile_global_stack.insert(name.clone()) {
             return Err(Error::DependencyCycle {
                 global: name.clone(),
@@ -345,7 +345,8 @@ impl Compiler {
                 (Tree::Continue).with_type(Type::Continue(Span::None)),
             ))
         })?;
-        self.global_name_to_id.insert(name.clone(), id);
+        self.global_name_to_id
+            .insert(name.clone(), CompiledGlobal::Package(id));
         self.compile_global_stack.shift_remove(name);
         Ok(Tree::Package(id, Box::new(Tree::Break), FanBehavior::Expand).with_type(typ))
     }
@@ -700,6 +701,7 @@ impl Compiler {
             Terminator::Goto(_, index, _) => self.compile_process_goto(*index)?,
 
             Terminator::Unreachable(_) => self.compile_process_unreachable()?,
+            Terminator::ToDo(_) => todo!(),
         }
 
         for (parameter, was_empty_before) in received_parameters.into_iter().rev() {
@@ -1224,10 +1226,17 @@ impl Compiler {
     }
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum CompiledGlobal {
+    Package(usize),
+    #[allow(dead_code)]
+    Unimplemented,
+}
+
 #[derive(Clone, Default)]
 pub struct IcCompiled {
     pub(crate) id_to_package: Arc<IndexMap<usize, Net<Unlinked>>>,
-    pub(crate) name_to_id: IndexMap<GlobalName<Universal>, usize>,
+    pub(crate) name_to_id: IndexMap<GlobalName<Universal>, CompiledGlobal>,
     package_is_case_branch: IndexMap<usize, ArcStr>,
 }
 
@@ -1236,7 +1245,7 @@ impl Display for IcCompiled {
         for (k, v) in self.id_to_package.iter() {
             // check if it has a name
             for (name, id) in self.name_to_id.iter() {
-                if id == k {
+                if id == &CompiledGlobal::Package(*k) {
                     f.write_fmt(format_args!("// {} \n", name))?;
                 }
             }
@@ -1247,11 +1256,6 @@ impl Display for IcCompiled {
 }
 
 impl IcCompiled {
-    pub fn get_with_name(&self, name: &GlobalName<Universal>) -> Option<Net<Unlinked>> {
-        let id = self.name_to_id.get(name)?;
-        self.id_to_package.get(id).cloned()
-    }
-
     pub fn get_case_branch_name(&self, id: usize) -> Option<ArcStr> {
         self.package_is_case_branch.get(&id).cloned()
     }

--- a/crates/par-core/src/frontend_impl/captures.rs
+++ b/crates/par-core/src/frontend_impl/captures.rs
@@ -315,6 +315,9 @@ impl CaptureAnalysis {
             Terminator::Unreachable(span) => {
                 (Terminator::Unreachable(span.clone()), Captures::new())
             }
+            Terminator::ToDo(span) => {
+                (Terminator::ToDo(span.clone()), Captures::new())
+            }
         }
     }
 
@@ -606,7 +609,7 @@ impl BlockEnvAnalyzer {
             Terminator::Goto(_, index, _) => {
                 self.schedule_block(*index, env);
             }
-            Terminator::Unreachable(_) => {}
+            Terminator::Unreachable(_) | Terminator::ToDo(_) => {}
         }
     }
 
@@ -860,7 +863,7 @@ impl<'a> CaptureCollector<'a> {
             Terminator::Goto(_, index, _) => {
                 self.old_block_caps.get(index).cloned().unwrap_or_default()
             }
-            Terminator::Unreachable(_) => Captures::new(),
+            Terminator::Unreachable(_) | Terminator::ToDo(_) => Captures::new(),
         }
     }
 

--- a/crates/par-core/src/frontend_impl/captures.rs
+++ b/crates/par-core/src/frontend_impl/captures.rs
@@ -315,9 +315,7 @@ impl CaptureAnalysis {
             Terminator::Unreachable(span) => {
                 (Terminator::Unreachable(span.clone()), Captures::new())
             }
-            Terminator::ToDo(span) => {
-                (Terminator::ToDo(span.clone()), Captures::new())
-            }
+            Terminator::ToDo(span) => (Terminator::ToDo(span.clone()), Captures::new()),
         }
     }
 

--- a/crates/par-core/src/frontend_impl/language.rs
+++ b/crates/par-core/src/frontend_impl/language.rs
@@ -605,6 +605,7 @@ pub enum ProcessTerminator<S> {
     },
     Command(ProcessCommand<S>),
     Fallthrough(Span),
+    ToDo(Span),
 }
 
 #[derive(Clone, Debug)]
@@ -2775,6 +2776,7 @@ impl Context {
                 Some(process) => process,
                 None => Err(CompileError::MustEndProcess(span.clone()))?,
             },
+            ProcessTerminator::ToDo(span) => process::Process::todo(span.clone()),
         })
     }
 
@@ -3900,7 +3902,8 @@ impl<S> Spanning for ProcessTerminator<S> {
             | Self::Submit { span, .. }
             | Self::If { span, .. }
             | Self::Throw(span, ..)
-            | Self::Fallthrough(span) => span.clone(),
+            | Self::Fallthrough(span)
+            | Self::ToDo(span) => span.clone(),
             Self::Command(command) => command.span.clone(),
         }
     }

--- a/crates/par-core/src/frontend_impl/language.rs
+++ b/crates/par-core/src/frontend_impl/language.rs
@@ -439,6 +439,7 @@ pub enum Expression<S> {
     },
     Construction(Span, Construct<S>),
     Application(Span, Box<Self>, Apply<S>),
+    ToDo(Span),
 }
 
 #[derive(Clone, Debug)]
@@ -572,6 +573,7 @@ pub enum ProcessStep<S> {
         else_: Option<Box<Process<S>>>,
     },
     Command(ProcessCommand<S>),
+    ToDo(Span),
 }
 
 #[derive(Clone, Debug)]
@@ -2232,6 +2234,16 @@ impl Context {
                     ),
                 })
             }
+
+            Expression::ToDo(span) => Arc::new(process::Expression::Chan {
+                span: span.clone(),
+                captures: Captures::new(),
+                chan_name: LocalName::result(),
+                chan_annotation: None,
+                chan_type: (),
+                expr_type: (),
+                process: process::Process::todo(span.clone()),
+            }),
         });
         let None = self.original_object_name else {
             unreachable!("original_object_name should be none after expression")
@@ -2683,6 +2695,9 @@ impl Context {
                 }
                 ProcessStep::Command(command) => {
                     break self.compile_process_command(command, Some((source, index + 1)))?;
+                }
+                ProcessStep::ToDo(span) => {
+                    break process::Process::todo(span.clone());
                 }
             }
         };
@@ -3740,7 +3755,8 @@ impl<S> Spanning for Expression<S> {
             | Self::Neg { span, .. }
             | Self::ComparisonChain { span, .. }
             | Self::Application(span, _, _)
-            | Self::Construction(span, _) => span.clone(),
+            | Self::Construction(span, _)
+            | Self::ToDo(span) => span.clone(),
         }
     }
 }
@@ -3886,9 +3902,10 @@ impl<S> Spanning for Process<S> {
 impl<S> Spanning for ProcessStep<S> {
     fn span(&self) -> Span {
         match self {
-            Self::Let { span, .. } | Self::Catch { span, .. } | Self::If { span, .. } => {
-                span.clone()
-            }
+            Self::Let { span, .. }
+            | Self::Catch { span, .. }
+            | Self::If { span, .. }
+            | Self::ToDo(span) => span.clone(),
             Self::Command(command) => command.span.clone(),
         }
     }

--- a/crates/par-core/src/frontend_impl/lexer.rs
+++ b/crates/par-core/src/frontend_impl/lexer.rs
@@ -93,6 +93,7 @@ pub enum TokenKind {
     Type,
     Unfounded,
     External,
+    Todo,
 
     Unknown,
 }
@@ -228,6 +229,7 @@ impl TokenKind {
             TokenKind::Type => "type",
             TokenKind::Unfounded => "unfounded",
             TokenKind::External => "external",
+            TokenKind::Todo => "todo",
 
             TokenKind::Unknown => "???",
         }
@@ -325,6 +327,7 @@ fn identifier_kind(raw: &str) -> Option<TokenKind> {
         "type" => TokenKind::Type,
         "unfounded" => TokenKind::Unfounded,
         "external" => TokenKind::External,
+        "todo" => TokenKind::Todo,
         raw if raw.starts_with(char::is_uppercase) => TokenKind::UppercaseIdentifier,
         _ => TokenKind::LowercaseIdentifier,
     })

--- a/crates/par-core/src/frontend_impl/parse.rs
+++ b/crates/par-core/src/frontend_impl/parse.rs
@@ -1643,6 +1643,7 @@ fn expression_without_construction(input: &mut Input) -> Result<Expression<Unres
         expr_do,
         expr_box,
         expr_chan,
+        expr_todo,
         infix_or,
     ))
     .context(StrContext::Label("expression"))
@@ -2770,6 +2771,7 @@ fn process_head(input: &mut Input) -> Result<(Span, ProcessHead)> {
         proc_compound_assign,
         proc_catch,
         proc_throw,
+        proc_todo,
         expression_command,
         global_command,
         command,
@@ -3023,6 +3025,23 @@ fn proc_throw(input: &mut Input) -> Result<(Span, ProcessHead)> {
                 )),
             )
         })
+        .parse_next(input)
+}
+
+fn proc_todo(input: &mut Input) -> Result<(Span, ProcessHead)> {
+    t(TokenKind::Todo)
+        .map(|token| {
+            (
+                token.span.clone(),
+                ProcessHead::Terminator(ProcessTerminator::ToDo(token.span.clone())),
+            )
+        })
+        .parse_next(input)
+}
+
+fn expr_todo(input: &mut Input) -> Result<Expression<Unresolved>> {
+    t(TokenKind::Todo)
+        .map(|token| Expression::ToDo(token.span.clone()))
         .parse_next(input)
 }
 

--- a/crates/par-core/src/frontend_impl/process.rs
+++ b/crates/par-core/src/frontend_impl/process.rs
@@ -81,6 +81,7 @@ pub enum Terminator<Typ, S> {
     Block(Span, usize, Arc<Process<Typ, S>>, Arc<Process<Typ, S>>),
     Goto(Span, usize, Captures),
     Unreachable(Span),
+    ToDo(Span),
 }
 
 #[derive(Clone, Debug)]
@@ -151,6 +152,7 @@ impl<Typ, S> Spanning for Terminator<Typ, S> {
             Self::Block(span, _, _, _) => span.clone(),
             Self::Goto(span, _, _) => span.clone(),
             Self::Unreachable(span) => span.clone(),
+            Self::ToDo(span) => span.clone(),
         }
     }
 }
@@ -238,6 +240,10 @@ impl<Typ, S> Process<Typ, S> {
             typ,
             command,
         })
+    }
+
+    pub fn todo(span: Span) -> Arc<Self> {
+        Self::terminal(Terminator::ToDo(span))
     }
 }
 
@@ -438,6 +444,7 @@ impl<S: Clone> Process<(), S> {
                 Terminator::Goto(span.clone(), *index, caps.clone())
             }
             Terminator::Unreachable(span) => Terminator::Unreachable(span.clone()),
+            Terminator::ToDo(span) => Terminator::ToDo(span.clone()),
         };
 
         Arc::new(Process::new(steps, terminator))
@@ -532,7 +539,7 @@ impl<S: Clone + Eq + std::hash::Hash + std::fmt::Display> Process<Type<S>, S> {
                 body.types_at_spans(program, docs, consume);
                 process.types_at_spans(program, docs, consume);
             }
-            Terminator::Goto(_, _, _) | Terminator::Unreachable(_) => {}
+            Terminator::Goto(_, _, _) | Terminator::Unreachable(_) | Terminator::ToDo(_) => {}
         }
     }
 }
@@ -1066,6 +1073,7 @@ impl<S: Clone> Process<Type<S>, S> {
                 Terminator::Goto(span.clone(), *index, captures.clone())
             }
             Terminator::Unreachable(span) => Terminator::Unreachable(span.clone()),
+            Terminator::ToDo(span) => Terminator::ToDo(span.clone()),
         };
         Arc::new(Process::new(steps, terminator))
     }
@@ -1283,6 +1291,7 @@ impl<S: Clone> Process<(), S> {
             ),
             Terminator::Goto(span, index, captures) => Terminator::Goto(span, index, captures),
             Terminator::Unreachable(span) => Terminator::Unreachable(span),
+            Terminator::ToDo(span) => Terminator::ToDo(span),
         };
         Ok(Process::new(steps, terminator))
     }
@@ -1501,7 +1510,7 @@ impl<Typ, S> Process<Typ, S> {
             }
             Terminator::Block(_, _, _body, process) => process.free_variables(),
             Terminator::Goto(_, _, caps) => caps.names.keys().cloned().collect(),
-            Terminator::Unreachable(_) => IndexSet::new(),
+            Terminator::Unreachable(_) | Terminator::ToDo(_) => IndexSet::new(),
         };
 
         for step in self.steps.iter().rev() {
@@ -1543,6 +1552,10 @@ impl<Typ, S: Clone + std::fmt::Display> Process<Typ, S> {
         match &self.terminator {
             Terminator::Unreachable(_) => {
                 write!(f, "unreachable")
+            }
+
+            Terminator::ToDo(_) => {
+                write!(f, "todo")
             }
 
             Terminator::Poll {

--- a/crates/par-core/src/frontend_impl/types/checking.rs
+++ b/crates/par-core/src/frontend_impl/types/checking.rs
@@ -302,6 +302,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
                 captures,
             } => self.check_process_submit(span, driver, point, values, captures, emit),
             Terminator::Unreachable(span) => self.check_process_unreachable(span, emit),
+            Terminator::ToDo(span) => self.check_process_todo(span, emit),
             Terminator::Block(span, index, body, then) => {
                 self.check_process_block(span, *index, body, then, emit)
             }
@@ -738,6 +739,44 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
         }
         self.variables.clear();
         Terminator::Unreachable(span.clone())
+    }
+
+    fn check_process_todo(
+        &mut self,
+        span: &Span,
+        emit: &mut impl FnMut(TypeError<S>),
+    ) -> Terminator<Type<S>, S> {
+        for (name, typ) in &self.variables {
+            if self.type_has_holes(typ) {
+                emit(TypeError::TypeMustBeKnownAtThisPoint(
+                    span.clone(),
+                    name.clone(),
+                ));
+            }
+        }
+        self.variables.clear();
+        Terminator::ToDo(span.clone())
+    }
+
+    fn type_has_holes(&self, typ: &Type<S>) -> bool {
+        match typ {
+            Type::Hole(..) | Type::DualHole(..) => true,
+            Type::Name(_, _, args) | Type::DualName(_, _, args) => {
+                args.iter().any(|arg| self.type_has_holes(arg))
+            }
+            Type::Box(_, inner) | Type::DualBox(_, inner) => self.type_has_holes(inner),
+            Type::Pair(_, left, right, _) | Type::Function(_, left, right, _) => {
+                self.type_has_holes(left) || self.type_has_holes(right)
+            }
+            Type::Either(_, branches) | Type::Choice(_, branches) => {
+                branches.values().any(|branch| self.type_has_holes(branch))
+            }
+            Type::Recursive { body, .. } | Type::Iterative { body, .. } => {
+                self.type_has_holes(body)
+            }
+            Type::Exists(_, _, body) | Type::Forall(_, _, body) => self.type_has_holes(body),
+            _ => false,
+        }
     }
 
     fn check_process_block(
@@ -1994,6 +2033,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
                 emit,
             ),
             Terminator::Unreachable(span) => self.infer_process_unreachable(span, emit),
+            Terminator::ToDo(span) => self.infer_process_todo(span, inference_subject, emit),
             Terminator::Block(span, index, body, then) => {
                 self.infer_process_block(span, *index, body, then, inference_subject, emit)
             }
@@ -2497,6 +2537,20 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
         }
         self.variables.clear();
         (Terminator::Unreachable(span.clone()), Type::choice(vec![]))
+    }
+
+    fn infer_process_todo(
+        &mut self,
+        span: &Span,
+        inference_subject: &LocalName,
+        emit: &mut impl FnMut(TypeError<S>),
+    ) -> (Terminator<Type<S>, S>, Type<S>) {
+        emit(TypeError::TypeMustBeKnownAtThisPoint(
+            span.clone(),
+            inference_subject.clone(),
+        ));
+        self.variables.clear();
+        (Terminator::ToDo(span.clone()), Type::Fail(span.clone()))
     }
 
     fn infer_process_block(

--- a/crates/par-core/src/frontend_impl/types/checking.rs
+++ b/crates/par-core/src/frontend_impl/types/checking.rs
@@ -746,6 +746,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
         span: &Span,
         emit: &mut impl FnMut(TypeError<S>),
     ) -> Terminator<Type<S>, S> {
+        emit(TypeError::Todo(span.clone()));
         for (name, typ) in &self.variables {
             if self.type_has_holes(typ) {
                 emit(TypeError::TypeMustBeKnownAtThisPoint(
@@ -2545,6 +2546,7 @@ impl<S: Clone + Eq + std::hash::Hash> Context<S> {
         inference_subject: &LocalName,
         emit: &mut impl FnMut(TypeError<S>),
     ) -> (Terminator<Type<S>, S>, Type<S>) {
+        emit(TypeError::Todo(span.clone()));
         emit(TypeError::TypeMustBeKnownAtThisPoint(
             span.clone(),
             inference_subject.clone(),

--- a/crates/par-core/src/frontend_impl/types/error.rs
+++ b/crates/par-core/src/frontend_impl/types/error.rs
@@ -553,7 +553,7 @@ impl<S: Clone + Eq + std::hash::Hash + std::fmt::Display> TypeError<S> {
                 miette::miette!(
                     severity = miette::Severity::Warning,
                     labels = labels,
-                    "Unimplemented code (`todo`)"
+                    "Incomplete code (`todo`)"
                 )
             }
         }.with_source_code(source_code)

--- a/crates/par-core/src/frontend_impl/types/error.rs
+++ b/crates/par-core/src/frontend_impl/types/error.rs
@@ -60,6 +60,7 @@ pub enum TypeError<S> {
     PollBranchMustSubmit(Span),
     CannotUseLinearVariableInBox(Span, LocalName),
     NonExhaustiveIf(Span),
+    Todo(Span),
 }
 
 /// Create a `LabeledSpan` without a label at `span`
@@ -547,7 +548,19 @@ impl<S: Clone + Eq + std::hash::Hash + std::fmt::Display> TypeError<S> {
                 )
 
             }
+            Self::Todo(span) => {
+                let labels = labels_from_span(code, span);
+                miette::miette!(
+                    severity = miette::Severity::Warning,
+                    labels = labels,
+                    "Unimplemented code (`todo`)"
+                )
+            }
         }.with_source_code(source_code)
+    }
+
+    pub fn is_warning(&self) -> bool {
+        matches!(self, Self::Todo(_))
     }
 }
 
@@ -619,6 +632,7 @@ impl<S: Clone + Eq + std::hash::Hash> TypeError<S> {
             | Self::PollBranchMustSubmit(span)
             | Self::CannotUseLinearVariableInBox(span, _)
             | Self::NonExhaustiveIf(span)
+            | Self::Todo(span)
             | Self::CannotUnrollAscendantIterative(span, _) => (span.clone(), None),
 
             Self::TypesCannotBeUnified(span, _typ1, _typ2) => (span.clone(), None),

--- a/crates/par-core/src/frontend_impl/types/visibility.rs
+++ b/crates/par-core/src/frontend_impl/types/visibility.rs
@@ -386,7 +386,9 @@ fn validate_process_visibility(
             validate_process_visibility(current_module, body, visibility, errors);
             validate_process_visibility(current_module, then, visibility, errors);
         }
-        process::Terminator::Goto(..) | process::Terminator::Unreachable(..) => {}
+        process::Terminator::Goto(..)
+        | process::Terminator::Unreachable(..)
+        | process::Terminator::ToDo(..) => {}
     }
 }
 

--- a/crates/par-runtime/src/linker.rs
+++ b/crates/par-runtime/src/linker.rs
@@ -187,9 +187,7 @@ impl Artifact<Unlinked> {
                     ArtifactGlobal::Package(pkg) => {
                         (k.clone(), ArtifactGlobal::Package(link_package_ptr(pkg)))
                     }
-                    ArtifactGlobal::Unimplemented => {
-                        (k.clone(), ArtifactGlobal::Unimplemented)
-                    }
+                    ArtifactGlobal::Unimplemented => (k.clone(), ArtifactGlobal::Unimplemented),
                 })
                 .collect(),
         })

--- a/crates/par-runtime/src/linker.rs
+++ b/crates/par-runtime/src/linker.rs
@@ -164,10 +164,16 @@ pub fn link_package_ptr(package: &PackagePtr<Unlinked>) -> PackagePtr<Linked> {
     Index(package.0.clone())
 }
 
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub enum ArtifactGlobal<Ext: Clone> {
+    Package(PackagePtr<Ext>),
+    Unimplemented,
+}
+
 #[derive(Serialize, Deserialize)]
 pub struct Artifact<Ext: Clone> {
     pub arena: Arc<Arena<Ext>>,
-    pub definition_to_package: HashMap<String, PackagePtr<Ext>>,
+    pub definition_to_package: HashMap<String, ArtifactGlobal<Ext>>,
 }
 
 impl Artifact<Unlinked> {
@@ -177,7 +183,14 @@ impl Artifact<Unlinked> {
             definition_to_package: self
                 .definition_to_package
                 .iter()
-                .map(|(k, v)| (k.clone(), link_package_ptr(v)))
+                .map(|(k, v)| match v {
+                    ArtifactGlobal::Package(pkg) => {
+                        (k.clone(), ArtifactGlobal::Package(link_package_ptr(pkg)))
+                    }
+                    ArtifactGlobal::Unimplemented => {
+                        (k.clone(), ArtifactGlobal::Unimplemented)
+                    }
+                })
                 .collect(),
         })
     }

--- a/src/language_server/feedback.rs
+++ b/src/language_server/feedback.rs
@@ -74,11 +74,17 @@ pub fn diagnostic_for_error(err: &CompileError, fallback_uri: &Uri) -> (Uri, lsp
             (span, error.to_string(), related_spans)
         }
     };
+    let severity = match err {
+        CompileError::Type { error, .. } if error.error.is_warning() => {
+            lsp::DiagnosticSeverity::WARNING
+        }
+        _ => lsp::DiagnosticSeverity::ERROR,
+    };
     (
         uri_for_error(err).unwrap_or_else(|| fallback_uri.clone()),
         lsp::Diagnostic {
             range: span_to_lsp_range(&span),
-            severity: Some(lsp::DiagnosticSeverity::ERROR),
+            severity: Some(severity),
             code: None,
             code_description: None,
             source: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,12 +11,12 @@ use clap::{Command, arg, command, value_parser};
 use colored::Colorize;
 #[cfg(feature = "playground")]
 use eframe::egui;
+use par_core::runtime::TranspiledGlobal;
 use par_core::{
     frontend::{Type, is_lowercase_identifier, set_miette_hook},
     runtime::RuntimeCompilerError,
     workspace::{CheckedWorkspace, ModulePath, WorkspaceDiscoveryError, WorkspaceError},
 };
-use par_core::runtime::TranspiledGlobal;
 use par_doc::DocOptions;
 use tokio::time::Instant;
 #[cfg(not(target_family = "wasm"))]

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,12 +16,13 @@ use par_core::{
     runtime::RuntimeCompilerError,
     workspace::{CheckedWorkspace, ModulePath, WorkspaceDiscoveryError, WorkspaceError},
 };
+use par_core::runtime::TranspiledGlobal;
 use par_doc::DocOptions;
 use tokio::time::Instant;
 #[cfg(not(target_family = "wasm"))]
 use url::Url;
 
-use par_runtime::linker::{Artifact, Linked, Unlinked};
+use par_runtime::linker::{Artifact, ArtifactGlobal, Linked, Unlinked};
 use par_runtime::spawn::TokioSpawn;
 use std::fmt::Display;
 use std::fs::{self, File};
@@ -661,8 +662,32 @@ fn run_definition(
             return;
         };
 
+        let package_to_run = match rt_compiled.code.name_to_package.get(name) {
+            Some(TranspiledGlobal::Package(pkg)) => pkg.clone(),
+            Some(TranspiledGlobal::Unimplemented) => {
+                println!(
+                    "{}",
+                    format!(
+                        "Definition {} is unimplemented (directly or indirectly contains a todo; run `par check` for details)",
+                        target.unwrap_or_else(|| "Main.Main".to_string())
+                    )
+                    .bright_red()
+                );
+                return;
+            }
+            None => {
+                println!(
+                    "{}",
+                    format!(
+                        "Definition {} not found",
+                        target.unwrap_or_else(|| "Main.Main".to_string())
+                    )
+                    .bright_red()
+                );
+                return;
+            }
+        };
         let start = Instant::now();
-        let package_to_run = rt_compiled.code.get_with_name(name).unwrap();
         let start_runtime = if print_stats {
             par_runtime::start_and_instantiate_with_stats
         } else {
@@ -706,10 +731,20 @@ fn run_definition_vm(binary_path: PathBuf, target: Option<String>, print_stats: 
         let target = format!("{}.{}", parsed_target.module_path, definition_target);
 
         let start = Instant::now();
-        let package_to_run = artifact
-            .definition_to_package
-            .get(&target)
-            .expect(format!("Definition {target} not found").as_str());
+        let package_to_run = match artifact.definition_to_package.get(&target) {
+            Some(ArtifactGlobal::Package(pkg)) => pkg,
+            Some(ArtifactGlobal::Unimplemented) => {
+                println!(
+                    "{}",
+                    format!("Definition {target} is unimplemented (directly or indirectly contains a todo; run `par check` for details)").bright_red()
+                );
+                return;
+            }
+            None => {
+                println!("{}", format!("Definition {target} not found").bright_red());
+                return;
+            }
+        };
         let start_runtime = if print_stats {
             par_runtime::start_and_instantiate_with_stats
         } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -683,7 +683,7 @@ fn run_definition(
                 println!(
                     "{}",
                     format!(
-                        "Definition {} is unimplemented (directly or indirectly contains a todo; run `par check` for details)",
+                        "Definition {} is incomplete (directly or indirectly contains a todo; run `par check` for details)",
                         target.unwrap_or_else(|| "Main.Main".to_string())
                     )
                     .bright_red()
@@ -751,7 +751,7 @@ fn run_definition_vm(binary_path: PathBuf, target: Option<String>, print_stats: 
             Some(ArtifactGlobal::Unimplemented) => {
                 println!(
                     "{}",
-                    format!("Definition {target} is unimplemented (directly or indirectly contains a todo; run `par check` for details)").bright_red()
+                    format!("Definition {target} is incomplete (directly or indirectly contains a todo; run `par check` for details)").bright_red()
                 );
                 return;
             }

--- a/src/main.rs
+++ b/src/main.rs
@@ -170,7 +170,7 @@ impl Display for NewPackageError {
 fn build_checked_package(package_path: &PathBuf) -> Result<CheckedWorkspaceBuild, BuildError> {
     let build =
         checked_workspace_from_path(package_path, None).map_err(map_workspace_build_error)?;
-    if !build.type_errors.is_empty() {
+    if build.type_errors.iter().any(|e| !e.error.is_warning()) {
         return Err(BuildError::Type {
             errors: build.type_errors,
             sources: build.sources.clone(),

--- a/src/main.rs
+++ b/src/main.rs
@@ -94,17 +94,26 @@ enum BuildError {
 impl BuildError {
     fn display(&self) -> String {
         match self {
-            Self::Discovery(error) => error.to_string(),
-            Self::Workspace(error) => error.to_string(),
+            Self::Discovery(error) => error.to_string().bright_red().to_string(),
+            Self::Workspace(error) => error.to_string().bright_red().to_string(),
             Self::Type { errors, sources } => errors
                 .iter()
-                .map(|error| format!("{:?}", error.to_report(sources)))
+                .map(|error| {
+                    let report = format!("{:?}", error.to_report(sources));
+                    if error.error.is_warning() {
+                        report.yellow().to_string()
+                    } else {
+                        report.bright_red().to_string()
+                    }
+                })
                 .collect::<Vec<_>>()
                 .join("\n"),
             Self::InetCompile { error, sources } => format!(
                 "inet compilation error: {}",
                 error.display(&source_for_fallback(sources))
-            ),
+            )
+            .bright_red()
+            .to_string(),
         }
     }
 }
@@ -175,6 +184,12 @@ fn build_checked_package(package_path: &PathBuf) -> Result<CheckedWorkspaceBuild
             errors: build.type_errors,
             sources: build.sources.clone(),
         });
+    }
+    for warning in build.warnings() {
+        eprintln!(
+            "{}",
+            format!("{:?}", warning.to_report(&build.sources)).yellow()
+        );
     }
     Ok(build)
 }
@@ -641,7 +656,7 @@ fn run_definition(
             match build_runtime_package(&package_path, max_interactions) {
                 Ok((checked, rt_compiled, local_modules)) => (checked, rt_compiled, local_modules),
                 Err(error) => {
-                    println!("{}", error.display().bright_red());
+                    println!("{}", error.display());
                     return;
                 }
             };
@@ -773,7 +788,7 @@ fn compile(package_path: PathBuf, max_interactions: u32) {
                 (checked, rt_compiled, local_modules, sources)
             }
             Err(error) => {
-                println!("{}", error.display().bright_red());
+                println!("{}", error.display());
                 return;
             }
         };
@@ -818,7 +833,7 @@ fn check(package_path: PathBuf) -> Result<(), String> {
     let build_result = build_runtime_package(&package_path, MAX_INTERACTIONS_DEFAULT);
     if let Err(error) = build_result {
         let error_string = error.display();
-        eprintln!("{}", error_string.bright_red());
+        eprintln!("{error_string}");
         return Err(error_string);
     }
     Ok(())

--- a/src/playground/app.rs
+++ b/src/playground/app.rs
@@ -712,6 +712,14 @@ impl Playground {
                         );
                     }
 
+                    if let Some(warnings) = self.build.warnings() {
+                        ui.label(
+                            egui::RichText::new(warnings.display(self.built_code.clone()))
+                                .color(yellow())
+                                .code(),
+                        );
+                    }
+
                     let theme = self.get_theme(ui);
 
                     if self.show_compiled {
@@ -818,6 +826,11 @@ fn fix_light_theme(mut theme: ColorTheme) -> ColorTheme {
 #[allow(unused)]
 fn red() -> egui::Color32 {
     egui::Color32::from_hex("#DE3C4B").unwrap()
+}
+
+#[allow(unused)]
+fn yellow() -> egui::Color32 {
+    egui::Color32::from_hex("#e09f3e").unwrap()
 }
 
 #[allow(unused)]

--- a/src/playground/build.rs
+++ b/src/playground/build.rs
@@ -184,7 +184,7 @@ impl BuildResult {
             .map(format_definition)
             .collect();
 
-        if !build.type_errors.is_empty() {
+        if build.type_errors.iter().any(|e| !e.error.is_warning()) {
             return Self::TypeError {
                 pretty,
                 checked: Arc::new(build.checked),

--- a/src/playground/build.rs
+++ b/src/playground/build.rs
@@ -62,17 +62,22 @@ pub(super) enum BuildResult {
         pretty: String,
         checked: Arc<CheckedWorkspace>,
         errors: Vec<ScopedTypeError>,
+        warnings: Vec<ScopedTypeError>,
         sources: SourceLookup,
     },
     InetError {
         pretty: String,
         checked: Arc<CheckedWorkspace>,
         error: RuntimeCompilerError,
+        warnings: Vec<ScopedTypeError>,
+        sources: SourceLookup,
     },
     Ok {
         pretty: String,
         checked: Arc<CheckedWorkspace>,
         rt_compiled: Compiled<Linked>,
+        warnings: Vec<ScopedTypeError>,
+        sources: SourceLookup,
     },
 }
 
@@ -90,6 +95,30 @@ impl BuildResult {
             }),
             Self::InetError { error, .. } => Some(BuildError::InetCompile(error.clone())),
             Self::Ok { .. } => None,
+        }
+    }
+
+    pub(super) fn warnings(&self) -> Option<BuildError> {
+        let (warnings, sources) = match self {
+            Self::TypeError {
+                warnings, sources, ..
+            }
+            | Self::InetError {
+                warnings, sources, ..
+            }
+            | Self::Ok {
+                warnings, sources, ..
+            } => (warnings, sources),
+            Self::None | Self::DiscoveryError { .. } | Self::WorkspaceError { .. } => return None,
+        };
+
+        if warnings.is_empty() {
+            None
+        } else {
+            Some(BuildError::Type {
+                errors: warnings.clone(),
+                sources: sources.clone(),
+            })
         }
     }
 
@@ -184,12 +213,20 @@ impl BuildResult {
             .map(format_definition)
             .collect();
 
-        if build.type_errors.iter().any(|e| !e.error.is_warning()) {
+        let sources = build.sources.clone();
+        let (warnings, errors): (Vec<_>, Vec<_>) = build
+            .type_errors
+            .clone()
+            .into_iter()
+            .partition(|e| e.error.is_warning());
+
+        if !errors.is_empty() {
             return Self::TypeError {
                 pretty,
                 checked: Arc::new(build.checked),
-                errors: build.type_errors,
-                sources: build.sources,
+                errors,
+                warnings,
+                sources,
             };
         }
         let (checked, rt_compiled, _) = match build.compile_linked(max_interactions) {
@@ -199,6 +236,8 @@ impl BuildResult {
                     pretty,
                     checked: Arc::new(checked),
                     error,
+                    warnings,
+                    sources,
                 };
             }
         };
@@ -206,6 +245,8 @@ impl BuildResult {
             pretty,
             checked: Arc::new(checked),
             rt_compiled,
+            warnings,
+            sources,
         }
     }
 }

--- a/src/playground/run_menu.rs
+++ b/src/playground/run_menu.rs
@@ -5,6 +5,7 @@ use std::{
 
 use eframe::egui::{self, RichText};
 use futures::task::{Spawn, SpawnExt};
+use par_core::runtime::TranspiledGlobal;
 use par_core::{
     frontend::{
         Type, Visibility,
@@ -14,7 +15,6 @@ use par_core::{
     source::FileName,
     workspace::{CheckedWorkspace, FileImportScope, ModulePath},
 };
-use par_core::runtime::TranspiledGlobal;
 use par_runtime::linker::Linked;
 use par_runtime::pkgid::PackageId;
 use tokio_util::sync::CancellationToken;
@@ -107,7 +107,8 @@ fn run_definition(
     *cancel_token = Some(token.clone());
 
     let ty = name_to_ty.get(name).unwrap();
-    let Some(TranspiledGlobal::Package(package)) = compiled.code.name_to_package.get(name).cloned() else {
+    let Some(TranspiledGlobal::Package(package)) = compiled.code.name_to_package.get(name).cloned()
+    else {
         return;
     };
     let (handle, reducer_future) =

--- a/src/playground/run_menu.rs
+++ b/src/playground/run_menu.rs
@@ -14,6 +14,7 @@ use par_core::{
     source::FileName,
     workspace::{CheckedWorkspace, FileImportScope, ModulePath},
 };
+use par_core::runtime::TranspiledGlobal;
 use par_runtime::linker::Linked;
 use par_runtime::pkgid::PackageId;
 use tokio_util::sync::CancellationToken;
@@ -106,7 +107,9 @@ fn run_definition(
     *cancel_token = Some(token.clone());
 
     let ty = name_to_ty.get(name).unwrap();
-    let package = compiled.code.get_with_name(name).unwrap();
+    let Some(TranspiledGlobal::Package(package)) = compiled.code.name_to_package.get(name).cloned() else {
+        return;
+    };
     let (handle, reducer_future) =
         par_runtime::start_and_instantiate(spawner.clone(), compiled.code.arena.clone(), package);
 

--- a/src/test_runner.rs
+++ b/src/test_runner.rs
@@ -6,6 +6,7 @@ use std::sync::mpsc;
 use std::time::{Duration, Instant};
 
 use colored::Colorize;
+use par_core::runtime::TranspiledGlobal;
 use par_core::{
     frontend::{
         Type,
@@ -17,7 +18,6 @@ use par_core::{
     testing::{AssertionResult, provide_test},
     workspace::{CheckedWorkspace, ModulePath, WorkspaceDiscoveryError, WorkspaceError},
 };
-use par_core::runtime::TranspiledGlobal;
 use par_runtime::linker::Linked;
 use par_runtime::pkgid::{BuiltinPackage, PackageId};
 use par_runtime::spawn::TokioSpawn;

--- a/src/test_runner.rs
+++ b/src/test_runner.rs
@@ -338,7 +338,7 @@ fn run_single_definition(
         let package = match rt_compiled.code.name_to_package.get(run_name) {
             Some(TranspiledGlobal::Package(pkg)) => pkg.clone(),
             Some(TranspiledGlobal::Unimplemented) => {
-                return Err(format!("Test '{missing_type_name}' is unimplemented (directly or indirectly contains a todo; run `par check` for details)"));
+                return Err(format!("Test '{missing_type_name}' is incomplete (directly or indirectly contains a todo; run `par check` for details)"));
             }
             None => return Err(format!("Test package not found for '{missing_type_name}'")),
         };
@@ -411,7 +411,7 @@ async fn run_test(
     let package = match rt_compiled.code.name_to_package.get(name) {
         Some(TranspiledGlobal::Package(pkg)) => pkg.clone(),
         Some(TranspiledGlobal::Unimplemented) => {
-            return Err("Test is unimplemented (directly or indirectly contains a todo; run `par check` for details)".to_string());
+            return Err("Test is incomplete (directly or indirectly contains a todo; run `par check` for details)".to_string());
         }
         None => return Err("Test package not found".to_string()),
     };

--- a/src/test_runner.rs
+++ b/src/test_runner.rs
@@ -17,6 +17,7 @@ use par_core::{
     testing::{AssertionResult, provide_test},
     workspace::{CheckedWorkspace, ModulePath, WorkspaceDiscoveryError, WorkspaceError},
 };
+use par_core::runtime::TranspiledGlobal;
 use par_runtime::linker::Linked;
 use par_runtime::pkgid::{BuiltinPackage, PackageId};
 use par_runtime::spawn::TokioSpawn;
@@ -334,7 +335,13 @@ fn run_single_definition(
             .get_type_of(run_name)
             .ok_or_else(|| format!("Type not found for test '{}'", missing_type_name))?;
         require_assignable_type(program, &ty, &Type::Break(Span::None), "!")?;
-        let package = rt_compiled.code.get_with_name(run_name).unwrap();
+        let package = match rt_compiled.code.name_to_package.get(run_name) {
+            Some(TranspiledGlobal::Package(pkg)) => pkg.clone(),
+            Some(TranspiledGlobal::Unimplemented) => {
+                return Err(format!("Test '{missing_type_name}' is unimplemented (directly or indirectly contains a todo; run `par check` for details)"));
+            }
+            None => return Err(format!("Test package not found for '{missing_type_name}'")),
+        };
 
         let (handle, fut) = par_runtime::start_and_instantiate(
             Arc::new(TokioSpawn::new()),
@@ -401,7 +408,13 @@ async fn run_test(
 ) -> Result<TestStatus, String> {
     let (sender, receiver) = mpsc::channel();
 
-    let package = rt_compiled.code.get_with_name(name).unwrap();
+    let package = match rt_compiled.code.name_to_package.get(name) {
+        Some(TranspiledGlobal::Package(pkg)) => pkg.clone(),
+        Some(TranspiledGlobal::Unimplemented) => {
+            return Err("Test is unimplemented (directly or indirectly contains a todo; run `par check` for details)".to_string());
+        }
+        None => return Err("Test package not found".to_string()),
+    };
     let (mut root, reducer_future) = par_runtime::start_and_instantiate(
         Arc::new(TokioSpawn::new()),
         rt_compiled.code.arena.clone(),

--- a/src/test_runner.rs
+++ b/src/test_runner.rs
@@ -65,7 +65,7 @@ fn build_for_run(
 ) -> Result<(CheckedWorkspace, Compiled<Linked>, Vec<ModulePath>), BuildError> {
     let build =
         checked_workspace_from_path(package_path, None).map_err(map_workspace_build_error)?;
-    if !build.type_errors.is_empty() {
+    if build.type_errors.iter().any(|e| !e.error.is_warning()) {
         return Err(BuildError::Type {
             errors: build.type_errors,
             sources: build.sources.clone(),

--- a/src/workspace_support.rs
+++ b/src/workspace_support.rs
@@ -67,6 +67,10 @@ impl CheckedWorkspaceBuild {
         }
     }
 
+    pub(crate) fn warnings(&self) -> impl Iterator<Item = &ScopedTypeError> {
+        self.type_errors.iter().filter(|e| e.error.is_warning())
+    }
+
     pub(crate) fn compile_unlinked(
         self,
         max_interactions: u32,


### PR DESCRIPTION
This PR adds a process terminator `todo`, and a matching expression.
Those can be used to leave code unfinished while letting the type checker do its work.

During type checking we make sure there are no variables being inferred since there's no way to know what they're supposed to be.

Further, we always show a warning that the definition is incomplete.

Lastly, definitions which contain `todo` directly or indirectly do not appear in the final binary. If one attempts to run them, they'd get an error directing them to run `par check`.

Example usage:

`def T:! = todo`

`def T:! = chan res {todo}`
